### PR TITLE
Allow running the project

### DIFF
--- a/cli/nhcli.cabal
+++ b/cli/nhcli.cabal
@@ -54,6 +54,7 @@ library
       Neo.Build.Templates.AppMain,
       Neo.Core,
       Neo.Core.ProjectConfiguration,
+      Neo.Run,
     -- other-modules:
     -- other-extensions:
     hs-source-dirs:   src

--- a/cli/src/Neo/Run.hs
+++ b/cli/src/Neo/Run.hs
@@ -1,0 +1,35 @@
+module Neo.Run (
+  handle,
+  Error (..),
+) where
+
+import Array qualified
+import Neo.Core
+import Subprocess qualified
+import Task qualified
+
+
+data Error
+  = NixFileError
+  | CabalFileError
+  | CustomError Text
+  deriving (Show)
+
+
+handle :: ProjectConfiguration -> Task Error Unit
+handle config = do
+  let projectName = config.name
+  let rootFolder = [path|nhout|]
+  completion <-
+    Subprocess.openInherit [fmt|./result/bin/{projectName}|] (Array.fromLinkedList []) rootFolder Subprocess.InheritBOTH
+  if completion.exitCode != 0
+    then errorOut completion.stderr
+    else print completion.stdout
+
+
+errorOut :: Text -> Task Error _
+errorOut err =
+  [fmt|Oops running failed:
+    {err}|]
+    |> CustomError
+    |> Task.throw


### PR DESCRIPTION
This pull request adds a new "run" command to the `Neo` CLI tool, extending its functionality to allow running projects in addition to building them. The most important changes include updating the command parser, handling the new command, and defining the corresponding module and error types.

Closes #109 

### Command Parser Updates:
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R27): Added the "run" command to the `NeoCommand` data type and updated the `commandsParser` to include the new command. [[1]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R27) [[2]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150L58-R72)

### Command Handling:
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R81-R86): Implemented the `runParser` function to parse the "run" command and updated the `handleCommand` function to handle the new `Run` command. [[1]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R81-R86) [[2]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R118-R126)

### Module and Error Types:
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R103): Added a new `RunError` type to the `Error` data type to handle errors specific to the "run" command.
* [`cli/src/Neo/Run.hs`](diffhunk://#diff-f43595d538c2a74c1737df3ae2bf9ad945041a2d1d49bb5d35a455437c43548bR1-R35): Created a new module `Neo.Run` with a `handle` function to execute the project and defined the `Error` data type for run-specific errors.

### Library Configuration:
* [`cli/nhcli.cabal`](diffhunk://#diff-5fcfd352793959222631c7c3716473acf19f05c9f62b2ec07e113243268212efR57): Updated the library configuration to include the new `Neo.Run` module.

### Import Statements:
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R14): Added import statements for the new `Neo.Run` module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new command-line operation enabling users to run projects directly.
  - Enhanced execution feedback with improved error reporting to assist in diagnosing run-time issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->