### PR TITLE
refactor: Move foreach to task

### DIFF
--- a/core/core/Array.hs
+++ b/core/core/Array.hs
@@ -33,7 +33,6 @@ module Array (
   takeIf,
   dropIf,
   flatMap,
-  forEach,
   foldM,
   dropWhile,
   takeWhile,
@@ -42,6 +41,9 @@ module Array (
   partitionBy,
   splitFirst,
   any,
+
+  -- * Compatibility
+  unwrap,
 ) where
 
 import Basics
@@ -311,13 +313,6 @@ flatMap f array =
   array
     |> map f
     |> foldr append empty
-
-
--- | Emulates a foreach-loop like in other languages
--- FIXME: https://github.com/neohaskell/NeoHaskell/issues/126
-forEach :: forall (element :: Type). (element -> IO ()) -> Array element -> IO ()
-forEach callback self =
-  Data.Foldable.traverse_ callback (unwrap self)
 
 
 -- | TODO: Find a better name for this function.

--- a/core/core/Task.hs
+++ b/core/core/Task.hs
@@ -11,16 +11,20 @@ module Task (
   fromFailableIO,
   fromIO,
   runMain,
+  forEach,
 ) where
 
 import Applicable (Applicative (pure))
 import Applicable qualified
+import Array (Array)
+import Array qualified
 import Basics
 import Control.Exception (Exception)
 import Control.Exception qualified as Exception
 import Control.Monad.IO.Class qualified as Monad
 import Control.Monad.Trans.Except (ExceptT, runExceptT, throwE, withExceptT)
 import Data.Either qualified as Either
+import Data.Foldable qualified
 import Data.Text.IO qualified as GHCText
 import IO (IO)
 import IO qualified
@@ -119,3 +123,12 @@ fromIO io =
   io
     |> Monad.liftIO
     |> Task
+
+
+forEach ::
+  forall (element :: Type) (err :: Type).
+  (element -> Task err Unit) ->
+  Array element ->
+  Task err Unit
+forEach callback array =
+  Data.Foldable.traverse_ callback (Array.unwrap array)


### PR DESCRIPTION
This pull request includes changes to the `core/core/Array.hs` and `core/core/Task.hs` files to refactor and improve the codebase. The most important changes include removing the `forEach` function from `Array.hs` and adding it to `Task.hs`, as well as adding a new `unwrap` function for compatibility.

Fixes #126 

Refactoring and code improvements:

* [`core/core/Array.hs`](diffhunk://#diff-22813ea372c1ecc316c76e0b3a0b3b38027245a9a93c25fd8fa4423870acb619L316-L322): Removed the `forEach` function and its associated comments.
* [`core/core/Task.hs`](diffhunk://#diff-d3751ec066278dbb3aff3ec23533101fac33a6b02a19c7a56e14dcbc77a73ee7R126-R134): Added the `forEach` function, which traverses an array and applies a callback function to each element, wrapping the result in a `Task`.

Compatibility enhancements:

* [`core/core/Array.hs`](diffhunk://#diff-22813ea372c1ecc316c76e0b3a0b3b38027245a9a93c25fd8fa4423870acb619R44-R46): Added a new `unwrap` function to the module exports for compatibility purposes.

Code cleanup:

* [`core/core/Array.hs`](diffhunk://#diff-22813ea372c1ecc316c76e0b3a0b3b38027245a9a93c25fd8fa4423870acb619L36): Removed the `forEach` function from the module exports list.
* [`core/core/Task.hs`](diffhunk://#diff-d3751ec066278dbb3aff3ec23533101fac33a6b02a19c7a56e14dcbc77a73ee7R14-R27): Added necessary imports for `Array` and `Data.Foldable` to support the new `forEach` function.