### PR TITLE
feat: Install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+    echo ""
+    echo "     ❌ Oops! The installation script encountered an error."
+    echo ""
+    echo "     If it's taking you more than 15 minutes to figure out,"
+    echo "     consider it a bug in the installer, not your fault."
+    echo ""
+    echo "     Please report the issue at:"
+    echo ""
+    echo "     https://github.com/neohaskell/neohaskell/issues/new"
+    echo ""
+    echo "     Include your OS, shell, and anything you saw printed above."
+    echo ""
+    echo "     I'll be waiting for you."
+    exit 1
+}
+
+trap fail ERR
+
+if ! command -v nix &> /dev/null; then
+    echo "⚙️  Nix is not installed. Installing Nix with Determinate Systems..."
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate
+    echo "✅ Nix installed. Please restart your shell or source the profile if needed."
+    export PATH="$HOME/.nix-profile/bin:$HOME/.local/share/nix/profile/bin:$PATH"
+fi
+
+echo "📦 Installing NeoHaskell from GitHub..."
+nix-env -if https://github.com/neohaskell/NeoHaskell/archive/refs/heads/main.tar.gz
+
+echo "✅ NeoHaskell installed successfully!"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ trap fail ERR
 
 if ! command -v nix &> /dev/null; then
     echo "⚙️  Nix is not installed. Installing Nix with Determinate Systems..."
-    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate -- --yes
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 fail() {
     echo ""
-    echo "     ❌ Oops! The installation script encountered an error."
+    echo "neo: ❌ Oops! The installation script encountered an error."
     echo ""
     echo "     If it's taking you more than 15 minutes to figure out,"
     echo "     consider it a bug in the installer, not your fault."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -31,3 +31,5 @@ echo "📦 Installing NeoHaskell from GitHub..."
 nix-env -if https://github.com/neohaskell/NeoHaskell/archive/refs/heads/main.tar.gz
 
 echo "✅ NeoHaskell installed successfully!"
+echo ""
+echo "Try running 'neo --help' to see what you can do with it."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ trap fail ERR
 
 if ! command -v nix &> /dev/null; then
     echo "⚙️  Nix is not installed. Installing Nix with Determinate Systems..."
-    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate --yes
     echo "✅ Nix installed. Please restart your shell or source the profile if needed."
     export PATH="$HOME/.nix-profile/bin:$HOME/.local/share/nix/profile/bin:$PATH"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,8 +24,7 @@ trap fail ERR
 if ! command -v nix &> /dev/null; then
     echo "⚙️  Nix is not installed. Installing Nix with Determinate Systems..."
     curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate --yes
-    echo "✅ Nix installed. Please restart your shell or source the profile if needed."
-    export PATH="$HOME/.nix-profile/bin:$HOME/.local/share/nix/profile/bin:$PATH"
+    . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 fi
 
 echo "📦 Installing NeoHaskell from GitHub..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ trap fail ERR
 
 if ! command -v nix &> /dev/null; then
     echo "⚙️  Nix is not installed. Installing Nix with Determinate Systems..."
-    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate --yes
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --determinate -- --yes
     . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 fi
 


### PR DESCRIPTION
This pull request introduces a new installation script for NeoHaskell. The script ensures that Nix is installed on the system and then proceeds to install NeoHaskell from GitHub. It also includes error handling to provide a user-friendly message in case the installation fails.

Closes #134 

Key changes include:

* Added `scripts/install.sh` to automate the installation process for NeoHaskell, ensuring Nix is installed and then installing NeoHaskell from GitHub.
* Implemented error handling in the script to provide clear instructions and a link to report issues if the installation fails.