### PR TITLE
feat: `neo new` 

### DIFF
--- a/cli/nhcli.cabal
+++ b/cli/nhcli.cabal
@@ -55,6 +55,8 @@ library
       Neo.Core,
       Neo.Core.ProjectConfiguration,
       Neo.New,
+      Neo.New.Templates.NeoJson,
+      Neo.New.Templates.MainModule,
       Neo.Run,
     -- other-modules:
     -- other-extensions:

--- a/cli/nhcli.cabal
+++ b/cli/nhcli.cabal
@@ -54,6 +54,7 @@ library
       Neo.Build.Templates.AppMain,
       Neo.Core,
       Neo.Core.ProjectConfiguration,
+      Neo.New,
       Neo.Run,
     -- other-modules:
     -- other-extensions:

--- a/cli/src/Neo/Build.hs
+++ b/cli/src/Neo/Build.hs
@@ -52,8 +52,6 @@ handle config = do
         Array.fromLinkedList [rootFolder, "src"]
           |> Path.joinPaths
 
-  -- TODO: Remember to copy using https://hackage.haskell.org/package/directory-1.3.8.1/docs/System-Directory.html#v:copyFileWithMetadata
-  -- I mean into .neohaskell
   Directory.copy [path|src|] targetSrcFolder
     |> Task.mapError (\e -> CustomError (toText e))
 
@@ -63,16 +61,10 @@ handle config = do
 
   let haskellFiles = filepaths |> Array.takeIf (Path.endsWith haskellExtension)
 
-  -- -- haskellFiles = [A.hs,A/Lol.hs,A/B/Haha.hs,A/B/C/Rofl.hs]
-  -- -- Convert to:
-  -- -- modules = [A, A.Lol, A.B, A.B.C]
   let convertToModule filepath = do
         let pathText = Path.toText filepath
-        -- first we remove the extension
         let pathWithoutExtension = Text.dropRight (Text.length haskellExtension) pathText
-        -- then we split on the path separator
         let pathParts = Text.split "/" pathWithoutExtension
-        -- then we convert each part to a module name
         pathParts |> Text.joinWith "."
 
   let modules = haskellFiles |> Array.map convertToModule

--- a/cli/src/Neo/New.hs
+++ b/cli/src/Neo/New.hs
@@ -65,4 +65,13 @@ handle (ProjectName projectName) = do
   File.writeText moduleFilePath (MainModule.template moduleName)
     |> Task.mapError (\_ -> CustomError "Could not write module file")
 
-  print [fmt|Created project {projectName} at ./{Path.toText projectDir}|]
+  print [fmt|Created project {projectName} at ./{Path.toText projectDir}
+
+To build your project:
+  cd {Path.toText projectDir}
+  neo build
+
+To run your project:
+  cd {Path.toText projectDir}
+  neo run
+|]

--- a/cli/src/Neo/New.hs
+++ b/cli/src/Neo/New.hs
@@ -4,7 +4,16 @@ module Neo.New (
   ProjectName (..),
 ) where
 
+import Array qualified
+import Directory qualified
+import File qualified
+import Maybe qualified
 import Neo.Core
+import Neo.New.Templates.MainModule qualified as MainModule
+import Neo.New.Templates.NeoJson qualified as NeoJson
+import Path qualified
+import Task qualified
+import Text qualified
 
 
 newtype ProjectName = ProjectName Text
@@ -18,5 +27,42 @@ data Error
 
 
 handle :: ProjectName -> Task Error Unit
-handle (ProjectName _) = do
-  print "Hello world"
+handle (ProjectName projectName) = do
+  let kebabName = Text.toKebabCase projectName
+  let projectDir =
+        kebabName
+          |> Text.toLower
+          |> Path.fromText
+          |> Maybe.getOrDie -- TODO: Handle this better
+  let srcDir =
+        Array.fromLinkedList [projectDir, "src"]
+          |> Path.joinPaths
+
+  let moduleName =
+        projectName
+          |> Text.toPascalCase
+  let moduleFileName =
+        [fmt|{moduleName}.hs|]
+          |> Path.fromText
+          |> Maybe.getOrDie -- TODO: Handle this better
+  let moduleFilePath =
+        Array.fromLinkedList [srcDir, moduleFileName]
+          |> Path.joinPaths
+  let configFileName = [path|neo.json|]
+  let configFilePath =
+        Array.fromLinkedList [projectDir, configFileName]
+          |> Path.joinPaths
+
+  Directory.create projectDir
+    |> Task.mapError (\_ -> [fmt|Could not create directory {Path.toText projectDir}|] |> CustomError)
+
+  File.writeText configFilePath (NeoJson.template kebabName)
+    |> Task.mapError (\_ -> CustomError "Could not write config file")
+
+  Directory.create srcDir
+    |> Task.mapError (\_ -> [fmt|Could not create directory {Path.toText srcDir}|] |> CustomError)
+
+  File.writeText moduleFilePath (MainModule.template moduleName)
+    |> Task.mapError (\_ -> CustomError "Could not write module file")
+
+  print [fmt|Created project {projectName} at ./{Path.toText projectDir}|]

--- a/cli/src/Neo/New.hs
+++ b/cli/src/Neo/New.hs
@@ -1,0 +1,22 @@
+module Neo.New (
+  handle,
+  Error (..),
+  ProjectName (..),
+) where
+
+import Neo.Core
+
+
+newtype ProjectName = ProjectName Text
+  deriving (Show, Eq, Ord)
+
+
+data Error
+  = CabalFileError
+  | CustomError Text
+  deriving (Show)
+
+
+handle :: ProjectName -> Task Error Unit
+handle (ProjectName _) = do
+  print "Hello world"

--- a/cli/src/Neo/New/Templates/MainModule.hs
+++ b/cli/src/Neo/New/Templates/MainModule.hs
@@ -1,0 +1,16 @@
+module Neo.New.Templates.MainModule where
+
+import Core
+
+
+template :: Text -> Text
+template moduleName = do
+  [fmt|module {moduleName} where
+
+import Core
+
+
+run :: Task Text ()
+run = do
+    print "Let's go NeoHaskell! ⏩"
+  |]

--- a/cli/src/Neo/New/Templates/NeoJson.hs
+++ b/cli/src/Neo/New/Templates/NeoJson.hs
@@ -1,0 +1,16 @@
+module Neo.New.Templates.NeoJson where
+
+import Core
+
+
+template :: Text -> Text
+template projectName = do
+  [fmt|{{
+  "name": "{projectName}",
+  "version": "0.0.1",
+  "description": "Your project's description",
+  "author": "Your Name",
+  "license": "ISC",
+  "dependencies": {{
+  }}
+}}|]

--- a/core/options-parser/Command.hs
+++ b/core/options-parser/Command.hs
@@ -2,6 +2,7 @@ module Command (
   OptionsParser,
   CommandOptions (..),
   PathConfig (..),
+  TextConfig (..),
   text,
   path,
   parseWith,


### PR DESCRIPTION
This pull request introduces a new feature to create a NeoHaskell project using the `new` command. The changes span multiple files to incorporate this new functionality, including updates to the command parsing and handling logic, as well as the addition of templates for new projects.

Closes #133 

Key changes include:

### New Command Implementation:
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R14): Added the `New` command to the `NeoCommand` data type and updated the command parser to include the `new` command. Implemented the `newParser` function to parse the project name and handle the `New` command. [[1]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R14) [[2]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R29) [[3]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R59-R65) [[4]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150L72-R81) [[5]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R96-R101) [[6]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R116-R133) [[7]](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R157-R159)

### New Module and Templates:
* [`cli/src/Neo/New.hs`](diffhunk://#diff-6dfb76729b77d0aa0a320eb5bb7624eb4210c16451eb115776a5d0c03844fc42R1-R68): Created a new module `Neo.New` to handle the creation of a new project, including defining the `ProjectName` type and the `handle` function to set up the project structure and files.
* [`cli/src/Neo/New/Templates/MainModule.hs`](diffhunk://#diff-1aaa87fddf459938911ef1349caf75bd6f86becc7354f30358fc08bf96793de5R1-R16): Added a template for the main module file of a new project.
* [`cli/src/Neo/New/Templates/NeoJson.hs`](diffhunk://#diff-f925bc565b29af512090e427bf802a67d6b8135d16c066f87fbb0eed11f82cedR1-R16): Added a template for the `neo.json` configuration file of a new project.

### Dependency and Import Updates:
* [`cli/nhcli.cabal`](diffhunk://#diff-5fcfd352793959222631c7c3716473acf19f05c9f62b2ec07e113243268212efR57-R59): Updated the cabal file to include the new modules `Neo.New`, `Neo.New.Templates.NeoJson`, and `Neo.New.Templates.MainModule`.
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R14): Imported the `Neo.New` module to use its functionalities.

### Cleanup:
* [`cli/src/Neo/Build.hs`](diffhunk://#diff-ace22c9f767a62a98411ead7af93acd2bf654285925dd975747028651d0b26c8L55-L56): Removed outdated comments and TODOs related to file handling and module conversion. [[1]](diffhunk://#diff-ace22c9f767a62a98411ead7af93acd2bf654285925dd975747028651d0b26c8L55-L56) [[2]](diffhunk://#diff-ace22c9f767a62a98411ead7af93acd2bf654285925dd975747028651d0b26c8L66-L75)

These changes collectively add the capability to create new NeoHaskell projects from the command line, streamlining the project setup process for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new CLI command for project creation that automatically scaffolds a project using a specified name.
  - Added dynamic templates to generate a main module and a JSON configuration file seamlessly.
  - Enhanced command-line parsing to support flexible text-based options for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->