### PR TITLE
feat(auth): Re-export validation helpers from Auth.OAuth2 module

### DIFF
--- a/core/auth/Auth/OAuth2.hs
+++ b/core/auth/Auth/OAuth2.hs
@@ -30,8 +30,20 @@
 -- = Security Notes
 --
 -- * Store tokens in 'Auth.SecretStore', NOT in the event store
--- * Always validate the State parameter on callback (CSRF protection)
+-- * Always validate the State parameter on callback using 'validateState' (CSRF protection)
+-- * Always validate redirect URIs using 'validateRedirectUri' before token exchange
 -- * Never log or serialize 'ClientSecret' or tokens to events
+--
+-- = Secure Callback Handling
+--
+-- @
+-- -- In your callback handler:
+-- case OAuth2.validateState expectedState returnedState of
+--   Err err -> -- Handle CSRF attack / expired state
+--   Ok () -> do
+--     -- State is valid, proceed with token exchange
+--     tokens <- OAuth2.exchangeCode provider clientId clientSecret redirectUri code
+-- @
 --
 -- = See Also
 --
@@ -82,6 +94,10 @@ module Auth.OAuth2 (
   -- * Errors
   OAuth2Error (..),
 
+  -- * Validation Helpers
+  validateState,
+  validateRedirectUri,
+
   -- * Operations
   authorizeUrl,
   exchangeCode,
@@ -119,4 +135,6 @@ import Auth.OAuth2.Types (
   unwrapRedirectUri,
   unwrapRefreshToken,
   unwrapState,
+  validateRedirectUri,
+  validateState,
  )


### PR DESCRIPTION
## Summary

Closes #275

- Re-export `validateState` and `validateRedirectUri` from `Auth.OAuth2` module
- Add secure callback handling example to module documentation

## Why

Makes secure patterns discoverable from the main OAuth2 import, following the "pit of success" principle - it should be hard to use the API wrong.

Before:
```haskell
import Auth.OAuth2 (...)
import Auth.OAuth2.Types (validateState, validateRedirectUri)  -- Easy to forget!
```

After:
```haskell
import Auth.OAuth2 (validateState, validateRedirectUri, ...)  -- All in one place
```

## Changes

- `core/auth/Auth/OAuth2.hs`: Added exports and documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth2 security validation utilities are now publicly available. Developers can validate state parameters to prevent CSRF attacks and verify redirect URIs before token exchange to maintain secure callback handling.

* **Documentation**
  * Enhanced documentation with secure callback handling examples and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->