### PR TITLE
feat(ide): add LSP server skeleton with stdio transport

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,4 @@ packages:
   core/*.cabal
   testbed/*.cabal
   integrations/nhintegrations.cabal
+  lsp/*.cabal

--- a/lsp/launcher/Main.hs
+++ b/lsp/launcher/Main.hs
@@ -1,0 +1,80 @@
+module Main (main) where
+
+import Prelude
+
+import System.Environment (getArgs)
+import System.Exit (ExitCode (..), exitSuccess, exitWith)
+import System.IO (hPutStrLn, stderr)
+
+import NeoHaskell.LSP.Server qualified as Server
+
+
+-- | NeoHaskell LSP server version.
+version :: String
+version = "0.1.0.0"
+
+
+-- | Entry point for the @neohaskell-lsp@ executable.
+--
+-- Accepted flags:
+--
+-- * @--stdio@ (default): communicate over stdin\/stdout
+-- * @--version@: print version and exit
+-- * @--log-level=debug|info|warn|error@: control log verbosity (placeholder)
+main :: IO ()
+main = do
+  args <- getArgs
+  case parseMode args of
+    PrintVersion -> do
+      hPutStrLn stderr ("neohaskell-lsp " <> version)
+      exitSuccess
+    RunStdio _logLevel -> do
+      exitCode <- Server.run
+      case exitCode of
+        0 -> exitSuccess
+        n -> exitWith (ExitFailure n)
+
+
+-- ---------------------------------------------------------------------------
+-- CLI argument parsing
+-- ---------------------------------------------------------------------------
+
+-- | Operating mode parsed from command-line arguments.
+data Mode
+  = RunStdio LogLevel
+  | PrintVersion
+
+-- | Log verbosity level.
+-- Currently accepted but not wired to the @lsp@ library's logger.
+data LogLevel
+  = Debug
+  | Info
+  | Warn
+  | Error
+  deriving (Show)
+
+
+-- | Parse command-line arguments into a 'Mode'.
+--
+-- Recognises @--version@, @--stdio@, and @--log-level=LEVEL@.
+-- Defaults to @RunStdio Info@ when no arguments are given.
+parseMode :: [String] -> Mode
+parseMode = go Info
+  where
+    go logLevel [] = RunStdio logLevel
+    go logLevel (arg : rest) =
+      case arg of
+        "--version" -> PrintVersion
+        "--stdio"   -> go logLevel rest
+        _
+          | Just lvl <- parseLogLevelFlag arg -> go lvl rest
+          | otherwise -> go logLevel rest  -- ignore unknown flags
+
+    parseLogLevelFlag :: String -> Maybe LogLevel
+    parseLogLevelFlag flag =
+      case flag of
+        "--log-level=debug" -> Just Debug
+        "--log-level=info"  -> Just Info
+        "--log-level=warn"  -> Just Warn
+        "--log-level=error" -> Just Error
+        _                   -> Nothing

--- a/lsp/neohaskell-lsp.cabal
+++ b/lsp/neohaskell-lsp.cabal
@@ -1,0 +1,91 @@
+cabal-version: 3.4
+name: neohaskell-lsp
+version: 0.1.0.0
+synopsis: NeoHaskell Language Server
+description:
+  Language Server Protocol implementation for NeoHaskell.
+  Provides IDE features (diagnostics, formatting, semantic tokens)
+  via stdio transport.
+homepage: https://neohaskell.org
+license: Apache-2.0
+author: NeoHaskell Contributors
+maintainer: nhlib@nickseagull.dev
+category: Development
+build-type: Simple
+
+common common_cfg
+  ghc-options:
+    -Wall
+    -Wno-orphans
+    -threaded
+    -fno-warn-partial-type-signatures
+    -fno-warn-name-shadowing
+    -Werror
+
+  default-extensions:
+    ApplicativeDo
+    BlockArguments
+    DataKinds
+    DeriveDataTypeable
+    DuplicateRecordFields
+    ImportQualifiedPost
+    ImpredicativeTypes
+    NamedFieldPuns
+    NoFieldSelectors
+    NoImplicitPrelude
+    OverloadedLabels
+    OverloadedLists
+    OverloadedRecordDot
+    OverloadedStrings
+    PackageImports
+    PartialTypeSignatures
+    QualifiedDo
+    QuasiQuotes
+    Strict
+    TemplateHaskell
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+
+  build-depends:
+    base
+
+library
+  import: common_cfg
+  exposed-modules:
+    NeoHaskell.LSP.Handlers
+    NeoHaskell.LSP.Server
+    NeoHaskell.LSP.State
+  build-depends:
+    aeson,
+    containers,
+    lsp >= 2.0 && < 3,
+    lsp-types >= 2.0 && < 3,
+    stm,
+    text
+  hs-source-dirs: src
+  default-language: GHC2021
+
+executable neohaskell-lsp
+  import: common_cfg
+  main-is: Main.hs
+  build-depends:
+    neohaskell-lsp
+  hs-source-dirs: launcher
+  default-language: GHC2021
+
+test-suite neohaskell-lsp-test
+  import: common_cfg
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  hs-source-dirs: test
+  other-modules:
+  build-depends:
+    containers,
+    hspec,
+    neohaskell-lsp,
+    stm
+  default-language: GHC2021
+  ghc-options:
+    -rtsopts
+    -with-rtsopts=-N

--- a/lsp/src/NeoHaskell/LSP/Handlers.hs
+++ b/lsp/src/NeoHaskell/LSP/Handlers.hs
@@ -1,0 +1,165 @@
+module NeoHaskell.LSP.Handlers
+  ( handlers
+  )
+where
+
+import Prelude
+
+import Control.Concurrent.STM (atomically, modifyTVar', writeTVar)
+import Control.Monad.IO.Class (liftIO)
+import Data.Map.Strict qualified as Map
+import Language.LSP.Protocol.Message qualified as Msg
+import Language.LSP.Protocol.Types qualified as LSP
+import Language.LSP.Server qualified as LSP
+import Language.LSP.VFS (virtualFileText)
+import System.IO (hPutStrLn, stderr)
+
+import NeoHaskell.LSP.State (ServerState (..))
+
+
+-- | All LSP handlers for the NeoHaskell language server.
+--
+-- Combines notification handlers (lifecycle events) with request handlers
+-- (formatting, semantic tokens) into a single 'LSP.Handlers' value.
+handlers :: ServerState -> LSP.Handlers (LSP.LspM ())
+handlers state = mconcat
+  [ initializedHandler state
+  , didOpenHandler state
+  , didChangeHandler state
+  , didSaveHandler state
+  , didCloseHandler state
+  , formattingHandler
+  , semanticTokensHandler
+  ]
+
+
+-- ---------------------------------------------------------------------------
+-- Notification handlers
+-- ---------------------------------------------------------------------------
+
+-- | Handle @initialized@ notification.
+--
+-- Reads the project root from the server environment and stores it
+-- in 'ServerState'. Logs the root path to stderr for debugging.
+initializedHandler :: ServerState -> LSP.Handlers (LSP.LspM ())
+initializedHandler state =
+  LSP.notificationHandler Msg.SMethod_Initialized \_ -> do
+    env <- LSP.getLspEnv
+    let root = LSP.resRootPath env
+    liftIO do
+      atomically (writeTVar state.projectRoot root)
+      case root of
+        Just path ->
+          hPutStrLn stderr ("[neohaskell-lsp] Initialized with root: " <> path)
+        Nothing ->
+          hPutStrLn stderr "[neohaskell-lsp] Initialized (no root path)"
+
+
+-- | Handle @textDocument/didOpen@ notification.
+--
+-- Stores the document content in the 'documents' TVar and publishes
+-- empty diagnostics (clearing any stale errors for this URI).
+didOpenHandler :: ServerState -> LSP.Handlers (LSP.LspM ())
+didOpenHandler state =
+  LSP.notificationHandler Msg.SMethod_TextDocumentDidOpen \msg -> do
+    let uri = msg._params._textDocument._uri
+        nuri = LSP.toNormalizedUri uri
+        content = msg._params._textDocument._text
+    liftIO (atomically (modifyTVar' state.documents (Map.insert nuri content)))
+    clearDiagnostics uri
+
+
+-- | Handle @textDocument/didChange@ notification.
+--
+-- Uses full document sync ('TextDocumentSyncKind_Full'): the client sends
+-- the entire file content on every change. We read the updated content from
+-- the VFS (which the @lsp@ library updates before calling our handler).
+didChangeHandler :: ServerState -> LSP.Handlers (LSP.LspM ())
+didChangeHandler state =
+  LSP.notificationHandler Msg.SMethod_TextDocumentDidChange \msg -> do
+    let uri = msg._params._textDocument._uri
+        nuri = LSP.toNormalizedUri uri
+    mfile <- LSP.getVirtualFile nuri
+    case mfile of
+      Just vf -> do
+        let content = virtualFileText vf
+        liftIO (atomically (modifyTVar' state.documents (Map.insert nuri content)))
+      Nothing ->
+        pure ()
+
+
+-- | Handle @textDocument/didSave@ notification.
+--
+-- With @includeText = True@ in our sync options, the save notification
+-- carries the full document text. We read from the VFS for consistency.
+didSaveHandler :: ServerState -> LSP.Handlers (LSP.LspM ())
+didSaveHandler state =
+  LSP.notificationHandler Msg.SMethod_TextDocumentDidSave \msg -> do
+    let uri = msg._params._textDocument._uri
+        nuri = LSP.toNormalizedUri uri
+    mfile <- LSP.getVirtualFile nuri
+    case mfile of
+      Just vf -> do
+        let content = virtualFileText vf
+        liftIO (atomically (modifyTVar' state.documents (Map.insert nuri content)))
+      Nothing ->
+        pure ()
+
+
+-- | Handle @textDocument/didClose@ notification.
+--
+-- Removes the document from our state and publishes empty diagnostics
+-- to clear any errors from the Problems panel. Per LSP spec, stale
+-- diagnostics persist until explicitly cleared.
+didCloseHandler :: ServerState -> LSP.Handlers (LSP.LspM ())
+didCloseHandler state =
+  LSP.notificationHandler Msg.SMethod_TextDocumentDidClose \msg -> do
+    let uri = msg._params._textDocument._uri
+        nuri = LSP.toNormalizedUri uri
+    liftIO (atomically (modifyTVar' state.documents (Map.delete nuri)))
+    clearDiagnostics uri
+
+
+-- ---------------------------------------------------------------------------
+-- Request handlers (stubs)
+-- ---------------------------------------------------------------------------
+
+-- | Handle @textDocument/formatting@ request.
+--
+-- Returns empty edits (no formatting changes). The capability is declared
+-- so the client knows the server supports it — actual formatting will be
+-- implemented when the transpiler is integrated (Phase 2).
+formattingHandler :: LSP.Handlers (LSP.LspM ())
+formattingHandler =
+  LSP.requestHandler Msg.SMethod_TextDocumentFormatting \_req responder -> do
+    responder (Right (LSP.InL []))
+
+
+-- | Handle @textDocument/semanticTokens/full@ request.
+--
+-- Returns null (no tokens). The capability is declared with a legend
+-- containing standard token types — actual token computation will be
+-- implemented when the transpiler is integrated (Phase 2).
+semanticTokensHandler :: LSP.Handlers (LSP.LspM ())
+semanticTokensHandler =
+  LSP.requestHandler Msg.SMethod_TextDocumentSemanticTokensFull \_req responder -> do
+    responder (Right (LSP.InR LSP.Null))
+
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+-- | Publish empty diagnostics for a URI, clearing any previously reported errors.
+--
+-- This is required by the LSP spec: if you published errors and the file
+-- becomes valid, you MUST send @publishDiagnostics@ with an empty list.
+-- The URI must exactly match what the client sent (no path normalization).
+clearDiagnostics :: LSP.Uri -> LSP.LspM () ()
+clearDiagnostics uri =
+  LSP.sendNotification Msg.SMethod_TextDocumentPublishDiagnostics
+    LSP.PublishDiagnosticsParams
+      { _uri = uri
+      , _version = Nothing
+      , _diagnostics = []
+      }

--- a/lsp/src/NeoHaskell/LSP/Server.hs
+++ b/lsp/src/NeoHaskell/LSP/Server.hs
@@ -1,0 +1,59 @@
+module NeoHaskell.LSP.Server
+  ( -- * Running the server
+    run
+  )
+where
+
+import Prelude
+
+import Control.Monad.IO.Class (liftIO)
+import Language.LSP.Protocol.Types qualified as LSP
+import Language.LSP.Server qualified as LSP
+
+import NeoHaskell.LSP.Handlers (handlers)
+import NeoHaskell.LSP.State (initState)
+
+
+-- | Run the NeoHaskell LSP server over stdio.
+--
+-- Creates initial server state, then enters the @lsp@ library's main loop.
+-- Returns an exit code (0 = success).
+--
+-- The server advertises:
+--
+-- * Full document sync (client sends entire file on every change)
+-- * Document formatting (stub — returns empty edits)
+-- * Semantic tokens (stub — returns null)
+--
+-- Position encoding defaults to UTF-16 (LSP standard). UTF-32 negotiation
+-- will be added in a future phase.
+run :: IO Int
+run = do
+  state <- initState
+  LSP.runServer LSP.ServerDefinition
+    { LSP.defaultConfig = ()
+    , LSP.configSection = "neohaskell"
+    , LSP.parseConfig = \_ _ -> Right ()
+    , LSP.onConfigChange = \_ -> pure ()
+    , LSP.doInitialize = \env _req -> pure (Right env)
+    , LSP.staticHandlers = \_ -> handlers state
+    , LSP.interpretHandler = \env -> LSP.Iso (LSP.runLspT env) liftIO
+    , LSP.options = serverOptions
+    }
+
+
+-- | Server options defining LSP capabilities.
+--
+-- Sets full document sync with open\/close\/save notifications and
+-- @includeText@ on save. Other capabilities (formatting, semantic tokens)
+-- are inferred by the @lsp@ library from registered handlers.
+serverOptions :: LSP.Options
+serverOptions = LSP.defaultOptions
+  { LSP.optTextDocumentSync = Just LSP.TextDocumentSyncOptions
+      { _openClose = Just True
+      , _change = Just LSP.TextDocumentSyncKind_Full
+      , _willSave = Nothing
+      , _willSaveWaitUntil = Nothing
+      , _save = Just (LSP.InR LSP.SaveOptions { _includeText = Just True })
+      }
+  }

--- a/lsp/src/NeoHaskell/LSP/State.hs
+++ b/lsp/src/NeoHaskell/LSP/State.hs
@@ -1,0 +1,51 @@
+module NeoHaskell.LSP.State
+  ( -- * Types
+    ServerState (..)
+  , TranspileResult (..)
+    -- * Construction
+  , initState
+  )
+where
+
+import Prelude
+
+import Control.Concurrent.STM (TVar, newTVarIO)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Language.LSP.Protocol.Types qualified as LSP
+
+
+-- | Placeholder for future transpilation results.
+-- Will hold AST, errors, and other transpiler output in Phase 2A.
+data TranspileResult = TranspileResult
+  deriving (Show, Eq)
+
+
+-- | Shared mutable state for the LSP server.
+--
+-- All fields use 'TVar' for thread-safe access. Currently single-threaded
+-- (the @lsp@ library runs handlers on one thread), but this prepares for
+-- Phase 2A where a background thread runs the transpiler on a debounce timer.
+data ServerState = ServerState
+  { documents :: TVar (Map LSP.NormalizedUri Text)
+  -- ^ Currently open document contents, keyed by normalized URI.
+  , lastGoodTranspilation :: TVar (Map LSP.NormalizedUri TranspileResult)
+  -- ^ Last successful transpilation result per document.
+  -- Used to provide stale-but-valid results while re-transpiling.
+  , projectRoot :: TVar (Maybe FilePath)
+  -- ^ Project root path, set during initialization from the client's @rootUri@.
+  }
+
+
+-- | Create a fresh 'ServerState' with empty maps and no project root.
+initState :: IO ServerState
+initState = do
+  docs <- newTVarIO Map.empty
+  transpiled <- newTVarIO Map.empty
+  root <- newTVarIO Nothing
+  pure ServerState
+    { documents = docs
+    , lastGoodTranspilation = transpiled
+    , projectRoot = root
+    }

--- a/lsp/test/Main.hs
+++ b/lsp/test/Main.hs
@@ -1,0 +1,29 @@
+module Main (main) where
+
+import Prelude
+
+import Control.Concurrent.STM (atomically, readTVar)
+import Data.Map.Strict qualified as Map
+import Test.Hspec
+
+import NeoHaskell.LSP.State (ServerState (..), initState)
+
+
+main :: IO ()
+main = hspec do
+  describe "NeoHaskell.LSP.State" do
+    describe "initState" do
+      it "creates state with empty documents" \_ -> do
+        state <- initState
+        docs <- atomically (readTVar state.documents)
+        docs `shouldBe` Map.empty
+
+      it "creates state with no project root" \_ -> do
+        state <- initState
+        root <- atomically (readTVar state.projectRoot)
+        root `shouldBe` Nothing
+
+      it "creates state with empty transpilation cache" \_ -> do
+        state <- initState
+        cache <- atomically (readTVar state.lastGoodTranspilation)
+        cache `shouldBe` Map.empty


### PR DESCRIPTION
## Summary

Closes #487 — Implements the Phase 1B LSP Server Skeleton.

- Adds `lsp/` package (placed here instead of `editor/vscode/server/` per maintainer request) with a working LSP binary that speaks stdio
- Handles full document lifecycle: `didOpen`, `didChange`, `didSave`, `didClose` — storing contents in TVars for future transpiler integration
- Stubs `textDocument/formatting` (empty edits) and `textDocument/semanticTokens/full` (null) so the server doesn't crash on any standard request
- CLI accepts `--stdio` (default), `--version`, and `--log-level=debug|info|warn|error`

## What's included

| File | Purpose |
|------|---------|
| `lsp/neohaskell-lsp.cabal` | Package definition matching monorepo conventions |
| `lsp/src/NeoHaskell/LSP/State.hs` | `ServerState` with TVars for documents, transpilation cache, project root |
| `lsp/src/NeoHaskell/LSP/Handlers.hs` | All notification + request handlers |
| `lsp/src/NeoHaskell/LSP/Server.hs` | `ServerDefinition`, full doc sync, server options |
| `lsp/launcher/Main.hs` | CLI entry point with arg parsing |
| `lsp/test/Main.hs` | 3 tests verifying State initialization |
| `cabal.project` | Updated to include `lsp/*.cabal` |

## Verification

- Compiles clean with `-Werror` on GHC 9.8.4
- `hlint lsp/` → no hints
- `cabal test neohaskell-lsp-test` → 3/3 pass
- `cabal run neohaskell-lsp -- --version` → prints version and exits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces NeoHaskell Language Server Protocol (LSP) server with standard input/output support
  * Adds command-line interface with `--version` and `--log-level` configuration options
  * Implements document lifecycle management (open, change, save, close) for source files
  * Includes formatting and semantic token support

* **Tests**
  * Adds test suite for server state initialization and management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->