### PR TITLE
feat: Point to GitHub issues on `neo` failure

### DIFF
--- a/cli/app/Main.hs
+++ b/cli/app/Main.hs
@@ -6,4 +6,4 @@ import Task qualified
 
 
 main :: IO ()
-main = Task.runOrPanic Neo.run
+main = Task.runMain Neo.run


### PR DESCRIPTION
This pull request includes several changes to improve error handling and update the `Task` module in the Haskell project. The most important changes include updating the `run` function, adding error mapping in the `run` function, and enhancing error reporting.

Closes #68 

Improvements to error handling:

* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150L33-R33): Updated the `run` function to use `Task Text Unit` instead of `Task _ Unit` to provide more specific error types.
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150L135-R177): Added the `errorToText` function to convert errors into user-friendly text messages for better error reporting.
* [`cli/src/Neo.hs`](diffhunk://#diff-e3c009163acfbd0882f900544afb06bec692b3c69857470c689a5b0bc6316150R55-R69): Enhanced the `run` function to map errors using `Task.mapError`, providing detailed error messages when a command fails.

Updates to the `Task` module:

* [`core/core/Task.hs`](diffhunk://#diff-d3751ec066278dbb3aff3ec23533101fac33a6b02a19c7a56e14dcbc77a73ee7R90-R99): Added the `runMain` function to handle tasks that return `Unit` and print errors to the console.
* [`cli/app/Main.hs`](diffhunk://#diff-bd117ba56a1dd82e23f3217a664189f409583d6dfe36853288a4e54ae8a1bb3dL9-R9): Updated the main function to use `Task.runMain` instead of `Task.runOrPanic` for better error handling.