### PR TITLE
test(macos): Filters subscription events by entity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
             extra-substituters = https://cache.iog.io
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
-      # - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
 
       # - name: Build the project with Nix
       #   run: nix build


### PR DESCRIPTION
Addresses test interference in macOS by filtering subscription events based on the entity name. This ensures that tests only process events relevant to their specific context, preventing cross-test contamination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test isolation by adding per-entity filtering to event subscribers so tests only record and fail on relevant events, reducing cross-test interference and preserving existing test behaviors (collection, ordering, unsubscription).

* **Chores**
  * Reformatted CI workflow health-check options for the database service (no functional change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->