### PR TITLE
fix(templates): correct JSON template formatting

### DIFF
--- a/cli/src/Neo/New/Templates/NeoJson.hs
+++ b/cli/src/Neo/New/Templates/NeoJson.hs
@@ -5,12 +5,12 @@ import Core
 
 template :: Text -> Text
 template projectName = do
-  [fmt|{{
+  [fmt|{
   "name": "#{projectName}",
   "version": "0.0.1",
   "description": "Your project's description",
   "author": "Your Name",
   "license": "ISC",
-  "dependencies": {{
-  }}
-}}|]
+  "dependencies": {
+  }
+}|]


### PR DESCRIPTION
Fixes malformed JSON syntax in project template by removing double braces that would cause parsing errors when generating new projects