### PR TITLE
fix(core): handle io exceptions in subprocess

### DIFF
--- a/cli/src/Neo/Build.hs
+++ b/cli/src/Neo/Build.hs
@@ -81,7 +81,7 @@ handle config = do
 
   completion <-
     Subprocess.openInherit "nix-build" (Array.fromLinkedList ["-E", buildExpression]) rootFolder Subprocess.InheritBOTH
-      |> Task.mapError (\_ -> CustomError "Failed to run nix-build")
+      |> Task.mapError (\err -> CustomError [fmt|Failed to run nix-build: #{err}|])
   if completion.exitCode != 0
     then errorOut completion.stderr
     else print completion.stdout

--- a/cli/src/Neo/Run.hs
+++ b/cli/src/Neo/Run.hs
@@ -22,7 +22,7 @@ handle config = do
   let rootFolder = [path|.|]
   completion <-
     Subprocess.openInherit [fmt|./result/bin/#{projectName}|] (Array.fromLinkedList []) rootFolder Subprocess.InheritBOTH
-      |> Task.mapError (\_ -> CustomError "Failed to run the built application")
+      |> Task.mapError (\err -> CustomError [fmt|Failed to run the built application: #{err}|])
   if completion.exitCode != 0
     then errorOut completion.stderr
     else print completion.stdout

--- a/cli/src/Neo/Shell.hs
+++ b/cli/src/Neo/Shell.hs
@@ -81,7 +81,7 @@ handle config = do
 
   completion <-
     Subprocess.openInherit "nix-shell" (Array.fromLinkedList ["-E", shellExpression]) rootFolder Subprocess.InheritBOTH
-      |> Task.mapError (\_ -> CustomError "Failed to open the shell")
+      |> Task.mapError (\err -> CustomError [fmt|Failed to open the shell: #{err}|])
   if completion.exitCode != 0
     then errorOut completion.stderr
     else Task.yield ()

--- a/core/system/Subprocess.hs
+++ b/core/system/Subprocess.hs
@@ -47,7 +47,7 @@ data InheritStream
 
 
 data Error
-  = NotExecutable
+  = ProcessError Text
   deriving (Show)
 
 
@@ -76,11 +76,11 @@ openInherit executable arguments directory inheritStream = do
     -- System.Process.readCreateProcessWithExitCode processToExecute ""
     System.Process.createProcess processToExecute
       |> Task.fromFailableIO @Exception.IOError
-      |> Task.mapError (\_ -> NotExecutable)
+      |> Task.mapError (\err -> ProcessError [fmt|#{err}|])
   ec <-
     System.Process.waitForProcess ph
       |> Task.fromFailableIO @Exception.IOError
-      |> Task.mapError (\_ -> NotExecutable)
+      |> Task.mapError (\err -> ProcessError [fmt|#{err}|])
   let exitCode = case ec of
         System.Exit.ExitSuccess -> 0
         System.Exit.ExitFailure code -> code


### PR DESCRIPTION
As discussed in https://github.com/neohaskell/NeoHaskell/issues/197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified and improved error handling for build, run, and shell commands with clearer, user-friendly messages.
  * Subprocess failures (including process creation and execution errors) now surface reliably and consistently.
  * Command failures show more actionable diagnostics instead of ambiguous or silent errors.
  * Reduced unexpected crash paths so CLI commands fail gracefully with meaningful feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->