### PR TITLE
fix(service): add command name and event types to CommandExecutor logs

### DIFF
--- a/core/service/Service/CommandExecutor/Core.hs
+++ b/core/service/Service/CommandExecutor/Core.hs
@@ -6,24 +6,30 @@ module Service.CommandExecutor.Core (
   execute,
 ) where
 
+import Array (Array)
 import Array qualified
 import AsyncTask qualified
 import Basics
 import Decider (CommandResult (..), DecisionContext (..), runDecision)
 import Float qualified
+import GHC.TypeLits qualified as GHC
 import Int qualified
 import Json qualified
 import Log qualified
 import Maybe (Maybe (..))
+import Maybe qualified
+import Record qualified
 import Result (Result (..))
 import Service.Auth (RequestContext)
 import Service.Command (Event (..))
-import Service.Command.Core (Command (..), Entity (..), EntityOf, EventOf)
+import Service.Command.Core (Command (..), Entity (..), EntityOf, EventOf, NameOf)
 import Service.EntityFetcher.Core (EntityFetchResult (..), EntityFetcher, FetchedEntity (..))
 import Service.EntityFetcher.Core qualified
 import Service.Event (EntityName, InsertionPayload (..), InsertionType (..))
 import Service.Event qualified as Event
+import Service.Event.EntityName qualified as EntityName
 import Service.Event.StreamId (StreamId, ToStreamId (..))
+import Service.Event.StreamId qualified as StreamId
 import Service.EventStore.Core (EventStore)
 import Service.EventStore.Core qualified as EventStore
 import Task (Task)
@@ -83,6 +89,17 @@ awaitWithJitter retryCount = do
   AsyncTask.sleep jitteredDelay
 
 
+-- | Extract constructor names from a list of events for logging.
+--
+-- Uses 'Show' to get the textual representation and takes the first word,
+-- which is the constructor name (e.g., @"CartCreated"@ from @"CartCreated {..}"@).
+extractEventNames :: forall event. (Show event) => Array event -> Text
+extractEventNames events =
+  events
+    |> Array.map (\event -> toText event |> Text.words |> Array.first |> Maybe.withDefault "Unknown")
+    |> Text.joinWith ", "
+
+
 -- | Execute a command through the event-sourcing pipeline.
 --
 -- This function:
@@ -102,6 +119,8 @@ execute ::
     ToStreamId (EntityIdType commandEntity),
     Eq (EntityIdType commandEntity),
     Show (EntityIdType commandEntity),
+    Show commandEvent,
+    GHC.KnownSymbol (NameOf command),
     IsMultiTenant command ~ 'False
   ) =>
   EventStore commandEvent ->
@@ -143,11 +162,13 @@ execute eventStore entityFetcher entityName requestContext command = do
 
   let maxRetries = 10
 
+  let commandNameText = GHC.symbolVal (Record.Proxy @(NameOf command)) |> Text.fromLinkedList
+
   let retryLoop retryCount currentEntity currentStreamId = do
         let streamIdText = case currentStreamId of
-              Just sid -> toText sid
+              Just sid -> StreamId.toText sid
               Nothing -> "new-stream"
-        Log.withScope [("component", "CommandExecutor"), ("streamId", streamIdText), ("entityName", toText entityName)] do
+        Log.withScope [("component", "CommandExecutor"), ("streamId", streamIdText), ("entityName", EntityName.toText entityName), ("commandName", commandNameText)] do
           case retryCount of
             0 -> Log.info "Executing command" |> Task.ignoreError
             _ -> Log.debug [fmt|Retrying command (attempt #{retryCount})|] |> Task.ignoreError
@@ -227,7 +248,9 @@ execute eventStore entityFetcher entityName requestContext command = do
                   case insertResult of
                     Ok _success -> do
                       let eventsCount = Array.length events
-                      Log.info [fmt|Command executed successfully, #{toText eventsCount} event(s) inserted|] |> Task.ignoreError
+                      let eventNames = extractEventNames events
+                      Log.withScope [("eventsEmitted", eventNames)] do
+                        Log.info [fmt|Command executed successfully, #{toText eventsCount} event(s) inserted|] |> Task.ignoreError
                       Task.yield
                         CommandAccepted
                           { streamId = finalStreamId,

--- a/core/service/Service/ServiceDefinition/Core.hs
+++ b/core/service/Service/ServiceDefinition/Core.hs
@@ -177,6 +177,7 @@ instance
     Eq entityIdType,
     Ord entityIdType,
     Show entityIdType,
+    Show event,
     Json.FromJSON cmd,
     Schema.ToSchema cmd,
     BuildHandlersForTransports transports,

--- a/core/testlib/Test/Service/Command/Core.hs
+++ b/core/testlib/Test/Service/Command/Core.hs
@@ -168,6 +168,9 @@ addOrUpdateItem items itemId amount = do
 type instance EntityOf AddItemToCart = CartEntity
 
 
+type instance NameOf AddItemToCart = "AddItemToCart"
+
+
 instance Command AddItemToCart where
   getEntityIdImpl cmd = cmd.cartId |> Just
 
@@ -188,6 +191,9 @@ instance Command AddItemToCart where
 
 
 type instance EntityOf RemoveItemFromCart = CartEntity
+
+
+type instance NameOf RemoveItemFromCart = "RemoveItemFromCart"
 
 
 instance Command RemoveItemFromCart where
@@ -213,6 +219,9 @@ instance Command RemoveItemFromCart where
 
 
 type instance EntityOf CheckoutCart = CartEntity
+
+
+type instance NameOf CheckoutCart = "CheckoutCart"
 
 
 instance Command CheckoutCart where
@@ -257,6 +266,9 @@ instance Json.FromJSON AuthenticatedAddItem
 
 
 type instance EntityOf AuthenticatedAddItem = CartEntity
+
+
+type instance NameOf AuthenticatedAddItem = "AuthenticatedAddItem"
 
 
 instance Command AuthenticatedAddItem where
@@ -388,6 +400,9 @@ instance Json.FromJSON OwnedCartCheckout
 
 
 type instance EntityOf OwnedCartCheckout = OwnedCartEntity
+
+
+type instance NameOf OwnedCartCheckout = "OwnedCartCheckout"
 
 
 instance Command OwnedCartCheckout where

--- a/testbed/src/Testbed/Cart/Core.hs
+++ b/testbed/src/Testbed/Cart/Core.hs
@@ -69,7 +69,7 @@ data CartEvent
         stockId :: Uuid,
         quantity :: Int
       }
-  deriving (Generic)
+  deriving (Eq, Show, Ord, Generic)
 
 
 getEventEntityId :: CartEvent -> Uuid

--- a/testbed/src/Testbed/Document/Core.hs
+++ b/testbed/src/Testbed/Document/Core.hs
@@ -51,7 +51,7 @@ data DocumentEvent
       , attachmentRef :: FileRef
       , createdAt :: Int64
       }
-  deriving (Generic)
+  deriving (Eq, Show, Ord, Generic)
 
 
 getEventEntityId :: DocumentEvent -> Uuid

--- a/testbed/src/Testbed/Stock/Core.hs
+++ b/testbed/src/Testbed/Stock/Core.hs
@@ -54,7 +54,7 @@ data StockEvent
       , quantity :: Int
       , cartId :: Uuid
       }
-  deriving (Generic)
+  deriving (Eq, Show, Ord, Generic)
 
 
 getEventEntityId :: StockEvent -> Uuid


### PR DESCRIPTION
## Summary

- Add `commandName` and `eventsEmitted` fields to CommandExecutor structured log output
- Strip newtype wrappers from `EntityName` and `StreamId` for cleaner log values
- Closes #424

## Changes

### CommandExecutor logs now include:

**Before:**
```json
{"component":"CommandExecutor","entityName":"EntityName \"UsuarioEntity\"","streamId":"StreamId \"9cf39f6e-...\"","message":"Executing command"}
```

**After:**
```json
{"component":"CommandExecutor","entityName":"UsuarioEntity","commandName":"SubirModeloAutonomo","streamId":"9cf39f6e-...","message":"Executing command"}
{"component":"CommandExecutor","entityName":"UsuarioEntity","commandName":"SubirModeloAutonomo","streamId":"9cf39f6e-...","eventsEmitted":"ModeloAutonomoSubido","message":"Command executed successfully, 1 event(s) inserted"}
```

### Files changed

| File | Change |
|------|--------|
| `core/service/Service/CommandExecutor/Core.hs` | Add `commandName` to log scope, `eventsEmitted` to success log, use unwrapped `EntityName.toText`/`StreamId.toText`, add `extractEventNames` helper |
| `core/service/Service/ServiceDefinition/Core.hs` | Add `Show event` constraint to `CommandInspect` instance |
| `core/testlib/Test/Service/Command/Core.hs` | Add `NameOf` type instances for 5 manually-defined test commands |
| `testbed/src/Testbed/{Cart,Stock,Document}/Core.hs` | Add `Show`/`Eq`/`Ord` derives to event types |

### New constraints on `execute`

- `Show commandEvent` — needed to extract event constructor names for `eventsEmitted`
- `GHC.KnownSymbol (NameOf command)` — needed to extract command name from `NameOf` type family

Both constraints are already satisfied at all existing call sites (events derive `Show` via Generic, commands get `NameOf` via TH macro).

## Checklist

- [x] `cabal build all` passes
- [x] `cabal test nhcore-test-core` passes (978 examples, 0 failures)
- [x] `hlint` clean on all changed files
- [x] Follows NeoHaskell style guide (pipes, qualified imports, do-blocks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced command execution logging to display emitted event names and diagnostic information during command processing and retry scenarios.
  * Extended event type infrastructure with comparison and representation capabilities for Cart, Document, and Stock events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->