### PR TITLE
feat(service): add toVariant reverse extraction to EventVariantOf

### DIFF
--- a/core/service/EventVariantOf.hs
+++ b/core/service/EventVariantOf.hs
@@ -8,12 +8,16 @@ module EventVariantOf
   , event
   ) where
 
+import Maybe (Maybe (..))
 
--- | Declares that @eventVariant@ can be converted into @event@.
+
+-- | Declares that @eventVariant@ can be converted to/from @event@.
 --
 -- This typeclass enables individual event types to be wrapped into
--- an entity's event ADT. The Decider smart constructors use this
--- constraint to accept variant types directly.
+-- an entity's event ADT ('fromVariant') and extracted back out
+-- ('toVariant'). The Decider smart constructors use 'fromVariant'
+-- to accept variant types directly. The OutboundIntegration dispatch
+-- uses 'toVariant' to extract specific variants for typed handlers.
 --
 -- The identity instance @EventVariantOf event event@ is provided,
 -- so existing code that passes the event ADT directly continues to work.
@@ -29,16 +33,27 @@ module EventVariantOf
 -- -- Identity instance (provided by default — every ADT is a variant of itself)
 -- instance EventVariantOf CartEvent CartEvent where
 --   fromVariant cartEvent = cartEvent
+--   toVariant cartEvent = Just cartEvent
 --
 -- -- Standalone event type with explicit instance
 -- data PdfUploaded = PdfUploaded { entityId :: Uuid, pdfRef :: Text }
 --
 -- instance EventVariantOf DocumentEvent PdfUploaded where
 --   fromVariant uploaded = DocumentPdfUploaded uploaded.entityId uploaded.pdfRef
+--   toVariant docEvent = case docEvent of
+--     DocumentPdfUploaded eid ref -> Just (PdfUploaded { entityId = eid, pdfRef = ref })
+--     _ -> Nothing
 -- @
 class EventVariantOf event eventVariant where
   -- | Convert an event variant into the parent event ADT.
   fromVariant :: eventVariant -> event
+
+  -- | Extract a specific event variant from the parent event ADT.
+  --
+  -- Returns 'Just' if the event matches this variant, 'Nothing' otherwise.
+  -- Used by OutboundIntegration dispatch to route decoded events to
+  -- typed handlers.
+  toVariant :: event -> Maybe eventVariant
 
 
 -- | Every event type is a variant of itself.
@@ -49,10 +64,15 @@ class EventVariantOf event eventVariant where
 -- @
 -- -- This still works (CartEvent is a variant of CartEvent):
 -- Decider.acceptExisting [ItemAdded { entityId = id, stockId = sid, quantity = 1 }]
+--
+-- -- And toVariant always succeeds for identity:
+-- toVariant (ItemAdded { entityId = id, stockId = sid, quantity = 1 }) == Just (ItemAdded ...)
 -- @
-instance EventVariantOf event event where
+instance {-# OVERLAPPABLE #-} EventVariantOf event event where
   fromVariant eventValue = eventValue
   {-# INLINE fromVariant #-}
+  toVariant eventValue = Just eventValue
+  {-# INLINE toVariant #-}
 
 
 -- | Wrap an event variant into the parent event ADT.

--- a/core/test/EventVariantOfSpec.hs
+++ b/core/test/EventVariantOfSpec.hs
@@ -33,6 +33,11 @@ data StandaloneCreated = StandaloneCreated
 -- | EventVariantOf instance bridging StandaloneCreated to TestEvent.
 instance EventVariantOf TestEvent StandaloneCreated where
   fromVariant created = TestEventA { testId = created.standaloneId }
+  toVariant testEvent =
+    case testEvent of
+      TestEventA { testId = tid } ->
+        Just (StandaloneCreated { standaloneId = tid })
+      _ -> Nothing
 
 
 -- | Second standalone event type that maps to TestEventB.
@@ -45,6 +50,11 @@ data StandaloneLabeled = StandaloneLabeled
 -- | EventVariantOf instance bridging StandaloneLabeled to TestEvent.
 instance EventVariantOf TestEvent StandaloneLabeled where
   fromVariant labeled = TestEventB { testLabel = labeled.label }
+  toVariant testEvent =
+    case testEvent of
+      TestEventB { testLabel = lbl } ->
+        Just (StandaloneLabeled { label = lbl })
+      _ -> Nothing
 
 
 -- ============================================================
@@ -230,3 +240,101 @@ spec = do
             second |> shouldBe (Just (TestEventA { testId = 6 }))
           _ ->
             fail "Expected Accept constructor"
+
+    describe "toVariant" do
+
+      describe "identity instance" do
+        -- Test 20: happy — identity toVariant returns Just
+        it "toVariant returns Just for identity instance" \_ -> do
+          let original = TestEventA { testId = 42 }
+          let result = toVariant original :: Maybe TestEvent
+          result |> shouldBe (Just (TestEventA { testId = 42 }))
+
+        -- Test 21: happy — identity toVariant with second constructor
+        it "toVariant returns Just for second constructor" \_ -> do
+          let original = TestEventB { testLabel = "hello" }
+          let result = toVariant original :: Maybe TestEvent
+          result |> shouldBe (Just (TestEventB { testLabel = "hello" }))
+
+        -- Test 22: edge — identity toVariant with zero boundary
+        it "toVariant preserves zero boundary value" \_ -> do
+          let original = TestEventA { testId = 0 }
+          let result = toVariant original :: Maybe TestEvent
+          result |> shouldBe (Just (TestEventA { testId = 0 }))
+
+        -- Test 23: edge — identity toVariant with empty text
+        it "toVariant preserves empty text" \_ -> do
+          let original = TestEventB { testLabel = "" }
+          let result = toVariant original :: Maybe TestEvent
+          result |> shouldBe (Just (TestEventB { testLabel = "" }))
+
+      describe "custom variant extraction" do
+        -- Test 24: happy — extract matching variant
+        it "toVariant extracts StandaloneCreated from matching TestEventA" \_ -> do
+          let adtEvent = TestEventA { testId = 99 }
+          let result = toVariant adtEvent :: Maybe StandaloneCreated
+          result |> shouldBe (Just (StandaloneCreated { standaloneId = 99 }))
+
+        -- Test 25: happy — extract second matching variant
+        it "toVariant extracts StandaloneLabeled from matching TestEventB" \_ -> do
+          let adtEvent = TestEventB { testLabel = "world" }
+          let result = toVariant adtEvent :: Maybe StandaloneLabeled
+          result |> shouldBe (Just (StandaloneLabeled { label = "world" }))
+
+        -- Test 26: happy — non-matching constructor returns Nothing
+        it "toVariant returns Nothing for non-matching constructor (Created vs EventB)" \_ -> do
+          let adtEvent = TestEventB { testLabel = "wrong" }
+          let result = toVariant adtEvent :: Maybe StandaloneCreated
+          result |> shouldBe Nothing
+
+        -- Test 27: happy — non-matching constructor returns Nothing (reverse)
+        it "toVariant returns Nothing for non-matching constructor (Labeled vs EventA)" \_ -> do
+          let adtEvent = TestEventA { testId = 1 }
+          let result = toVariant adtEvent :: Maybe StandaloneLabeled
+          result |> shouldBe Nothing
+
+        -- Test 28: edge — extract with zero value
+        it "toVariant extracts variant with zero value" \_ -> do
+          let adtEvent = TestEventA { testId = 0 }
+          let result = toVariant adtEvent :: Maybe StandaloneCreated
+          result |> shouldBe (Just (StandaloneCreated { standaloneId = 0 }))
+
+        -- Test 29: edge — extract with negative value
+        it "toVariant extracts variant with negative value" \_ -> do
+          let adtEvent = TestEventA { testId = -1 }
+          let result = toVariant adtEvent :: Maybe StandaloneCreated
+          result |> shouldBe (Just (StandaloneCreated { standaloneId = -1 }))
+
+        -- Test 30: edge — extract with empty text
+        it "toVariant extracts variant with empty text" \_ -> do
+          let adtEvent = TestEventB { testLabel = "" }
+          let result = toVariant adtEvent :: Maybe StandaloneLabeled
+          result |> shouldBe (Just (StandaloneLabeled { label = "" }))
+
+      describe "round-trip (fromVariant . toVariant)" do
+        -- Test 31: happy — round-trip StandaloneCreated
+        it "fromVariant after toVariant round-trips StandaloneCreated" \_ -> do
+          let original = StandaloneCreated { standaloneId = 77 }
+          let adtEvent = fromVariant original :: TestEvent
+          let roundTripped = toVariant adtEvent :: Maybe StandaloneCreated
+          roundTripped |> shouldBe (Just original)
+
+        -- Test 32: happy — round-trip StandaloneLabeled
+        it "fromVariant after toVariant round-trips StandaloneLabeled" \_ -> do
+          let original = StandaloneLabeled { label = "round-trip" }
+          let adtEvent = fromVariant original :: TestEvent
+          let roundTripped = toVariant adtEvent :: Maybe StandaloneLabeled
+          roundTripped |> shouldBe (Just original)
+
+        -- Test 33: edge — round-trip with empty text
+        it "round-trip preserves empty text" \_ -> do
+          let original = StandaloneLabeled { label = "" }
+          let adtEvent = fromVariant original :: TestEvent
+          let roundTripped = toVariant adtEvent :: Maybe StandaloneLabeled
+          roundTripped |> shouldBe (Just original)
+
+        -- Test 34: edge — round-trip identity
+        it "round-trip works for identity instance" \_ -> do
+          let original = TestEventA { testId = 42 }
+          let roundTripped = toVariant (fromVariant original :: TestEvent) :: Maybe TestEvent
+          roundTripped |> shouldBe (Just original)


### PR DESCRIPTION
## Summary

Extends the `EventVariantOf` typeclass with a `toVariant :: event -> Maybe eventVariant` method — the reverse direction of the existing `fromVariant`. This enables extraction of specific event variants from the parent ADT, which is required by OutboundIntegration dispatch (#576) to route decoded events to typed handlers.

## Changes

- **`core/service/EventVariantOf.hs`**: Added `toVariant` method to the `EventVariantOf` class. Updated identity instance with `{-# OVERLAPPABLE #-}` pragma and `toVariant = Just`. Updated haddock documentation with `toVariant` examples.
- **`core/test/EventVariantOfSpec.hs`**: Added `toVariant` implementations to both custom test instances (`StandaloneCreated`, `StandaloneLabeled`). Added 15 new tests covering identity extraction, custom variant extraction (match + mismatch), boundary values (zero, negative, empty text), and `fromVariant`/`toVariant` round-trips.

## Checklist

- [x] Tests written (outside-in TDD)
- [x] `cabal build all` passes
- [x] `cabal test nhcore-test-core` passes (1016 examples, 0 failures)
- [x] `hlint` clean on changed files

Closes #587
Blocks #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bidirectional event conversion capability, enabling events to be converted to and from typed variants with optional matching semantics.

* **Tests**
  * Added comprehensive test coverage for bidirectional event conversion including round-trip validation and pattern-matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->