### PR TITLE
ai: trim Claude Code context overhead

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "autocompact_percentage_override": 75,
+  "env": {
+    "BASH_MAX_OUTPUT_LENGTH": "150000"
+  },
   "hooks": {
     "PreToolUse": [
       {
@@ -61,7 +65,18 @@
       "Bash(git push -f:*)",
       "Bash(git reset --hard:*)",
       "Read(.git/**)",
-      "Write(.git/**)"
+      "Write(.git/**)",
+      "Read(dist-newstyle/**)",
+      "Read(**/dist-newstyle/**)",
+      "Read(installer/target/**)",
+      "Read(**/target/**)",
+      "Read(**/node_modules/**)",
+      "Read(website/.astro/**)",
+      "Read(website/dist/**)",
+      "Read(**/.next/**)",
+      "Read(**/build/**)",
+      "Read(**/__pycache__/**)",
+      "Read(**/.venv/**)"
     ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# NeoHaskell
+
+NeoHaskell is a newcomer-friendly Haskell dialect. Monorepo with core library (nhcore), testbed, transpiler, CLI, Rust installer, and Astro website. Event-sourcing + CQRS architecture.
+
+## Where things live
+
+| Task | Location |
+|---|---|
+| Core types (Text, Array, Result) | `core/core/` |
+| Event-sourcing | `core/service/Service/` |
+| Concurrency primitives | `core/concurrency/` |
+| Tests | `core/test/`, `testbed/tests/` |
+| CLI design | `cli/design/` |
+| Transpiler design | `transpiler/design/` |
+| Installer (Rust) | `installer/` |
+| Website (Astro/Starlight) | `website/` |
+
+## Universal style rules
+
+- **Pipes over nesting**: `x |> foo |> bar` — not `bar $ foo x`
+- **Do + let** for bindings — never `let..in` / `where`
+- **`case ... of`** for pattern matching — never in function arg lists
+- **Qualified imports**: `EventStore.new` style
+- **String interpolation**: `[fmt|Hello #{name}!|]` — not `<>` / `++`
+- **`Task err val`** instead of `IO`; **`Result error value`** instead of `Either`
+- **`Task.yield` / `Result.ok`** instead of `pure` / `return`
+
+## Forbidden
+
+`let..in`, `where`, point-free style, single-letter type params, raw `IO`, `Either`, `<>`/`++` for string concat.
+
+## Build / test
+
+```bash
+cabal build all                 # Build everything
+cabal test                      # All tests
+cabal test nhcore-test-core     # Core only (no Postgres needed)
+hlint .                         # Lint (CI treats warnings as errors)
+./scripts/run-doctest           # Doctests
+```
+
+Test suites needing PostgreSQL: `nhcore-test-service`, `nhcore-test-integration`, `nhcore-test`.
+
+## Reference
+
+- **Detailed conventions, full pipeline, all test patterns**: see [AGENTS.md](AGENTS.md)
+- **Style enforcement**: invoke the `neohaskell-style-guide` skill
+- **Feature implementation pipeline**: invoke the `neohaskell-feature-pipeline` skill (17 phases, run via `python3 .opencode/skills/neohaskell-feature-pipeline/pipeline.py`)
+- **ADR drafting**: invoke `neohaskell-adr-architect` or `neohaskell-adr-template`
+
+## Non-negotiable
+
+- Every change ships with tests (happy path + error + boundary)
+- Bug fixes include regression tests
+- Never modify existing test expectations without maintainer approval
+- Branch off `main`; never edit `main` directly (enforced by hook)


### PR DESCRIPTION
Adds deny rules for build artifacts (dist-newstyle, target, node_modules, .astro, etc.), autocompact + bash output overrides, and a lean CLAUDE.md that points to AGENTS.md for detail (AGENTS.md isn't auto-loaded by Claude Code). Frees fixed per-turn context so more headroom remains for actual work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project guide documenting codebase layout, universal style rules, forbidden patterns, build and test commands, and contribution guidelines.

* **Chores**
  * Updated development configuration for enhanced tooling support and expanded permission controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->