### PR TITLE
feat(core): auto-derive ToSchema in command TH macro

### DIFF
--- a/testbed/src/Testbed/Cart/Commands/AddItem.hs
+++ b/testbed/src/Testbed/Cart/Commands/AddItem.hs
@@ -22,10 +22,6 @@ data AddItem = AddItem
   deriving (Generic, Typeable, Show)
 
 
--- | Schema derivation example: automatic schema generation from Generic
-instance ToSchema AddItem
-
-
 instance Json.FromJSON AddItem
 
 

--- a/testbed/src/Testbed/Cart/Commands/CreateCart.hs
+++ b/testbed/src/Testbed/Cart/Commands/CreateCart.hs
@@ -25,9 +25,6 @@ instance Json.FromJSON CreateCart
 instance Json.ToJSON CreateCart
 
 
-instance ToSchema CreateCart
-
-
 getEntityId :: CreateCart -> Maybe Uuid
 getEntityId _ = Nothing
 

--- a/testbed/src/Testbed/Document/Commands/CreateDocument.hs
+++ b/testbed/src/Testbed/Document/Commands/CreateDocument.hs
@@ -31,9 +31,6 @@ data CreateDocument = CreateDocument
 instance Json.FromJSON CreateDocument
 
 
-instance ToSchema CreateDocument
-
-
 getEntityId :: CreateDocument -> Maybe Uuid
 getEntityId cmd = Just cmd.documentId
 

--- a/testbed/src/Testbed/Stock/Commands/InitializeStock.hs
+++ b/testbed/src/Testbed/Stock/Commands/InitializeStock.hs
@@ -24,9 +24,6 @@ data InitializeStock = InitializeStock
 instance Json.FromJSON InitializeStock
 
 
-instance ToSchema InitializeStock
-
-
 getEntityId :: InitializeStock -> Maybe Uuid
 getEntityId _ = Nothing
 

--- a/testbed/src/Testbed/Stock/Commands/ReserveStock.hs
+++ b/testbed/src/Testbed/Stock/Commands/ReserveStock.hs
@@ -30,9 +30,6 @@ instance Json.FromJSON ReserveStock
 instance Json.ToJSON ReserveStock
 
 
-instance ToSchema ReserveStock
-
-
 getEntityId :: ReserveStock -> Maybe Uuid
 getEntityId cmd = Just cmd.stockId
 


### PR DESCRIPTION
## Summary

- The `command` Template Haskell macro now automatically generates a `ToSchema` instance for OpenAPI schema support
- This eliminates the need for users to manually add `instance ToSchema MyCommand` for every command type
- Removed manual ToSchema instances from testbed commands (now generated automatically)

## Benefits

- **Zero-friction OpenAPI support**: Existing projects compile without adding manual `ToSchema` instances
- **Follows NeoHaskell philosophy**: Sensible defaults with minimal boilerplate
- **Reduces cognitive load**: One less thing for users (Jess) to remember

## Test plan

- [x] All 841 nhcore tests pass
- [x] Testbed builds and links successfully
- [x] Commands without manual ToSchema instances compile correctly

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined OpenAPI schema generation by automatically deriving schemas for command types through framework infrastructure.
  * Removed redundant manual schema instance declarations across multiple command modules, reducing boilerplate code while maintaining equivalent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->