### PR TITLE
feat(syntax): port Comment.toHaskell to use Layout library

### DIFF
--- a/core/syntax/Syntax/Comment.hs
+++ b/core/syntax/Syntax/Comment.hs
@@ -18,7 +18,7 @@
 -- == Transpilation
 --
 -- @
--- comment |> Syntax.Comment.toHaskell
+-- comment |> Syntax.Comment.toHaskell |> Layout.render
 -- @
 --
 -- Produces valid Haskell comment syntax:
@@ -45,6 +45,8 @@ import Parser qualified
 import Text (Text)
 import Text qualified
 import Prelude qualified
+import Layout (Blueprint)
+import Layout qualified
 
 
 -- | A NeoHaskell source comment, captured with its content and source position.
@@ -234,32 +236,32 @@ comment =
 -- __Multi-line doc comments__: each content line becomes a separate @-- |@ line.
 --
 -- @
--- toHaskell (LineComment { content = "hello", ... })
+-- toHaskell (LineComment { content = "hello", ... }) |> Layout.render
 --   == "-- hello"
 --
--- toHaskell (BlockComment { content = " world ", depth = 1, ... })
+-- toHaskell (BlockComment { content = " world ", depth = 1, ... }) |> Layout.render
 --   == "{- world -}"
 --
--- toHaskell (DocComment { content = "Calculates distance.", ... })
+-- toHaskell (DocComment { content = "Calculates distance.", ... }) |> Layout.render
 --   == "-- | Calculates distance."
 -- @
-toHaskell :: Comment -> Text
+toHaskell :: Comment -> Blueprint annotation
 toHaskell commentNode =
   case commentNode of
     LineComment { content = capturedContent } ->
-      [fmt|-- #{capturedContent}|]
+      Layout.text [fmt|-- #{capturedContent}|]
     BlockComment { content = capturedContent } -> do
       let innerHaskell =
             capturedContent
               |> Text.replace "/*" "{-"
               |> Text.replace "*/" "-}"
-      [fmt|{-#{innerHaskell}-}|]
+      Layout.text [fmt|{-#{innerHaskell}-}|]
     DocComment { content = capturedContent } -> do
       let contentLines = capturedContent |> Text.lines
       case Array.length contentLines of
         0 ->
-          "-- |"
+          Layout.text "-- |"
         _ ->
           contentLines
-            |> Array.map (\line -> [fmt|-- | #{line}|])
-            |> Text.joinWith "\n"
+            |> Array.map (\docLine -> Layout.text [fmt|-- | #{docLine}|])
+            |> Layout.stack

--- a/core/test-core/Syntax/CommentSpec.hs
+++ b/core/test-core/Syntax/CommentSpec.hs
@@ -6,6 +6,7 @@ import Parser qualified
 import Result qualified
 import Syntax.Comment (Comment (..))
 import Syntax.Comment qualified
+import Layout qualified
 import Test
 
 
@@ -214,6 +215,7 @@ spec = do
               , content  = "hello"
               }
       Syntax.Comment.toHaskell commentNode
+        |> Layout.render
         |> shouldBe "-- hello"
 
     it "transpiles flat block comment to {- -}" \_ -> do
@@ -224,6 +226,7 @@ spec = do
               , depth    = 1
               }
       Syntax.Comment.toHaskell commentNode
+        |> Layout.render
         |> shouldBe "{- world -}"
 
     it "transpiles nested block comment with marker substitution" \_ -> do
@@ -234,6 +237,7 @@ spec = do
               , depth    = 2
               }
       Syntax.Comment.toHaskell commentNode
+        |> Layout.render
         |> shouldBe "{- outer {- inner -} outer -}"
 
     it "transpiles single-line doc comment to -- |" \_ -> do
@@ -243,6 +247,7 @@ spec = do
               , content  = "Calculates distance."
               }
       Syntax.Comment.toHaskell commentNode
+        |> Layout.render
         |> shouldBe "-- | Calculates distance."
 
     it "transpiles multi-line doc comment to multiple -- | lines" \_ -> do
@@ -252,4 +257,5 @@ spec = do
               , content  = "Line one.\nLine two."
               }
       Syntax.Comment.toHaskell commentNode
+        |> Layout.render
         |> shouldBe "-- | Line one.\n-- | Line two."


### PR DESCRIPTION
## Summary

Closes #562

Ports `Syntax.Comment.toHaskell` from returning raw `Text` to returning a `Blueprint annotation`, using the Layout library (#497). This aligns comment codegen with the structured approach the rest of the transpiler will use.

## Changes

- **`core/syntax/Syntax/Comment.hs`**: Changed `toHaskell :: Comment -> Text` → `toHaskell :: Comment -> Blueprint annotation`. Each comment variant now uses `Layout.text` for single-line output and `Layout.stack` for multi-line doc comments. Added `Layout` imports. Updated Haddock examples.
- **`core/test-core/Syntax/CommentSpec.hs`**: All 5 `toHaskell` tests now pipe through `Layout.render` before asserting. Added `import Layout qualified`.

## Checklist

- [x] Signature changed to `Comment -> Blueprint annotation`
- [x] Implementation uses `Layout.text`, `Layout.stack`
- [x] `import Layout (Blueprint)` and `import Layout qualified` added
- [x] Tests render Blueprint before asserting
- [x] `cabal build all` passes (227 modules)
- [x] `cabal test nhcore-test-core` passes (932 tests, 0 failures)
- [x] `hlint` clean on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured comment transpilation to use Layout-based rendering architecture, improving how comment output is composed and formatted across line, block, and documentation comment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->