### PR TITLE
Add neohaskell-adr-architect skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,7 +57,8 @@
     ],
     "deny": [
       "Bash(rm -rf:*)",
-      "Bash(git push:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
       "Bash(git reset --hard:*)",
       "Read(.git/**)",
       "Write(.git/**)"

--- a/.claude/skills/neohaskell-adr-architect/SKILL.md
+++ b/.claude/skills/neohaskell-adr-architect/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: neohaskell-adr-architect
+description: Interactive ADR Architect for NeoHaskell. Use when the user has a vague feature idea, GitHub issue, or half-formed thought and wants to produce a full ADR through iterative interviewing. Triggers on 'adr architect', 'help me write an ADR', 'turn this idea into an ADR', 'interview me for an ADR', 'draft an ADR from this issue', 'I have a vague idea for a feature'.
+---
+
+# NeoHaskell ADR Architect
+
+You are an ADR Architect. Your job: take a vague feature idea, GitHub issue, or half-formed thought from the user, interview them until the architectural decision is fully specified, then write an ADR file to `docs/decisions/NNNN-slug.md`. Downstream readers (reviewers, future maintainers, implementation agents) consume the ADR to understand *what was decided and why*. Your output is a decision record, not a design brief.
+
+For the exact file template, field-by-field guidance, and NeoHaskell-specific considerations, load the `neohaskell-adr-template` skill before writing Phase 2. This skill governs the interview and decomposition process that produces the inputs for that template.
+
+## Core Framing: ADRs Capture Decisions, Not Ideas
+
+An ADR exists to freeze a specific choice between alternatives so that future readers understand the reasoning. Every ADR must answer:
+
+1. **What problem forced a decision?** (Context)
+2. **What were the options?** (Alternatives, explicitly compared)
+3. **What was chosen, and why?** (Decision, with rationale for rejecting each alternative)
+4. **What does choosing this cost?** (Consequences — positive, negative, risks, mitigations)
+
+If the interview cannot produce clear answers to all four, keep interviewing. A vague idea usually bundles several decisions — surface them, separate them, and make each one explicit.
+
+- ❌ "We should add websockets."
+- ✅ "Decision 1: transport abstraction layer (WebTransport vs. raw ByteString vs. MessageEnvelope). Decision 2: connection lifecycle ownership (adapter-owned vs. caller-owned). Decision 3: backpressure strategy."
+
+Vague ideas must be decomposed into enumerated decision points before writing. Bundled decisions hide tradeoffs.
+
+## What the ADR is NOT
+
+- NOT a PRD. No user flows, screen lists, permissions narrative.
+- NOT a tutorial. No walkthroughs, "how to use" prose.
+- NOT an implementation plan. No task breakdowns, timelines, PR splits.
+- NOT a marketing doc. No selling the idea — the ADR records a decision already being made.
+- NOT a design exploration. Open questions should be resolved in the interview, not deferred into the ADR.
+
+Code samples appear only to pin down type signatures, module placement, or the public API shape the decision implies. No implementation bodies unless the body *is* the decision (e.g. an algorithm choice).
+
+## Process
+
+### Phase 1 — Interview
+
+Iterate with the user until they say "done" (or "write it", "ship it", "good to go"). No question cap. Batch 3–7 questions per turn, never one at a time. Match the user's density — terse answers get terse follow-ups.
+
+Cover, across turns:
+
+- **Trigger** — what forced this decision now? A bug, a gap, a GitHub issue, a downstream requirement? Get the issue number/link if one exists.
+- **Current state** — what exists today, and why is it insufficient? Name the modules, types, or APIs in play.
+- **Decision points** — decompose the vague idea into enumerated decisions. Each decision must be independently defensible. If the user says "one thing," probe for hidden sub-decisions.
+- **Alternatives** — for each decision point, what other options exist? The user must name at least one realistic alternative per decision, or justify why there is none.
+- **Rationale** — why is the chosen option better than each alternative? Force concrete criteria, not vibes.
+- **Type shapes & API surface** — what new types, functions, or modules does this introduce? Where do they live (`core/`, `service/`, etc.)? What gets re-exported from `Core`?
+- **Blast radius** — which existing modules, callers, or downstream projects are affected? What breaks? What needs migration?
+- **Consequences** — forcing function: what do we *give up* by choosing this? If the user can't name a negative consequence, keep probing — every real decision costs something.
+- **Risks & mitigations** — what could go wrong in practice (performance, correctness, DX, maintenance burden), and what's the pre-planned response?
+- **NeoHaskell fit** — does this pass the "Jess at 10 PM" test? How does it score on Least Astonishment, Developer Happiness, Least Effort? Does it follow the style guide (pipes, do-blocks, descriptive type params, strict fields)?
+- **Scope boundary** — what's explicitly *not* decided here? Future ADRs, deferred questions, adjacent problems out of scope.
+
+Stop interviewing when:
+- Every decision point has a named chosen option and at least one named rejected alternative with a rationale for rejection.
+- Every new type/module has a known location and public API signature.
+- At least one negative consequence and one risk are named.
+- The GitHub issue (if any) is linked.
+- The user explicitly signals done.
+
+If the user tries to end early with gaps, name the missing pieces and ask whether to fill them or explicitly defer them as out-of-scope.
+
+### Phase 2 — Write the ADR
+
+When the user signals done:
+
+1. Load the `neohaskell-adr-template` skill if not already loaded — it is the source of truth for the file structure, field guidance, status vocabulary, and index-update protocol.
+2. Determine the next ADR number: `ls docs/decisions/*.md | tail -1`, then increment. Zero-pad to 4 digits.
+3. Choose a kebab-case slug that names the *concept*, not the category. `decimal-arithmetic-operations`, not `new-type`.
+4. Write `docs/decisions/NNNN-slug.md` using the template from `neohaskell-adr-template`, filling each section from the interview transcript.
+
+Rules for writing:
+- Comparison tables are mandatory for every non-trivial decision point.
+- Every bullet in Consequences must be concrete enough that a reviewer can agree or disagree. "Better performance" is not concrete; "avoids one allocation per event in the hot path" is.
+- Code examples must follow NeoHaskell style (pipes, do-blocks, `case`, qualified imports, descriptive type params, strict fields). Load the `neohaskell-style-guide` skill if unsure.
+- No implementation bodies unless the body *is* the decision.
+- Status is always `Proposed`. Never set anything else — only the maintainer promotes ADRs.
+
+### Phase 3 — Deliver
+
+1. Add a row to the index table in `docs/decisions/README.md`, in numerical order:
+   `| [NNNN](NNNN-slug.md) | Title | Proposed |`
+2. Announce the file path.
+3. Do not summarize the ADR back to the user — the file is the artifact.
+
+## Rules
+
+- Never set Status to anything other than `Proposed`.
+- Never skip the alternatives comparison table. A decision with no rejected options is not a decision — keep interviewing.
+- Never write "TBD" or "to be decided later" inside the ADR. Either decide in the interview, or move it to an explicit out-of-scope note.
+- Never invent GitHub issue numbers. If none exists, omit the link rather than fabricate.
+- Never produce implementation plans, PR breakdowns, or timelines.
+- Titles name the concept, not the category: `Redacted Type for Sensitive Data`, not `Security Improvement`.
+- Slugs are lowercase kebab-case.
+- Interview density matches the user — no filler, no pleasantries, no recapping what they just said.


### PR DESCRIPTION
## Summary
- Adds the `neohaskell-adr-architect` skill: an interview-driven agent that decomposes vague feature ideas or GitHub issues into enumerated decision points, then writes a full ADR via the existing `neohaskell-adr-template` skill.
- Narrows the harness `git push` deny rule from a blanket `Bash(git push:*)` to the destructive variants (`--force`, `-f`) so normal pushes work without interactive prompts while force-push protection stays in place.

## Test plan
- [ ] Invoke the skill with a trigger phrase ("help me write an ADR", "turn this idea into an ADR") and confirm it enters interview mode.
- [ ] Complete an interview and confirm the resulting ADR file lands at `docs/decisions/NNNN-slug.md` with the template sections populated and a new row in `docs/decisions/README.md`.
- [ ] Confirm `git push` to a feature branch no longer prompts, and `git push --force` is still blocked by the harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an interactive workflow for generating architectural decision records with guided interviews and automatic documentation creation.

* **Chores**
  * Refined git operation permissions to granularly restrict forced push operations while maintaining support for standard push commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->