### PR TITLE
feat: add AI-powered PDF transcription integration (multimodal)

### DIFF
--- a/docs/decisions/0023-ai-pdf-transcription.md
+++ b/docs/decisions/0023-ai-pdf-transcription.md
@@ -108,7 +108,7 @@ data TranscriptionResult = TranscriptionResult
   , pageCount :: Maybe Int
   -- ^ Number of pages processed (if available)
   , confidence :: Maybe Float
-  -- ^ Confidence score (always Nothing for v1)
+  -- ^ Confidence score (always Nothing for v1, Float is Double-precision in NeoHaskell)
   }
   deriving (Show, Eq, Generic)
 ```
@@ -146,7 +146,7 @@ data ImageUrl = ImageUrl
 
 The integration follows the piggyback pattern used by `Pdf.ExtractText.Internal`:
 
-```
+```text
 AiTranscribe.Request
   → ToAction.toAction
     → Integration.action \ctx ->

--- a/docs/decisions/0023-ai-pdf-transcription.md
+++ b/docs/decisions/0023-ai-pdf-transcription.md
@@ -1,0 +1,263 @@
+# ADR-0023: AI-Powered PDF Transcription via Multimodal Models
+
+## Status
+
+Proposed
+
+## Context
+
+NeoHaskell has `Integration.Pdf.ExtractText` for CLI-based PDF text extraction using poppler-utils (`pdftotext`, `pdfinfo`). While effective for well-structured digital PDFs, this approach fails for:
+
+1. **Scanned documents**: CLI extraction returns empty text since there is no embedded text layer.
+2. **Complex layouts**: Multi-column documents, forms, and mixed content produce garbled output.
+3. **Handwritten notes**: No text to extract — requires visual understanding.
+4. **Summarization and structured extraction**: CLI tools extract raw text but cannot interpret, summarize, or restructure content.
+
+Multimodal AI models (Google Gemini, Anthropic Claude Vision, OpenAI GPT-4V) can process PDF pages as images and extract text with understanding of layout, context, and even handwriting. NeoHaskell already has an `Integration.OpenRouter` module that provides access to 300+ models including multimodal ones.
+
+### Current State
+
+- `Integration.Pdf.ExtractText` — CLI-based extraction (poppler-utils), works for digital PDFs
+- `Integration.OpenRouter` — AI model access via OpenRouter API, currently text-only
+- `Integration.OpenRouter.Message` — Conversation messages with `content :: Text` (no multimodal support)
+- `ActionContext.fileAccess :: Maybe FileAccessContext` — Already exists in `core/service/Integration.hs`
+- `FileAccessContext.retrieveFile :: FileRef -> Task FileAccessError Bytes` — Already exists
+- `Bytes.toBase64` in `core/core/Bytes.hs` — Base64 encoding utility
+
+### GitHub Issue
+
+- [#343: Add AI-powered PDF transcription integration (multimodal)](https://github.com/neohaskell/NeoHaskell/issues/343)
+
+## Decision
+
+### 1. Module Placement
+
+Two new modules in `nhintegrations`, following the Jess/Nick two-persona pattern:
+
+| Module | Persona | Purpose |
+|--------|---------|---------|
+| `Integration.Ai.TranscribePdf` | Jess (User) | Config records, types, `defaultConfig` |
+| `Integration.Ai.TranscribePdf.Internal` | Nick (Developer) | `ToAction` instance, orchestration logic |
+
+Placed under `Integration.Ai.` namespace to distinguish from the CLI-based `Integration.Pdf.` namespace.
+
+### 2. Type Definitions
+
+All types use NeoHaskell style: descriptive type parameters, `Result` not `Either`, `Task` not `IO`.
+
+#### Extraction Modes
+
+```haskell
+-- | Modes for AI-powered text extraction.
+data ExtractionMode
+  = FullText
+  -- ^ Extract all text faithfully, preserving structure
+  | Summary
+  -- ^ Summarize document content
+  | Structured
+  -- ^ Extract as structured JSON matching a provided schema
+  deriving (Show, Eq, Generic)
+```
+
+#### Configuration
+
+```haskell
+-- | Configuration for AI transcription.
+data Config = Config
+  { extractionMode :: ExtractionMode
+  -- ^ How to extract text (default: FullText)
+  , language :: Maybe Text
+  -- ^ Language hint for the AI model (e.g., "en", "es")
+  , maxPages :: Maybe Int
+  -- ^ Limit number of pages to process (Nothing = all)
+  , systemPrompt :: Maybe Text
+  -- ^ Override the default system prompt
+  , timeoutSeconds :: Int
+  -- ^ Timeout for the API call (default: 120)
+  }
+  deriving (Show, Eq, Generic)
+```
+
+#### Request Record (Jess's API)
+
+```haskell
+-- | Main request record that Jess instantiates.
+-- Follows the same pattern as Pdf.ExtractText.Request.
+data Request command = Request
+  { fileRef :: FileRef
+  -- ^ Reference to the uploaded PDF file
+  , model :: Text
+  -- ^ AI model to use (e.g., "google/gemini-pro-1.5")
+  , config :: Config
+  -- ^ Extraction configuration
+  , onSuccess :: TranscriptionResult -> command
+  -- ^ Callback for successful transcription
+  , onError :: Text -> command
+  -- ^ Callback for transcription errors
+  }
+  deriving (Generic)
+```
+
+#### Result Type
+
+```haskell
+-- | Result of AI-powered transcription.
+data TranscriptionResult = TranscriptionResult
+  { text :: Text
+  -- ^ Extracted/transcribed text
+  , pageCount :: Maybe Int
+  -- ^ Number of pages processed (if available)
+  , confidence :: Maybe Float
+  -- ^ Confidence score (always Nothing for v1)
+  }
+  deriving (Show, Eq, Generic)
+```
+
+#### Message Extension (in OpenRouter.Message)
+
+To support multimodal content, the `Message` type's `content` field changes from `Text` to a `Content` sum type:
+
+```haskell
+-- | Message content — either plain text or multimodal content array.
+data Content
+  = TextContent Text
+  -- ^ Plain text content (backward compatible)
+  | MultiContent (Array ContentPart)
+  -- ^ Array of content parts (text + images/attachments)
+  deriving (Show, Eq, Generic)
+
+-- | A single part within multimodal content.
+data ContentPart
+  = TextPart Text
+  -- ^ Text content part
+  | ImageUrlPart ImageUrl
+  -- ^ Image/attachment content part
+  deriving (Show, Eq, Generic)
+
+-- | Image URL reference for multimodal content.
+data ImageUrl = ImageUrl
+  { url :: Text
+  -- ^ Data URL (e.g., "data:application/pdf;base64,...")
+  }
+  deriving (Show, Eq, Generic)
+```
+
+### 3. Architecture: Piggyback on OpenRouter
+
+The integration follows the piggyback pattern used by `Pdf.ExtractText.Internal`:
+
+```
+AiTranscribe.Request
+  → ToAction.toAction
+    → Integration.action \ctx ->
+      → ctx.fileAccess.retrieveFile fileRef    -- Get PDF bytes
+      → Bytes.toBase64 pdfBytes                -- Encode to base64
+      → Message.userWithAttachment prompt base64 mimeType  -- Build multimodal message
+      → OpenRouter.chatCompletion messages model onSuccess onError
+        → OpenRouter.toHttpRequest             -- Transform to HTTP
+        → Integration.outbound httpRequest     -- Execute via HTTP integration
+      → Parse response → TranscriptionResult
+      → Integration.emitCommand (config.onSuccess result)
+```
+
+Key design points:
+
+- **Uses `Integration.action`**: Because file retrieval requires IO context (like `Pdf.ExtractText.Internal`), NOT the pure transform pattern
+- **No direct HTTP calls**: Piggybacks on the existing OpenRouter → Http pipeline
+- **No changes to core**: `ActionContext.fileAccess` and `FileAccessContext` already exist and are sufficient
+
+### 4. Message Backward Compatibility
+
+**Critical**: The Message JSON serialization MUST remain backward-compatible.
+
+| Content Type | JSON Output |
+|-------------|-------------|
+| `TextContent "hello"` | `"content": "hello"` (string — same as today) |
+| `MultiContent [TextPart "prompt", ImageUrlPart ...]` | `"content": [{"type":"text","text":"prompt"}, {"type":"image_url","image_url":{"url":"data:..."}}]` (array) |
+
+- `ToJSON`: `TextContent` serializes as a plain JSON string, `MultiContent` as an array
+- `FromJSON`: Accepts BOTH formats — string parses to `TextContent`, array parses to `MultiContent`
+- Existing `Message.user "hello"` produces identical JSON to today's implementation
+
+### 5. Smart Constructors and Defaults
+
+```haskell
+-- | Default configuration for AI transcription.
+-- Mode: FullText, Timeout: 120 seconds
+defaultConfig :: Config
+
+-- | Create a multimodal user message with an attachment.
+userWithAttachment :: Text -> Text -> Text -> Message
+-- userWithAttachment prompt base64Content mimeType
+```
+
+### 6. Instance Decisions
+
+| Instance | Decision | Rationale |
+|----------|----------|-----------|
+| `Generic` | **Yes** (derived) | Standard for all NeoHaskell types |
+| `Show` | **Yes** (derived) | Debugging |
+| `Eq` | **Yes** (derived) | Testing |
+| `ToJSON`/`FromJSON` | **Custom** for Content, ContentPart, ImageUrl | OpenRouter API format compliance |
+| `ToJSON`/`FromJSON` | **Derived** for ExtractionMode, Config, TranscriptionResult | Standard serialization |
+| `ToAction` | **Custom** in Internal | Orchestration logic |
+
+### 7. Error Handling
+
+`FileAccessError` variants map to `IntegrationError`:
+
+| FileAccessError | IntegrationError | Rationale |
+|----------------|-----------------|-----------|
+| `FileNotFound` | `ValidationError` | Invalid file reference |
+| `NotOwner` | `AuthenticationError` | Access denied |
+| `FileExpired` | `ValidationError` | File no longer available |
+| `FileIsDeleted` | `ValidationError` | File was deleted |
+| `BlobMissing` | `UnexpectedError` | Storage inconsistency |
+| `StorageError` | `UnexpectedError` | Infrastructure failure |
+
+No sensitive information (file paths, internal IDs) is exposed in error messages.
+
+## Consequences
+
+### Positive
+
+1. **Handles impossible-for-CLI cases**: Scanned documents, handwritten notes, and complex layouts that poppler-utils cannot process.
+
+2. **Reuses existing infrastructure**: No changes to `ActionContext`, `FileAccessContext`, `Application.hs`, or the OpenRouter pipeline.
+
+3. **Backward-compatible Message extension**: Existing text-only OpenRouter usage is completely unaffected.
+
+4. **NeoHaskell style compliant**: Follows the Jess/Nick two-persona model, qualified module design, pipe-friendly API.
+
+5. **Multiple extraction modes**: FullText, Summary, and Structured cover diverse use cases from simple OCR to data extraction.
+
+### Negative
+
+1. **API costs per request**: Unlike free CLI extraction, each AI transcription incurs API costs (varies by model and document size).
+
+2. **Network latency**: 120-second default timeout vs <5 seconds for CLI extraction. Long-running requests may impact the integration dispatcher worker pool.
+
+3. **AI hallucination risk**: Models may fabricate text that doesn't exist in the document. This is inherent to AI-based extraction and must be documented for users.
+
+4. **External data exposure**: File content (as base64) is sent to third-party AI providers via OpenRouter. PDFs may contain PII or sensitive data.
+
+### Risks
+
+1. **Memory pressure from base64 encoding**: Base64 encoding increases data size by ~33%. A 10MB PDF becomes ~13.3MB of base64 text. Mitigate with strict fields and document size limits.
+
+2. **Prompt injection via PDF content**: PDF text content is NOT interpolated into the system prompt (only sent as an image attachment), reducing but not eliminating injection risk.
+
+3. **Rate limiting**: OpenRouter may rate-limit large or frequent requests. Users should be aware of provider-specific limits.
+
+4. **Model availability**: Multimodal models may not always be available on OpenRouter. Error handling must gracefully report API failures.
+
+## References
+
+- [GitHub Issue #343](https://github.com/neohaskell/NeoHaskell/issues/343) — Original feature request
+- [ADR-0008: Integration Pattern](0008-integration-pattern.md) — Two-persona model (Jess/Nick)
+- [ADR-0015: HTTP Outbound Integration](0015-http-outbound-integration.md) — HTTP integration that OpenRouter piggybacks on
+- [Integration.Pdf.ExtractText](../../integrations/Integration/Pdf/ExtractText.hs) — Companion CLI-based extraction module
+- [Integration.OpenRouter](../../integrations/Integration/OpenRouter.hs) — AI model access via OpenRouter
+- [Integration.OpenRouter.Message](../../integrations/Integration/OpenRouter/Message.hs) — Current text-only Message type
+- [Integration.hs](../../core/service/Integration.hs) — ActionContext and FileAccessContext definitions
+- [Bytes.hs](../../core/core/Bytes.hs) — Base64 encoding utility

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -36,6 +36,7 @@ ADRs document significant architectural decisions made during the development of
 | [0020](0020-openapi-grouping-and-complete-endpoints.md) | OpenAPI Grouping and Complete Endpoint Coverage | Proposed |
 | [0021](0021-declarative-config-dsl.md) | Declarative Config DSL | Proposed |
 | [0022](0022-decimal-type.md) | Decimal Type for Financial Calculations | Proposed |
+| [0023](0023-ai-pdf-transcription.md) | AI-Powered PDF Transcription via Multimodal Models | Proposed |
 
 ## Creating New ADRs
 

--- a/integrations/Integration/Ai/TranscribePdf.hs
+++ b/integrations/Integration/Ai/TranscribePdf.hs
@@ -165,7 +165,7 @@ data TranscriptionResult = TranscriptionResult
   , pageCount :: Maybe Int
   -- ^ Number of pages processed (if available from model response)
   , confidence :: Maybe Float
-  -- ^ Confidence score (always Nothing for v1)
+  -- ^ Confidence score (always Nothing for v1, Float is Double-precision in NeoHaskell)
   }
   deriving (Show, Eq, Generic)
 

--- a/integrations/Integration/Ai/TranscribePdf.hs
+++ b/integrations/Integration/Ai/TranscribePdf.hs
@@ -1,7 +1,7 @@
 -- | # AI-Powered PDF Transcription Integration
 --
 -- This module provides AI-powered PDF text extraction using multimodal
--- models (Gemini, Claude Vision, GPT-4V) via the OpenRouter API.
+-- models (Gemini, Claude Vision, GPT-4o) via the OpenRouter API.
 --
 -- == Two-Persona Model
 --

--- a/integrations/Integration/Ai/TranscribePdf.hs
+++ b/integrations/Integration/Ai/TranscribePdf.hs
@@ -1,0 +1,220 @@
+-- | # AI-Powered PDF Transcription Integration
+--
+-- This module provides AI-powered PDF text extraction using multimodal
+-- models (Gemini, Claude Vision, GPT-4V) via the OpenRouter API.
+--
+-- == Two-Persona Model
+--
+-- Following ADR-0008 and ADR-0023, this integration separates concerns:
+--
+-- * __Jess (Integration User)__: Configures extraction with pure records.
+--   No @Task@, no API calls, no base64 encoding visible.
+--
+-- * __Nick (Integration Developer)__: Implements 'ToAction' with file retrieval,
+--   base64 encoding, and OpenRouter orchestration in
+--   "Integration.Ai.TranscribePdf.Internal".
+--
+-- == Quick Start
+--
+-- @
+-- import Integration qualified
+-- import Integration.Ai.TranscribePdf qualified as AiTranscribe
+--
+-- documentIntegrations :: Document -> DocumentEvent -> Integration.Outbound
+-- documentIntegrations doc event = case event of
+--   PdfUploaded info -> Integration.batch
+--     [ Integration.outbound AiTranscribe.Request
+--         { fileRef = info.fileRef
+--         , model = "google\/gemini-pro-1.5"
+--         , config = AiTranscribe.defaultConfig
+--         , onSuccess = \\result -> RecordTranscription
+--             { documentId = doc.id
+--             , text = result.text
+--             }
+--         , onError = \\err -> TranscriptionFailed
+--             { documentId = doc.id
+--             , error = err
+--             }
+--         }
+--     ]
+--   _ -> Integration.none
+-- @
+--
+-- == Extraction Modes
+--
+-- * 'FullText': Extract all text faithfully, preserving structure
+-- * 'Summary': Summarize document content
+-- * 'Structured': Extract as structured JSON
+--
+-- == Companion Module
+--
+-- For CLI-based extraction (faster, free, but limited to digital PDFs),
+-- see "Integration.Pdf.ExtractText".
+--
+-- == Data Privacy Notice
+--
+-- File content is sent to third-party AI providers via OpenRouter.
+-- Ensure appropriate data processing agreements are in place.
+-- See ADR-0023 for security and privacy considerations.
+--
+-- == Known Limitations (v1)
+--
+-- * No streaming support
+-- * No confidence scoring (always Nothing)
+-- * No page-level extraction (whole document only)
+module Integration.Ai.TranscribePdf
+  ( -- * Request Configuration (Jess's API)
+    Request (..)
+  , Config (..)
+  , ExtractionMode (..)
+
+    -- * Result Types
+  , TranscriptionResult (..)
+
+    -- * Config Helpers
+  , defaultConfig
+  ) where
+
+import Basics
+import Json qualified
+import Maybe (Maybe (..))
+import Service.FileUpload.Core (FileRef)
+import Text (Text)
+
+
+-- | Extraction modes for AI-powered transcription.
+--
+-- * 'FullText': Extract all text faithfully, preserving structure.
+--   Best for documents where you need the complete text.
+--
+-- * 'Summary': Summarize document content.
+--   Best for getting a quick overview of long documents.
+--
+-- * 'Structured': Extract as structured JSON.
+--   Best for forms, invoices, and documents with known structure.
+data ExtractionMode
+  = FullText
+  -- ^ Extract all text faithfully, preserving structure
+  | Summary
+  -- ^ Summarize document content
+  | Structured
+  -- ^ Extract as structured JSON
+  deriving (Show, Eq, Generic)
+
+instance Json.ToJSON ExtractionMode
+instance Json.FromJSON ExtractionMode
+
+
+-- | Configuration for AI transcription.
+--
+-- Use 'defaultConfig' for sensible defaults, then override specific fields:
+--
+-- @
+-- AiTranscribe.defaultConfig
+--   { extractionMode = AiTranscribe.Summary
+--   , language = Just "es"
+--   }
+-- @
+data Config = Config
+  { extractionMode :: ExtractionMode
+  -- ^ How to extract text (default: FullText)
+  , language :: Maybe Text
+  -- ^ Language hint for the AI model (e.g., "en", "es")
+  , maxPages :: Maybe Int
+  -- ^ Limit number of pages to process (Nothing = all)
+  , systemPrompt :: Maybe Text
+  -- ^ Override the default system prompt
+  , timeoutSeconds :: Int
+  -- ^ Timeout for the API call (default: 120)
+  }
+  deriving (Show, Eq, Generic)
+
+instance Json.ToJSON Config
+instance Json.FromJSON Config
+
+
+-- | Default configuration for AI transcription.
+--
+-- * Extraction mode: FullText
+-- * Language: None (auto-detect)
+-- * Max pages: None (all pages)
+-- * System prompt: None (use default)
+-- * Timeout: 120 seconds
+{-# INLINE defaultConfig #-}
+defaultConfig :: Config
+defaultConfig = Config
+  { extractionMode = FullText
+  , language = Nothing
+  , maxPages = Nothing
+  , systemPrompt = Nothing
+  , timeoutSeconds = 120
+  }
+
+
+-- | Result of AI-powered transcription.
+--
+-- @
+-- onSuccess = \\result -> RecordTranscription
+--   { text = result.text
+--   , pageCount = result.pageCount
+--   }
+-- @
+data TranscriptionResult = TranscriptionResult
+  { text :: Text
+  -- ^ Extracted\/transcribed text
+  , pageCount :: Maybe Int
+  -- ^ Number of pages processed (if available from model response)
+  , confidence :: Maybe Float
+  -- ^ Confidence score (always Nothing for v1)
+  }
+  deriving (Show, Eq, Generic)
+
+instance Json.ToJSON TranscriptionResult
+instance Json.FromJSON TranscriptionResult
+
+
+-- | The main request configuration record that Jess instantiates.
+--
+-- The @command@ type parameter is the domain command emitted by
+-- 'onSuccess' or 'onError' callbacks.
+--
+-- == Fields
+--
+-- * 'fileRef': Reference to the uploaded PDF file
+-- * 'model': AI model to use (e.g., @\"google\/gemini-pro-1.5\"@)
+-- * 'config': Extraction configuration (use 'defaultConfig')
+-- * 'onSuccess': Callback that receives result and returns a domain command
+-- * 'onError': Callback for error handling
+--
+-- == Example
+--
+-- @
+-- Integration.outbound AiTranscribe.Request
+--   { fileRef = e.uploadedFile
+--   , model = "google\/gemini-pro-1.5"
+--   , config = AiTranscribe.defaultConfig
+--       { extractionMode = AiTranscribe.Summary
+--       }
+--   , onSuccess = \\result -> RecordText
+--       { documentId = doc.id
+--       , text = result.text
+--       }
+--   , onError = \\err -> TranscriptionFailed
+--       { documentId = doc.id
+--       , error = err
+--       }
+--   }
+-- @
+data Request command = Request
+  { fileRef :: FileRef
+  -- ^ Reference to the uploaded PDF file
+  , model :: Text
+  -- ^ AI model to use (e.g., "google\/gemini-pro-1.5")
+  , config :: Config
+  -- ^ Extraction configuration
+  , onSuccess :: TranscriptionResult -> command
+  -- ^ Callback for successful transcription
+  , onError :: Text -> command
+  -- ^ Callback for transcription errors
+  }
+  deriving (Generic)

--- a/integrations/Integration/Ai/TranscribePdf/Internal.hs
+++ b/integrations/Integration/Ai/TranscribePdf/Internal.hs
@@ -125,7 +125,7 @@ extractResponseText response = do
               |> Array.map (\part -> case part of
                   Message.TextPart text -> text
                   Message.ImageUrlPart _ -> "")
-              |> Text.concat
+              |> Text.joinWith " "
         case textParts of
           "" -> Nothing
           result -> Just result

--- a/integrations/Integration/Ai/TranscribePdf/Internal.hs
+++ b/integrations/Integration/Ai/TranscribePdf/Internal.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Internal implementation for AI PDF transcription integration.
+--
+-- This module contains Nick's code - the 'ToAction' instance,
+-- file retrieval, base64 encoding, prompt building, and OpenRouter
+-- orchestration.
+--
+-- __This module is not exported to Jess.__
+module Integration.Ai.TranscribePdf.Internal
+  ( -- * For Testing Only
+    buildSystemPrompt
+  , buildExtractionPrompt
+  , fileAccessToIntegrationError
+  , integrationErrorToText
+  ) where
+
+import Array qualified
+import Basics
+import Bytes (Bytes)
+import Bytes qualified
+import Integration qualified
+import Integration.Ai.TranscribePdf (Config (..), ExtractionMode (..), Request (..), TranscriptionResult (..))
+import Integration.OpenRouter.Internal ()
+import Integration.OpenRouter.Message qualified as Message
+import Integration.OpenRouter.Request qualified as OpenRouter
+import Integration.OpenRouter.Response qualified as OpenRouter
+import Json qualified
+import Maybe (Maybe (..))
+import Service.Command.Core (NameOf)
+import Service.FileUpload.Core (FileAccessError (..))
+import Task (Task)
+import Task qualified
+import Text (Text)
+import Text qualified
+
+
+-- | ToAction instance that executes the AI transcription.
+--
+-- This is the main entry point - when Jess writes:
+--
+-- @
+-- Integration.outbound AiTranscribe.Request { ... }
+-- @
+--
+-- This instance converts the config into an executable action.
+instance
+  (Json.ToJSON command, KnownSymbol (NameOf command)) =>
+  Integration.ToAction (Request command)
+  where
+  toAction config = Integration.action \ctx -> do
+    executeTranscription ctx config
+
+
+-- | Execute an AI transcription request.
+executeTranscription ::
+  forall command.
+  (Json.ToJSON command, KnownSymbol (NameOf command)) =>
+  Integration.ActionContext ->
+  Request command ->
+  Task Integration.IntegrationError (Maybe Integration.CommandPayload)
+executeTranscription ctx config = do
+  -- Step 1: Get file access context
+  fileAccess <- case ctx.fileAccess of
+    Nothing ->
+      Task.throw (Integration.ValidationError "File uploads not enabled. Cannot access PDF file.")
+    Just fa ->
+      Task.yield fa
+
+  -- Step 2: Retrieve PDF bytes
+  pdfBytes <- fileAccess.retrieveFile config.fileRef
+    |> Task.mapError fileAccessToIntegrationError
+
+  -- Step 3: Encode to base64
+  let base64Text = pdfBytes |> Bytes.toBase64 |> bytesToText
+
+  -- Step 4: Build the system prompt
+  let sysPrompt = buildSystemPrompt config.config
+
+  -- Step 5: Build the user message with PDF attachment
+  let userMsg = Message.userWithAttachment
+        (buildExtractionPrompt config.config)
+        base64Text
+        "application/pdf"
+
+  -- Step 6: Create OpenRouter request
+  let openRouterRequest = OpenRouter.Request
+        { messages = [Message.system sysPrompt, userMsg]
+        , model = config.model
+        , config = OpenRouter.defaultConfig
+            { OpenRouter.timeoutSeconds = config.config.timeoutSeconds
+            }
+        , onSuccess = \response -> do
+            let resultText = extractResponseText response
+            let result = TranscriptionResult
+                  { text = resultText
+                  , pageCount = Nothing
+                  , confidence = Nothing
+                  }
+            config.onSuccess result
+        , onError = \err -> config.onError err
+        }
+
+  -- Step 7: Delegate to OpenRouter integration
+  let openRouterAction = Integration.toAction openRouterRequest
+  Integration.runAction ctx openRouterAction
+
+
+-- | Extract the text content from an OpenRouter response.
+extractResponseText :: OpenRouter.Response -> Text
+extractResponseText response = do
+  let choices = response.choices
+  case choices |> Array.first of
+    Nothing -> ""
+    Just choice -> case choice.message.content of
+      Message.TextContent text -> text
+      Message.MultiContent _ -> ""
+
+
+-- | Build the system prompt based on extraction mode and config.
+buildSystemPrompt :: Config -> Text
+buildSystemPrompt config = case config.systemPrompt of
+  Just custom -> custom
+  Nothing -> do
+    let basePrompt :: Text
+        basePrompt = case config.extractionMode of
+          FullText ->
+            "You are a document transcription assistant. Extract ALL text from the provided PDF document faithfully and completely. Preserve the original structure, headings, paragraphs, and formatting as much as possible. Do not summarize or omit any content."
+          Summary ->
+            "You are a document summarization assistant. Read the provided PDF document and produce a clear, concise summary of its contents. Capture the key points, main arguments, and important details."
+          Structured ->
+            "You are a structured data extraction assistant. Extract information from the provided PDF document and return it as a well-structured JSON object. Identify key fields, tables, and data points."
+    let languageHint :: Text
+        languageHint = case config.language of
+          Nothing -> ""
+          Just lang -> [fmt| The document is in #{lang}. Respond in the same language.|]
+    let pageHint :: Text
+        pageHint = case config.maxPages of
+          Nothing -> ""
+          Just n -> do
+            let nText = Text.fromInt n
+            [fmt| Only process the first #{nText} pages.|]
+    basePrompt |> Text.append languageHint |> Text.append pageHint
+
+
+-- | Build the extraction prompt (user message text).
+buildExtractionPrompt :: Config -> Text
+buildExtractionPrompt config = case config.extractionMode of
+  FullText ->
+    "Please extract all text from this PDF document."
+  Summary ->
+    "Please summarize the contents of this PDF document."
+  Structured ->
+    "Please extract structured data from this PDF document and return it as JSON."
+
+
+-- | Convert FileAccessError to IntegrationError.
+fileAccessToIntegrationError :: FileAccessError -> Integration.IntegrationError
+fileAccessToIntegrationError err = case err of
+  FileNotFound _ ->
+    Integration.ValidationError "File not found"
+  StateLookupFailed _ msg ->
+    Integration.UnexpectedError [fmt|Failed to lookup file state: #{msg}|]
+  NotOwner _ ->
+    Integration.AuthenticationError "Not authorized to access this file"
+  FileExpired _ ->
+    Integration.ValidationError "File has expired"
+  FileIsDeleted _ ->
+    Integration.ValidationError "File has been deleted"
+  BlobMissing _ ->
+    Integration.UnexpectedError "File blob is missing from storage"
+  StorageError msg ->
+    Integration.UnexpectedError [fmt|Storage error: #{msg}|]
+
+
+-- | Convert IntegrationError to Text for the onError callback.
+integrationErrorToText :: Integration.IntegrationError -> Text
+integrationErrorToText err = case err of
+  Integration.ValidationError msg -> msg
+  Integration.AuthenticationError msg -> msg
+  Integration.NetworkError msg -> msg
+  Integration.RateLimited _ -> "Rate limited"
+  Integration.PermanentFailure msg -> msg
+  Integration.UnexpectedError msg -> msg
+
+
+-- | Convert Bytes to Text (UTF-8 decoding of base64 output).
+bytesToText :: Bytes -> Text
+bytesToText bytes = bytes |> Text.fromBytes |> Text.trim

--- a/integrations/Integration/OpenRouter.hs
+++ b/integrations/Integration/OpenRouter.hs
@@ -69,8 +69,6 @@
 --
 -- * No streaming support
 -- * No tool/function calling
--- * No multimodal (images) support
---
 -- These will be added in future versions.
 module Integration.OpenRouter
   ( -- * Request Building
@@ -88,9 +86,13 @@ module Integration.OpenRouter
     -- * Message Types
   , Message (..)
   , Role (..)
+  , Content (..)
+  , ContentPart (..)
+  , ImageUrl (..)
   , user
   , assistant
   , system
+  , userWithAttachment
 
     -- * Transformation (Advanced)
     -- | For most use cases, use @Integration.outbound@ directly.
@@ -100,6 +102,6 @@ module Integration.OpenRouter
   ) where
 
 import Integration.OpenRouter.Internal (toHttpRequest)
-import Integration.OpenRouter.Message (Message (..), Role (..), assistant, system, user)
+import Integration.OpenRouter.Message (Content (..), ContentPart (..), ImageUrl (..), Message (..), Role (..), assistant, system, user, userWithAttachment)
 import Integration.OpenRouter.Request (Config (..), Request (..), chatCompletion, defaultConfig)
 import Integration.OpenRouter.Response (Choice (..), FinishReason (..), Response (..), Usage (..))

--- a/integrations/Integration/OpenRouter/Message.hs
+++ b/integrations/Integration/OpenRouter/Message.hs
@@ -3,7 +3,7 @@
 -- This module provides the 'Message' and 'Role' types for building
 -- conversations with AI models via OpenRouter.
 --
--- == Quick Start
+-- == Quick Start (Text-only)
 --
 -- @
 -- import Integration.OpenRouter.Message (Message)
@@ -16,18 +16,51 @@
 --   , Message.user "Tell me more."
 --   ]
 -- @
+--
+-- == Multimodal (Images\/PDFs)
+--
+-- @
+-- import Integration.OpenRouter.Message qualified as Message
+--
+-- -- Send a PDF attachment with a text prompt:
+-- multimodalMsg = Message.userWithAttachment
+--   "Extract all text from this document."
+--   base64Content
+--   "application\/pdf"
+-- @
+--
+-- == Backward Compatibility
+--
+-- Text-only messages serialize identically to the previous format:
+--
+-- * @Message.user \"hello\"@ → @{\"role\":\"user\",\"content\":\"hello\"}@
+--
+-- Multimodal messages use the OpenAI content array format:
+--
+-- * @Message.userWithAttachment ...@ → @{\"role\":\"user\",\"content\":[...]}@
 module Integration.OpenRouter.Message
   ( -- * Types
     Message (..)
   , Role (..)
 
+    -- * Content Types (Multimodal)
+  , Content (..)
+  , ContentPart (..)
+  , ImageUrl (..)
+
     -- * Smart Constructors
   , user
   , assistant
   , system
+
+    -- * Multimodal Constructors
+  , userWithAttachment
   ) where
 
+import Array (Array)
+import Array qualified
 import Basics
+import Result (Result (..))
 import Json qualified
 import Text (Text)
 
@@ -64,14 +97,123 @@ instance Json.FromJSON Role where
       other -> Json.fail [fmt|Unknown role: #{other}|]
 
 
+-- | Image URL reference for multimodal content.
+--
+-- Used to embed images or documents as data URLs:
+--
+-- @
+-- ImageUrl { url = "data:application\/pdf;base64,..." }
+-- @
+data ImageUrl = ImageUrl
+  { url :: Text
+  -- ^ Data URL (e.g., @\"data:application\/pdf;base64,...\"@)
+  }
+  deriving (Show, Eq, Generic)
+
+
+instance Json.ToJSON ImageUrl where
+  toJSON imageUrl =
+    Json.object
+      [ ("url", Json.toJSON imageUrl.url)
+      ]
+
+
+instance Json.FromJSON ImageUrl where
+  parseJSON = Json.withObject "ImageUrl" \obj -> do
+    url <- obj Json..: "url"
+    Json.yield ImageUrl {url}
+
+
+-- | A single part within multimodal content.
+--
+-- * 'TextPart' — A text segment
+-- * 'ImageUrlPart' — An image or document attachment
+data ContentPart
+  = TextPart Text
+  -- ^ Text content part
+  | ImageUrlPart ImageUrl
+  -- ^ Image\/attachment content part
+  deriving (Show, Eq, Generic)
+
+
+instance Json.ToJSON ContentPart where
+  toJSON part = case part of
+    TextPart text ->
+      Json.object
+        [ ("type", Json.toJSON ("text" :: Text))
+        , ("text", Json.toJSON text)
+        ]
+    ImageUrlPart imageUrl ->
+      Json.object
+        [ ("type", Json.toJSON ("image_url" :: Text))
+        , ("image_url", Json.toJSON imageUrl)
+        ]
+
+
+instance Json.FromJSON ContentPart where
+  parseJSON = Json.withObject "ContentPart" \obj -> do
+    partType <- obj Json..: "type"
+    case (partType :: Text) of
+      "text" -> do
+        text <- obj Json..: "text"
+        Json.yield (TextPart text)
+      "image_url" -> do
+        imageUrl <- obj Json..: "image_url"
+        Json.yield (ImageUrlPart imageUrl)
+      other ->
+        Json.fail [fmt|Unknown content part type: #{other}|]
+
+
+-- | Message content — either plain text or multimodal content array.
+--
+-- * 'TextContent' — Plain text (backward compatible with previous API)
+-- * 'MultiContent' — Array of content parts for multimodal messages
+--
+-- == JSON Serialization
+--
+-- * @TextContent \"hello\"@ → @\"hello\"@ (plain JSON string)
+-- * @MultiContent [...]@ → @[{\"type\":\"text\",...}, ...]@ (JSON array)
+--
+-- 'FromJSON' accepts both formats for backward compatibility.
+data Content
+  = TextContent Text
+  -- ^ Plain text content (backward compatible)
+  | MultiContent (Array ContentPart)
+  -- ^ Array of content parts (text + images\/attachments)
+  deriving (Show, Eq, Generic)
+
+
+instance Json.ToJSON Content where
+  toJSON content = case content of
+    TextContent text ->
+      Json.toJSON text
+    MultiContent parts ->
+      Json.toJSON parts
+
+
+instance Json.FromJSON Content where
+  parseJSON value = do
+    -- Try parsing as a plain text string first (backward compatible).
+    -- If that fails, parse as an array of content parts (multimodal).
+    case Json.decode value of
+      Ok (text :: Text) ->
+        Json.yield (TextContent text)
+      Err _ -> do
+        parts <- Json.parseJSON value
+        Json.yield (MultiContent parts)
+
+
 -- | A single message in a conversation.
 --
 -- Messages form the conversation history sent to the model.
 -- Use the smart constructors 'user', 'assistant', and 'system'
 -- for convenient message creation.
+--
+-- The 'content' field supports both plain text and multimodal content.
+-- Text-only messages serialize identically to the previous format.
 data Message = Message
   { role :: Role
-  , content :: Text
+  , content :: Content
   }
   deriving (Show, Eq, Generic)
 
@@ -97,7 +239,7 @@ instance Json.FromJSON Message where
 -- Message.user "What is the meaning of life?"
 -- @
 user :: Text -> Message
-user content = Message {role = User, content}
+user text = Message {role = User, content = TextContent text}
 
 
 -- | Create an assistant message.
@@ -108,7 +250,7 @@ user content = Message {role = User, content}
 -- Message.assistant "I'd be happy to help with that."
 -- @
 assistant :: Text -> Message
-assistant content = Message {role = Assistant, content}
+assistant text = Message {role = Assistant, content = TextContent text}
 
 
 -- | Create a system message.
@@ -119,4 +261,26 @@ assistant content = Message {role = Assistant, content}
 -- Message.system "You are a helpful coding assistant. Be concise."
 -- @
 system :: Text -> Message
-system content = Message {role = System, content}
+system text = Message {role = System, content = TextContent text}
+
+
+-- | Create a multimodal user message with an attachment.
+--
+-- Builds a message with both a text prompt and an image\/document
+-- attachment encoded as a data URL.
+--
+-- @
+-- Message.userWithAttachment
+--   "Extract all text from this document."
+--   base64Content
+--   "application\/pdf"
+-- @
+{-# INLINE userWithAttachment #-}
+userWithAttachment :: Text -> Text -> Text -> Message
+userWithAttachment prompt base64Content mimeType = do
+  let dataUrl = [fmt|data:#{mimeType};base64,#{base64Content}|]
+  let parts = Array.fromLinkedList
+        [ TextPart prompt
+        , ImageUrlPart ImageUrl {url = dataUrl}
+        ]
+  Message {role = User, content = MultiContent parts}

--- a/integrations/Integration/Pdf.hs
+++ b/integrations/Integration/Pdf.hs
@@ -5,6 +5,9 @@
 -- == Available Integrations
 --
 -- * "Integration.Pdf.ExtractText" - Local CLI-based text extraction
+--   (fast, free, requires poppler-utils)
+-- * "Integration.Ai.TranscribePdf" - AI-powered multimodal transcription
+--   (handles scanned docs, OCR, summarization — requires OpenRouter API key)
 --
 -- == Quick Start
 --

--- a/integrations/Integration/Pdf.hs
+++ b/integrations/Integration/Pdf.hs
@@ -5,9 +5,10 @@
 -- == Available Integrations
 --
 -- * "Integration.Pdf.ExtractText" - Local CLI-based text extraction
---   (fast, free, requires poppler-utils)
+--   (fast, free, requires poppler-utils). Re-exported from this module.
 -- * "Integration.Ai.TranscribePdf" - AI-powered multimodal transcription
---   (handles scanned docs, OCR, summarization — requires OpenRouter API key)
+--   (handles scanned docs, OCR, summarization — requires OpenRouter API key).
+--   Must be imported separately: @import Integration.Ai.TranscribePdf qualified as AiTranscribe@
 --
 -- == Quick Start
 --
@@ -25,7 +26,9 @@
 --
 -- == Requirements
 --
--- The text extraction integration requires poppler-utils:
+-- === Local Text Extraction
+--
+-- The @Integration.Pdf.ExtractText@ integration requires poppler-utils:
 --
 -- @
 -- # Ubuntu/Debian
@@ -37,6 +40,11 @@
 -- # Nix
 -- nix-shell -p poppler_utils
 -- @
+--
+-- === AI Transcription
+--
+-- The @Integration.Ai.TranscribePdf@ integration requires an OpenRouter API key.
+-- See <https://openrouter.ai/keys> for API key setup.
 module Integration.Pdf
   ( -- * Text Extraction
     module Integration.Pdf.ExtractText

--- a/integrations/nhintegrations.cabal
+++ b/integrations/nhintegrations.cabal
@@ -57,6 +57,8 @@ common common_cfg
 library
   import: common_cfg
   exposed-modules:
+    Integration.Ai.TranscribePdf
+    Integration.Ai.TranscribePdf.Internal
     Integration.Http
     Integration.Http.Auth
     Integration.Http.Internal
@@ -104,6 +106,7 @@ test-suite nhintegrations-test
     Integration.Oura.SleepSpec
     Integration.Oura.SyncAllSpec
     Integration.Oura.TypesSpec
+    Integration.Ai.TranscribePdf.InternalSpec
   build-depends:
     hspec,
     nhintegrations

--- a/integrations/test/Integration/Ai/TranscribePdf/InternalSpec.hs
+++ b/integrations/test/Integration/Ai/TranscribePdf/InternalSpec.hs
@@ -1,0 +1,142 @@
+module Integration.Ai.TranscribePdf.InternalSpec (spec) where
+
+import Basics
+import Integration qualified
+import Integration.Ai.TranscribePdf (Config (..), ExtractionMode (..))
+import Integration.Ai.TranscribePdf qualified as AiTranscribe
+import Integration.Ai.TranscribePdf.Internal
+import Json qualified
+import Maybe (Maybe (..))
+import Result (Result)
+import Result qualified
+import Service.FileUpload.Core (FileAccessError (..), FileRef (..))
+import Test.Hspec
+import Text (Text)
+import Text qualified
+
+
+spec :: Spec
+spec = do
+  describe "buildSystemPrompt" do
+    it "produces FullText prompt by default" do
+      let prompt = buildSystemPrompt AiTranscribe.defaultConfig
+      Text.contains "Extract ALL text" prompt `shouldBe` True
+
+    it "produces Summary prompt for Summary mode" do
+      let config = AiTranscribe.defaultConfig {extractionMode = Summary}
+      let prompt = buildSystemPrompt config
+      Text.contains "summary" prompt `shouldBe` True
+
+    it "produces Structured prompt for Structured mode" do
+      let config = AiTranscribe.defaultConfig {extractionMode = Structured}
+      let prompt = buildSystemPrompt config
+      Text.contains "JSON" prompt `shouldBe` True
+
+    it "appends language hint when provided" do
+      let config = AiTranscribe.defaultConfig {language = Just "es"}
+      let prompt = buildSystemPrompt config
+      Text.contains "es" prompt `shouldBe` True
+
+    it "appends maxPages hint when provided" do
+      let config = AiTranscribe.defaultConfig {maxPages = Just 5}
+      let prompt = buildSystemPrompt config
+      Text.contains "5" prompt `shouldBe` True
+
+    it "uses custom systemPrompt when provided" do
+      let config = AiTranscribe.defaultConfig {systemPrompt = Just "Custom prompt"}
+      let prompt = buildSystemPrompt config
+      prompt `shouldBe` "Custom prompt"
+
+  describe "buildExtractionPrompt" do
+    it "produces FullText extraction prompt" do
+      let prompt = buildExtractionPrompt AiTranscribe.defaultConfig
+      Text.contains "extract all text" prompt `shouldBe` True
+
+    it "produces Summary extraction prompt" do
+      let config = AiTranscribe.defaultConfig {extractionMode = Summary}
+      let prompt = buildExtractionPrompt config
+      Text.contains "summarize" prompt `shouldBe` True
+
+    it "produces Structured extraction prompt" do
+      let config = AiTranscribe.defaultConfig {extractionMode = Structured}
+      let prompt = buildExtractionPrompt config
+      Text.contains "JSON" prompt `shouldBe` True
+
+  describe "fileAccessToIntegrationError" do
+    it "converts FileNotFound to ValidationError" do
+      let ref = makeTestFileRef
+      let err = fileAccessToIntegrationError (FileNotFound ref)
+      err `shouldBe` Integration.ValidationError "File not found"
+
+    it "converts NotOwner to AuthenticationError" do
+      let ref = makeTestFileRef
+      let err = fileAccessToIntegrationError (NotOwner ref)
+      err `shouldBe` Integration.AuthenticationError "Not authorized to access this file"
+
+    it "converts FileExpired to ValidationError" do
+      let ref = makeTestFileRef
+      let err = fileAccessToIntegrationError (FileExpired ref)
+      err `shouldBe` Integration.ValidationError "File has expired"
+
+    it "converts FileIsDeleted to ValidationError" do
+      let ref = makeTestFileRef
+      let err = fileAccessToIntegrationError (FileIsDeleted ref)
+      err `shouldBe` Integration.ValidationError "File has been deleted"
+
+    it "converts BlobMissing to UnexpectedError" do
+      let ref = makeTestFileRef
+      let err = fileAccessToIntegrationError (BlobMissing ref)
+      err `shouldBe` Integration.UnexpectedError "File blob is missing from storage"
+
+    it "converts StorageError to UnexpectedError" do
+      let err = fileAccessToIntegrationError (StorageError "disk full")
+      err `shouldBe` Integration.UnexpectedError "Storage error: disk full"
+
+  describe "defaultConfig" do
+    it "has FullText extraction mode" do
+      AiTranscribe.defaultConfig.extractionMode `shouldBe` FullText
+
+    it "has 120 second timeout" do
+      AiTranscribe.defaultConfig.timeoutSeconds `shouldBe` 120
+
+    it "has no language hint" do
+      AiTranscribe.defaultConfig.language `shouldBe` Nothing
+
+    it "has no maxPages limit" do
+      AiTranscribe.defaultConfig.maxPages `shouldBe` Nothing
+
+    it "has no custom system prompt" do
+      AiTranscribe.defaultConfig.systemPrompt `shouldBe` Nothing
+
+  describe "TranscriptionResult JSON" do
+    it "roundtrips through JSON" do
+      let result = AiTranscribe.TranscriptionResult
+            { text = "Hello world"
+            , pageCount = Just 3
+            , confidence = Nothing
+            }
+      let encoded = Json.encodeText result
+      let decoded = Json.decodeText encoded :: Result Text AiTranscribe.TranscriptionResult
+      decoded `shouldBe` Result.Ok result
+
+  describe "ExtractionMode JSON" do
+    it "roundtrips FullText" do
+      let encoded = Json.encodeText FullText
+      let decoded = Json.decodeText encoded :: Result Text ExtractionMode
+      decoded `shouldBe` Result.Ok FullText
+
+    it "roundtrips Summary" do
+      let encoded = Json.encodeText Summary
+      let decoded = Json.decodeText encoded :: Result Text ExtractionMode
+      decoded `shouldBe` Result.Ok Summary
+
+    it "roundtrips Structured" do
+      let encoded = Json.encodeText Structured
+      let decoded = Json.decodeText encoded :: Result Text ExtractionMode
+      decoded `shouldBe` Result.Ok Structured
+
+
+-- Test helpers
+
+makeTestFileRef :: FileRef
+makeTestFileRef = FileRef "00000000-0000-0000-0000-000000000001"

--- a/integrations/test/Integration/Ai/TranscribePdf/InternalSpec.hs
+++ b/integrations/test/Integration/Ai/TranscribePdf/InternalSpec.hs
@@ -66,27 +66,27 @@ spec = do
     it "converts FileNotFound to ValidationError" do
       let ref = makeTestFileRef
       let err = fileAccessToIntegrationError (FileNotFound ref)
-      err `shouldBe` Integration.ValidationError "File not found"
+      err `shouldBe` Integration.ValidationError "File not found: 00000000-0000-0000-0000-000000000001"
 
     it "converts NotOwner to AuthenticationError" do
       let ref = makeTestFileRef
       let err = fileAccessToIntegrationError (NotOwner ref)
-      err `shouldBe` Integration.AuthenticationError "Not authorized to access this file"
+      err `shouldBe` Integration.AuthenticationError "Not authorized to access file: 00000000-0000-0000-0000-000000000001"
 
     it "converts FileExpired to ValidationError" do
       let ref = makeTestFileRef
       let err = fileAccessToIntegrationError (FileExpired ref)
-      err `shouldBe` Integration.ValidationError "File has expired"
+      err `shouldBe` Integration.ValidationError "File has expired: 00000000-0000-0000-0000-000000000001"
 
     it "converts FileIsDeleted to ValidationError" do
       let ref = makeTestFileRef
       let err = fileAccessToIntegrationError (FileIsDeleted ref)
-      err `shouldBe` Integration.ValidationError "File has been deleted"
+      err `shouldBe` Integration.ValidationError "File has been deleted: 00000000-0000-0000-0000-000000000001"
 
     it "converts BlobMissing to UnexpectedError" do
       let ref = makeTestFileRef
       let err = fileAccessToIntegrationError (BlobMissing ref)
-      err `shouldBe` Integration.UnexpectedError "File blob is missing from storage"
+      err `shouldBe` Integration.UnexpectedError "File blob is missing from storage: 00000000-0000-0000-0000-000000000001"
 
     it "converts StorageError to UnexpectedError" do
       let err = fileAccessToIntegrationError (StorageError "disk full")
@@ -108,11 +108,56 @@ spec = do
     it "has no custom system prompt" do
       AiTranscribe.defaultConfig.systemPrompt `shouldBe` Nothing
 
+  describe "integrationErrorToText" do
+    it "converts ValidationError to text" do
+      let result = integrationErrorToText (Integration.ValidationError "bad input")
+      result `shouldBe` "bad input"
+
+    it "converts AuthenticationError to text" do
+      let result = integrationErrorToText (Integration.AuthenticationError "not allowed")
+      result `shouldBe` "not allowed"
+
+    it "converts NetworkError to text" do
+      let result = integrationErrorToText (Integration.NetworkError "timeout")
+      result `shouldBe` "timeout"
+
+    it "converts RateLimited to text" do
+      let result = integrationErrorToText (Integration.RateLimited 30)
+      result `shouldBe` "Rate limited"
+
+    it "converts PermanentFailure to text" do
+      let result = integrationErrorToText (Integration.PermanentFailure "gone")
+      result `shouldBe` "gone"
+
+    it "converts UnexpectedError to text" do
+      let result = integrationErrorToText (Integration.UnexpectedError "oops")
+      result `shouldBe` "oops"
+
   describe "TranscriptionResult JSON" do
     it "roundtrips through JSON" do
       let result = AiTranscribe.TranscriptionResult
             { text = "Hello world"
             , pageCount = Just 3
+            , confidence = Nothing
+            }
+      let encoded = Json.encodeText result
+      let decoded = Json.decodeText encoded :: Result Text AiTranscribe.TranscriptionResult
+      decoded `shouldBe` Result.Ok result
+
+    it "roundtrips with confidence and no pageCount" do
+      let result = AiTranscribe.TranscriptionResult
+            { text = "Some text"
+            , pageCount = Nothing
+            , confidence = Just 0.95
+            }
+      let encoded = Json.encodeText result
+      let decoded = Json.decodeText encoded :: Result Text AiTranscribe.TranscriptionResult
+      decoded `shouldBe` Result.Ok result
+
+    it "roundtrips with all fields Nothing" do
+      let result = AiTranscribe.TranscriptionResult
+            { text = "Minimal"
+            , pageCount = Nothing
             , confidence = Nothing
             }
       let encoded = Json.encodeText result

--- a/integrations/test/Integration/OpenRouter/MessageSpec.hs
+++ b/integrations/test/Integration/OpenRouter/MessageSpec.hs
@@ -1,8 +1,10 @@
 module Integration.OpenRouter.MessageSpec (spec) where
 
+import Array qualified
 import Basics
 import Integration.OpenRouter.Message
 import Json qualified
+import Maybe (Maybe (..))
 import Result (Result)
 import Result qualified
 import Test.Hspec
@@ -17,17 +19,17 @@ spec = do
       it "creates user message" do
         let msg = user "Hello"
         msg.role `shouldBe` User
-        msg.content `shouldBe` "Hello"
+        msg.content `shouldBe` TextContent "Hello"
 
       it "creates assistant message" do
         let msg = assistant "Hi there"
         msg.role `shouldBe` Assistant
-        msg.content `shouldBe` "Hi there"
+        msg.content `shouldBe` TextContent "Hi there"
 
       it "creates system message" do
         let msg = system "You are helpful"
         msg.role `shouldBe` System
-        msg.content `shouldBe` "You are helpful"
+        msg.content `shouldBe` TextContent "You are helpful"
 
     describe "JSON encoding" do
       it "encodes Role to correct JSON strings" do
@@ -35,11 +37,19 @@ spec = do
         Json.encodeText Assistant `shouldBe` "\"assistant\""
         Json.encodeText System `shouldBe` "\"system\""
 
-      it "encodes Message to JSON object with role and content" do
+      it "encodes text-only Message to JSON with string content (backward compatible)" do
         let msg = user "Hello"
         let encoded = Json.encodeText msg
         Text.contains "\"role\":\"user\"" encoded `shouldBe` True
         Text.contains "\"content\":\"Hello\"" encoded `shouldBe` True
+
+      it "encodes multimodal Message to JSON with content array" do
+        let msg = userWithAttachment "Describe this" "base64data" "image/png"
+        let encoded = Json.encodeText msg
+        Text.contains "\"role\":\"user\"" encoded `shouldBe` True
+        Text.contains "\"type\":\"text\"" encoded `shouldBe` True
+        Text.contains "\"type\":\"image_url\"" encoded `shouldBe` True
+        Text.contains "data:image/png;base64,base64data" encoded `shouldBe` True
 
     describe "JSON decoding" do
       it "decodes Role from JSON strings" do
@@ -47,12 +57,67 @@ spec = do
         (Json.decodeText "\"assistant\"" :: Result Text Role) `shouldBe` Result.Ok Assistant
         (Json.decodeText "\"system\"" :: Result Text Role) `shouldBe` Result.Ok System
 
-      it "decodes Message from JSON object" do
+      it "decodes Message with string content (backward compatible)" do
         let jsonText = "{\"role\":\"user\",\"content\":\"Hello\"}" :: Text
         let decoded = Json.decodeText jsonText :: Result Text Message
         case decoded of
           Result.Ok msg -> do
             msg.role `shouldBe` User
-            msg.content `shouldBe` "Hello"
+            msg.content `shouldBe` TextContent "Hello"
           Result.Err err ->
             expectationFailure (Text.toLinkedList [fmt|Failed to decode: #{err}|])
+
+      it "decodes Message with array content (multimodal)" do
+        let jsonText = "{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Hello\"},{\"type\":\"image_url\",\"image_url\":{\"url\":\"data:image/png;base64,abc\"}}]}" :: Text
+        let decoded = Json.decodeText jsonText :: Result Text Message
+        case decoded of
+          Result.Ok msg -> do
+            msg.role `shouldBe` User
+            case msg.content of
+              MultiContent parts -> do
+                Array.length parts `shouldBe` 2
+              TextContent _ ->
+                expectationFailure "Expected MultiContent, got TextContent"
+          Result.Err err ->
+            expectationFailure (Text.toLinkedList [fmt|Failed to decode: #{err}|])
+
+    describe "Content JSON roundtrip" do
+      it "roundtrips TextContent" do
+        let content = TextContent "hello"
+        let encoded = Json.encodeText content
+        let decoded = Json.decodeText encoded :: Result Text Content
+        decoded `shouldBe` Result.Ok content
+
+      it "roundtrips MultiContent" do
+        let content = MultiContent (Array.fromLinkedList [TextPart "hello", ImageUrlPart ImageUrl {url = "data:image/png;base64,abc"}])
+        let encoded = Json.encodeText content
+        let decoded = Json.decodeText encoded :: Result Text Content
+        decoded `shouldBe` Result.Ok content
+
+    describe "userWithAttachment" do
+      it "creates message with correct data URL" do
+        let msg = userWithAttachment "Extract text" "AQID" "application/pdf"
+        msg.role `shouldBe` User
+        case msg.content of
+          MultiContent parts -> do
+            Array.length parts `shouldBe` 2
+          TextContent _ ->
+            expectationFailure "Expected MultiContent"
+
+      it "includes text prompt as first part" do
+        let msg = userWithAttachment "My prompt" "data" "application/pdf"
+        case msg.content of
+          MultiContent parts -> do
+            let firstPart = Array.first parts
+            firstPart `shouldBe` Just (TextPart "My prompt")
+          TextContent _ ->
+            expectationFailure "Expected MultiContent"
+
+      it "includes image URL with data URI as second part" do
+        let msg = userWithAttachment "prompt" "AQID" "application/pdf"
+        case msg.content of
+          MultiContent parts -> do
+            let secondPart = parts |> Array.drop 1 |> Array.first
+            secondPart `shouldBe` Just (ImageUrlPart ImageUrl {url = "data:application/pdf;base64,AQID"})
+          TextContent _ ->
+            expectationFailure "Expected MultiContent"

--- a/integrations/test/Integration/OpenRouter/MessageSpec.hs
+++ b/integrations/test/Integration/OpenRouter/MessageSpec.hs
@@ -121,3 +121,33 @@ spec = do
             secondPart `shouldBe` Just (ImageUrlPart ImageUrl {url = "data:application/pdf;base64,AQID"})
           TextContent _ ->
             expectationFailure "Expected MultiContent"
+
+      it "handles empty prompt" do
+        let msg = userWithAttachment "" "AQID" "application/pdf"
+        msg.role `shouldBe` User
+        case msg.content of
+          MultiContent parts -> do
+            Array.length parts `shouldBe` 2
+            Array.first parts `shouldBe` Just (TextPart "")
+          TextContent _ ->
+            expectationFailure "Expected MultiContent"
+
+      it "handles empty base64 data" do
+        let msg = userWithAttachment "prompt" "" "application/pdf"
+        msg.role `shouldBe` User
+        case msg.content of
+          MultiContent parts -> do
+            let secondPart = parts |> Array.drop 1 |> Array.first
+            secondPart `shouldBe` Just (ImageUrlPart ImageUrl {url = "data:application/pdf;base64,"})
+          TextContent _ ->
+            expectationFailure "Expected MultiContent"
+
+      it "handles empty MIME type" do
+        let msg = userWithAttachment "prompt" "AQID" ""
+        msg.role `shouldBe` User
+        case msg.content of
+          MultiContent parts -> do
+            let secondPart = parts |> Array.drop 1 |> Array.first
+            secondPart `shouldBe` Just (ImageUrlPart ImageUrl {url = "data:;base64,AQID"})
+          TextContent _ ->
+            expectationFailure "Expected MultiContent"

--- a/integrations/test/Integration/OpenRouter/ResponseSpec.hs
+++ b/integrations/test/Integration/OpenRouter/ResponseSpec.hs
@@ -105,7 +105,7 @@ spec = do
         case decoded of
           Result.Ok (choice :: Choice) -> do
             choice.message.role `shouldBe` Message.Assistant
-            choice.message.content `shouldBe` "Hello!"
+            choice.message.content `shouldBe` Message.TextContent "Hello!"
             choice.finishReason `shouldBe` Stop
             choice.index `shouldBe` 0
           Result.Err err ->

--- a/testbed/nhtestbed.cabal
+++ b/testbed/nhtestbed.cabal
@@ -71,6 +71,7 @@ library
     Testbed.Stock.Core
     Testbed.Stock.Queries.StockLevel
     Testbed.Stock.Service
+    Testbed.Examples.AiTranscription
     Testbed.Examples.HttpIntegration
     Testbed.Examples.OpenRouterIntegration
     Testbed.Examples.PdfExtraction

--- a/testbed/src/Testbed/Examples/AiTranscription.hs
+++ b/testbed/src/Testbed/Examples/AiTranscription.hs
@@ -1,0 +1,216 @@
+-- | Example AI-powered PDF transcription integration for testbed.
+--
+-- This module demonstrates how Jess (Integration User) would use the
+-- AI transcription integration to extract text from uploaded PDF files
+-- using multimodal AI models (Gemini, Claude Vision, GPT-4V) via OpenRouter.
+--
+-- == Usage Pattern
+--
+-- Jess configures AI transcription using pure records:
+--
+-- @
+-- Integration.outbound AiTranscribe.Request
+--   { fileRef = e.file
+--   , model = "google\/gemini-pro-1.5"
+--   , config = AiTranscribe.defaultConfig
+--   , onSuccess = \\result -> RecordTranscription { text = result.text }
+--   , onError = \\err -> TranscriptionFailed { error = err }
+--   }
+-- @
+--
+-- No @Task@, no base64 encoding, no API calls visible to Jess.
+--
+-- == Comparison with CLI Extraction
+--
+-- For digital PDFs where CLI tools suffice, see "Testbed.Examples.PdfExtraction".
+-- AI transcription is best for:
+--
+-- * Scanned documents requiring OCR
+-- * Complex layouts (multi-column, mixed content)
+-- * Handwritten notes
+-- * Document summarization
+-- * Structured data extraction (forms, invoices)
+--
+-- == Note
+--
+-- This module demonstrates the API design. The actual transcription
+-- sends PDF content to third-party AI providers via OpenRouter.
+-- See ADR-0023 for security and privacy considerations.
+module Testbed.Examples.AiTranscription
+  ( -- * Example Integration Builders
+    fullTextTranscription
+  , documentSummary
+  , structuredExtraction
+    -- * Example Command Types (for demonstration)
+  , TranscriptionOutcome (..)
+  ) where
+
+import Core
+import Integration qualified
+import Integration.Ai.TranscribePdf qualified as AiTranscribe
+import Integration.Ai.TranscribePdf.Internal ()  -- ToAction instance
+import Json qualified
+import Service.FileUpload.Core (FileRef)
+
+
+-- ============================================================================
+-- Example Commands
+-- These are simplified commands for demonstration purposes.
+-- In a real application, these would be defined in domain modules with
+-- proper EntityOf instances and command handlers.
+-- ============================================================================
+
+-- | Result of AI transcription integration.
+--
+-- Since onSuccess and onError must return the same command type,
+-- we use a sum type to represent all possible outcomes.
+data TranscriptionOutcome
+  = TranscriptionCompleted
+      { documentId :: Text
+      , transcribedText :: Text
+      , pageCount :: Maybe Int
+      }
+  | TranscriptionFailed
+      { documentId :: Text
+      , errorMessage :: Text
+      }
+  deriving (Generic, Show, Typeable)
+
+instance Json.ToJSON TranscriptionOutcome
+instance Json.FromJSON TranscriptionOutcome
+
+
+-- Type-level name instance required by Integration.ToAction
+type instance NameOf TranscriptionOutcome = "TranscriptionOutcome"
+
+
+-- ============================================================================
+-- Example Integrations (Jess's code)
+-- ============================================================================
+
+-- | Example: Full text extraction from a scanned PDF.
+--
+-- This shows the standard usage pattern:
+--
+-- * Extract all text faithfully (FullText mode, the default)
+-- * Use Gemini Pro 1.5 for multimodal understanding
+-- * Handle success and error cases
+--
+-- @
+-- documentIntegrations doc event = case event of
+--   PdfUploaded e -> Integration.batch
+--     [ fullTextTranscription doc.id e.fileRef ]
+--   _ -> Integration.none
+-- @
+fullTextTranscription ::
+  -- | Document ID
+  Text ->
+  -- | File reference from upload
+  FileRef ->
+  Integration.Action
+fullTextTranscription documentId fileRef =
+  Integration.outbound AiTranscribe.Request
+    { fileRef = fileRef
+    , model = "google/gemini-pro-1.5"
+    , config = AiTranscribe.defaultConfig
+    , onSuccess = \result ->
+        TranscriptionCompleted
+          { documentId = documentId
+          , transcribedText = result.text
+          , pageCount = result.pageCount
+          }
+    , onError = \err ->
+        TranscriptionFailed
+          { documentId = documentId
+          , errorMessage = err
+          }
+    }
+
+
+-- | Example: Summarize a long document.
+--
+-- This shows:
+--
+-- * Summary extraction mode
+-- * Language hint for non-English documents
+-- * Claude Vision for high-quality summarization
+--
+-- @
+-- reportIntegrations report event = case event of
+--   ReportUploaded e -> Integration.batch
+--     [ documentSummary report.id "es" e.fileRef ]
+--   _ -> Integration.none
+-- @
+documentSummary ::
+  -- | Document ID
+  Text ->
+  -- | Language hint (e.g., "es" for Spanish)
+  Text ->
+  -- | File reference from upload
+  FileRef ->
+  Integration.Action
+documentSummary documentId language fileRef =
+  Integration.outbound AiTranscribe.Request
+    { fileRef = fileRef
+    , model = "anthropic/claude-3.5-sonnet"
+    , config = AiTranscribe.defaultConfig
+        { AiTranscribe.extractionMode = AiTranscribe.Summary
+        , AiTranscribe.language = Just language
+        , AiTranscribe.maxPages = Just 50  -- Limit for very long documents
+        }
+    , onSuccess = \result ->
+        TranscriptionCompleted
+          { documentId = documentId
+          , transcribedText = result.text
+          , pageCount = result.pageCount
+          }
+    , onError = \err ->
+        TranscriptionFailed
+          { documentId = documentId
+          , errorMessage = err
+          }
+    }
+
+
+-- | Example: Extract structured data from an invoice.
+--
+-- This shows:
+--
+-- * Structured extraction mode (returns JSON)
+-- * Custom system prompt for domain-specific extraction
+-- * GPT-4V for structured understanding
+--
+-- @
+-- invoiceIntegrations invoice event = case event of
+--   InvoiceUploaded e -> Integration.batch
+--     [ structuredExtraction invoice.id e.fileRef ]
+--   _ -> Integration.none
+-- @
+structuredExtraction ::
+  -- | Document ID
+  Text ->
+  -- | File reference from upload
+  FileRef ->
+  Integration.Action
+structuredExtraction documentId fileRef =
+  Integration.outbound AiTranscribe.Request
+    { fileRef = fileRef
+    , model = "openai/gpt-4o"
+    , config = AiTranscribe.defaultConfig
+        { AiTranscribe.extractionMode = AiTranscribe.Structured
+        , AiTranscribe.systemPrompt = Just
+            "Extract invoice data as JSON with fields: invoice_number, date, vendor, line_items (array of {description, quantity, unit_price, total}), subtotal, tax, total."
+        , AiTranscribe.timeoutSeconds = 180  -- Longer for complex extraction
+        }
+    , onSuccess = \result ->
+        TranscriptionCompleted
+          { documentId = documentId
+          , transcribedText = result.text
+          , pageCount = result.pageCount
+          }
+    , onError = \err ->
+        TranscriptionFailed
+          { documentId = documentId
+          , errorMessage = err
+          }
+    }

--- a/testbed/src/Testbed/Examples/OpenRouterIntegration.hs
+++ b/testbed/src/Testbed/Examples/OpenRouterIntegration.hs
@@ -126,9 +126,12 @@ askAiWithConfig systemPrompt model question =
 handleSuccess :: OpenRouter.Response -> AiEvent
 handleSuccess response =
   case response.choices |> Array.first of
-    Just choice ->
+    Just choice -> do
+      let answerText = case choice.message.content of
+            Message.TextContent text -> text
+            Message.MultiContent _ -> ""
       AiAnswered
-        { answer = choice.message.content
+        { answer = answerText
         , model = response.model
         , tokensUsed = case response.usage of
             Just usage -> usage.totalTokens

--- a/testbed/src/Testbed/Examples/OpenRouterIntegration.hs
+++ b/testbed/src/Testbed/Examples/OpenRouterIntegration.hs
@@ -44,9 +44,11 @@ import Array qualified
 import Basics
 import Integration.Http qualified as Http
 import Integration.OpenRouter qualified as OpenRouter
+import Integration.OpenRouter.Message (Content (..), ContentPart (..))
 import Integration.OpenRouter.Message qualified as Message
 import Json qualified
 import Maybe (Maybe (..))
+import Text qualified
 import Text (Text)
 
 
@@ -128,8 +130,13 @@ handleSuccess response =
   case response.choices |> Array.first of
     Just choice -> do
       let answerText = case choice.message.content of
-            Message.TextContent text -> text
-            Message.MultiContent _ -> ""
+            TextContent text -> text
+            MultiContent parts ->
+              parts
+                |> Array.map (\part -> case part of
+                    TextPart text -> text
+                    ImageUrlPart _ -> "")
+                |> Text.concat
       AiAnswered
         { answer = answerText
         , model = response.model

--- a/testbed/src/Testbed/Examples/PdfExtraction.hs
+++ b/testbed/src/Testbed/Examples/PdfExtraction.hs
@@ -24,8 +24,8 @@
 --
 -- This module demonstrates the API design. The actual PDF extraction
 -- uses CLI tools (pdftotext, pdfinfo) from poppler-utils under the hood.
--- For scanned documents or complex layouts requiring AI, see the
--- AI-powered transcription integration (future #343).
+-- For scanned documents or complex layouts requiring AI, see
+-- "Testbed.Examples.AiTranscription" and "Integration.Ai.TranscribePdf".
 module Testbed.Examples.PdfExtraction
   ( -- * Example Integration Builders
     documentUploadIntegration

--- a/testbed/src/Testbed/Examples/PdfExtraction.hs
+++ b/testbed/src/Testbed/Examples/PdfExtraction.hs
@@ -143,13 +143,13 @@ documentUploadIntegration documentId fileRef =
     }
 
 
--- | Example: Extract specific pages for preview.
+-- | Example: Batch document extraction with page limits.
 --
 -- This shows:
 --
 -- * Page range selection (first 5 pages only)
 -- * Raw text mode (no layout preservation)
--- * Shorter timeout for quick previews
+-- * Shorter timeout for batch processing
 batchDocumentExtraction ::
   -- | Batch ID
   Text ->


### PR DESCRIPTION
## Summary

Implements #343 — AI-powered PDF transcription using multimodal models (Gemini, Claude Vision, GPT-4V) via OpenRouter.

- Adds `Integration.Ai.TranscribePdf` module following the two-persona model (ADR-0008, ADR-0023)
- Extends OpenRouter `Message.content` from `Text` to `Content` sum type for multimodal support
- Three extraction modes: FullText, Summary, Structured (JSON)
- 24 new tests (218 total, all pass), full project builds clean

## Changes

### New Files
- `integrations/Integration/Ai/TranscribePdf.hs` — Jess's API: `Request`, `Config`, `ExtractionMode`, `TranscriptionResult`, `defaultConfig`
- `integrations/Integration/Ai/TranscribePdf/Internal.hs` — Nick's API: `ToAction` instance with file retrieval, base64 encoding, prompt building, OpenRouter delegation
- `integrations/test/Integration/Ai/TranscribePdf/InternalSpec.hs` — Tests for prompt building, error conversion, JSON roundtrips, config defaults

### Modified Files
- `integrations/Integration/OpenRouter/Message.hs` — `Content` sum type (`TextContent | MultiContent`), `ContentPart`, `ImageUrl`, `userWithAttachment` constructor
- `integrations/Integration/OpenRouter.hs` — Re-exports new multimodal types
- `integrations/nhintegrations.cabal` — Register new modules
- `integrations/test/Integration/OpenRouter/MessageSpec.hs` — Tests for multimodal content
- `integrations/test/Integration/OpenRouter/ResponseSpec.hs` — Updated for `Content` type
- `testbed/src/Testbed/Examples/OpenRouterIntegration.hs` — Handle `Content` type in example
- `docs/decisions/0023-ai-pdf-transcription.md` — ADR with security/performance review

## Architecture

The integration follows the piggyback pattern: `TranscribePdf.Request` → builds `OpenRouter.Request` with multimodal content → delegates to OpenRouter's `ToAction` → which converts to `Http.Request` → executed by HTTP integration.

```
Jess: AiTranscribe.Request { fileRef, model, config, onSuccess, onError }
  → Nick: retrieveFile → base64 → buildPrompt → OpenRouter.Request
    → OpenRouter.Internal: toHttpRequest → Http.Request
      → Http.Internal: execute HTTP call
```

## v1 Limitations (documented)
- No streaming support
- No confidence scoring (always Nothing)
- No page-level extraction (whole document only)
- Entire PDF loaded into memory as base64

Closes #343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered PDF transcription with configurable extraction modes (full, summary, structured), language/page hints, timeouts, and multimodal (text+image) message support.

* **Documentation**
  * Added ADR and docs describing AI PDF transcription, integration guidance, requirements, and usage notes.

* **Tests & Examples**
  * New tests and example integrations demonstrating transcription workflows, multimodal messages, and sample builders for different extraction modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->