### PR TITLE
feat(TH): fold JSON + deriving boilerplate into concept markers (#630)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,24 @@ When unavoidable, prefix with `Ghc`:
 import Data.List qualified as GhcList
 ```
 
+### Concept Markers (`command`, `event`, `deriveQuery`)
+
+Each marker emits `Show`, `Generic`, `Json.FromJSON`, and `Json.ToJSON`
+(plus `ToSchema` for queries) for the named type — idempotently, via
+`TH.reifyInstances`. Two rules:
+
+- **Marker last.** The marker splice must come *after* every other
+  declaration in the file, including any custom `Json.ToJSON` /
+  `Json.FromJSON` instance you want to keep. Declaring a custom instance
+  *after* the marker produces a `Duplicate instance declarations`
+  compile error because the marker has already emitted the derived one.
+- **Custom encodings stay possible.** Want a tagged-sum `Json.ToJSON`
+  or `omitNothingFields`? Declare it *before* the marker call; the
+  marker detects it via `reifyInstances` and emits no duplicate.
+
+The four-pack helper lives at `Service.TH.Boilerplate` and is shared by
+all three markers — see ADR-0057.
+
 ## ANTI-PATTERNS (FORBIDDEN)
 
 - `let..in` or `where` clauses

--- a/core/nhcore.cabal
+++ b/core/nhcore.cabal
@@ -100,6 +100,7 @@ common common_cfg
     BlockArguments
     DataKinds
     DeriveDataTypeable
+    DerivingStrategies
     DuplicateRecordFields
     ImportQualifiedPost
     ImplicitParams
@@ -115,6 +116,7 @@ common common_cfg
     PartialTypeSignatures
     QualifiedDo
     QuasiQuotes
+    StandaloneDeriving
     Strict
     TemplateHaskell
     TypeApplications
@@ -223,12 +225,14 @@ library
     Service.CommandExecutor
     Service.CommandExecutor.Core
     Service.CommandExecutor.TH
+    Service.CommandExecutor.TH.Internal
     Service.Entity
     Service.Entity.Core
     Service.EntityFetcher
     Service.EntityFetcher.Core
     Service.Error
     Service.Event
+    Service.Event.TH
     Service.Event.EntityName
     Service.Event.EventMetadata
     Service.Event.StreamId
@@ -484,6 +488,12 @@ test-suite nhcore-test
     Service.Integration.SelectionSpec
     Service.Integration.TestFixtures
     Service.Integration.WireupSpec
+    Service.CommandExecutor.TH.AlreadyDerivedCommandFixture
+    Service.CommandExecutor.TH.FreshCommandFixture
+    Service.CommandExecutor.TH.PartialDerivedCommandFixture
+    Service.CommandExecutor.TH.SumCommandFixture
+    Service.CommandExecutor.THSpec
+    Service.Event.THSpec
 
   -- other-extensions:
   type: exitcode-stdio-1.0
@@ -535,8 +545,14 @@ test-suite nhcore-test-service
 
   other-modules:
     Service.ApplicationSpec
+    Service.CommandExecutor.THSpec
+    Service.CommandExecutor.TH.AlreadyDerivedCommandFixture
+    Service.CommandExecutor.TH.FreshCommandFixture
+    Service.CommandExecutor.TH.PartialDerivedCommandFixture
+    Service.CommandExecutor.TH.SumCommandFixture
     Service.CommandHandlerSpec
     Service.CommandSpec
+    Service.Event.THSpec
     Service.EventStore.InMemorySpec
     Service.EventStore.SimpleSpec
     Service.EventStore.Postgres.SubscriptionStoreSpec

--- a/core/nhcore.cabal
+++ b/core/nhcore.cabal
@@ -225,7 +225,6 @@ library
     Service.CommandExecutor
     Service.CommandExecutor.Core
     Service.CommandExecutor.TH
-    Service.CommandExecutor.TH.Internal
     Service.Entity
     Service.Entity.Core
     Service.EntityFetcher
@@ -283,6 +282,7 @@ library
     Service.FileUpload.Web
     Service.ServiceDefinition
     Service.ServiceDefinition.Core
+    Service.TH.Boilerplate
     Service.Transport
     Service.Transport.Web
     Service.Transport.Web.BuiltinSchemas

--- a/core/service/Service/CommandExecutor/TH.hs
+++ b/core/service/Service/CommandExecutor/TH.hs
@@ -5,12 +5,14 @@ module Service.CommandExecutor.TH (
 
 import Control.Monad.Fail qualified as MonadFail
 import Core
+import Data.Aeson qualified as Json
 import Data.Hashable qualified as Hashable
 import Data.List qualified as GhcList
 import GHC.Base (String)
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Ppr qualified as THPpr
 import Language.Haskell.TH.Syntax qualified as TH
+import Service.CommandExecutor.TH.Internal (emitInstanceIfMissing)
 
 
 data MultiTenancyMode
@@ -513,5 +515,46 @@ Please ensure you have `import Core` at the top of your module.
           (TH.ConT toSchemaClassName `TH.AppT` TH.ConT someName)
           [] -- Empty body, uses default implementation from Generic
 
-  pure ([nameOfInstance, commandInstance, toSchemaInstance] ++ knownHashInstance)
+  showDecls <-
+    emitInstanceIfMissing ''Show someName do
+      pure
+        [ TH.StandaloneDerivD
+            (Just TH.StockStrategy)
+            []
+            (TH.ConT ''Show `TH.AppT` TH.ConT someName)
+        ]
+  genericDecls <-
+    emitInstanceIfMissing ''Generic someName do
+      pure
+        [ TH.StandaloneDerivD
+            (Just TH.StockStrategy)
+            []
+            (TH.ConT ''Generic `TH.AppT` TH.ConT someName)
+        ]
+  fromJsonDecls <-
+    emitInstanceIfMissing ''Json.FromJSON someName do
+      pure
+        [ TH.InstanceD
+            Nothing
+            []
+            (TH.ConT ''Json.FromJSON `TH.AppT` TH.ConT someName)
+            []
+        ]
+  toJsonDecls <-
+    emitInstanceIfMissing ''Json.ToJSON someName do
+      pure
+        [ TH.InstanceD
+            Nothing
+            []
+            (TH.ConT ''Json.ToJSON `TH.AppT` TH.ConT someName)
+            []
+        ]
+  pure
+    ( [nameOfInstance, commandInstance, toSchemaInstance]
+        ++ knownHashInstance
+        ++ showDecls
+        ++ genericDecls
+        ++ fromJsonDecls
+        ++ toJsonDecls
+    )
 {-# INLINE command #-}

--- a/core/service/Service/CommandExecutor/TH.hs
+++ b/core/service/Service/CommandExecutor/TH.hs
@@ -5,14 +5,13 @@ module Service.CommandExecutor.TH (
 
 import Control.Monad.Fail qualified as MonadFail
 import Core
-import Data.Aeson qualified as Json
 import Data.Hashable qualified as Hashable
 import Data.List qualified as GhcList
 import GHC.Base (String)
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Ppr qualified as THPpr
 import Language.Haskell.TH.Syntax qualified as TH
-import Service.CommandExecutor.TH.Internal (emitInstanceIfMissing)
+import Service.CommandExecutor.TH.Internal (emitJsonAndDerivingBoilerplate)
 
 
 data MultiTenancyMode
@@ -515,46 +514,10 @@ Please ensure you have `import Core` at the top of your module.
           (TH.ConT toSchemaClassName `TH.AppT` TH.ConT someName)
           [] -- Empty body, uses default implementation from Generic
 
-  showDecls <-
-    emitInstanceIfMissing ''Show someName do
-      pure
-        [ TH.StandaloneDerivD
-            (Just TH.StockStrategy)
-            []
-            (TH.ConT ''Show `TH.AppT` TH.ConT someName)
-        ]
-  genericDecls <-
-    emitInstanceIfMissing ''Generic someName do
-      pure
-        [ TH.StandaloneDerivD
-            (Just TH.StockStrategy)
-            []
-            (TH.ConT ''Generic `TH.AppT` TH.ConT someName)
-        ]
-  fromJsonDecls <-
-    emitInstanceIfMissing ''Json.FromJSON someName do
-      pure
-        [ TH.InstanceD
-            Nothing
-            []
-            (TH.ConT ''Json.FromJSON `TH.AppT` TH.ConT someName)
-            []
-        ]
-  toJsonDecls <-
-    emitInstanceIfMissing ''Json.ToJSON someName do
-      pure
-        [ TH.InstanceD
-            Nothing
-            []
-            (TH.ConT ''Json.ToJSON `TH.AppT` TH.ConT someName)
-            []
-        ]
+  boilerplateDecls <- emitJsonAndDerivingBoilerplate someName
   pure
     ( [nameOfInstance, commandInstance, toSchemaInstance]
         ++ knownHashInstance
-        ++ showDecls
-        ++ genericDecls
-        ++ fromJsonDecls
-        ++ toJsonDecls
+        ++ boilerplateDecls
     )
 {-# INLINE command #-}

--- a/core/service/Service/CommandExecutor/TH.hs
+++ b/core/service/Service/CommandExecutor/TH.hs
@@ -11,7 +11,7 @@ import GHC.Base (String)
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Ppr qualified as THPpr
 import Language.Haskell.TH.Syntax qualified as TH
-import Service.CommandExecutor.TH.Internal (emitJsonAndDerivingBoilerplate)
+import Service.TH.Boilerplate (emitJsonAndDerivingBoilerplate)
 
 
 data MultiTenancyMode

--- a/core/service/Service/CommandExecutor/TH/Internal.hs
+++ b/core/service/Service/CommandExecutor/TH/Internal.hs
@@ -4,9 +4,13 @@
 -- Service.CommandExecutor.TH, Service.Query.TH, and Service.Event.TH.
 module Service.CommandExecutor.TH.Internal (
   emitInstanceIfMissing,
+  emitStockDeriving,
+  emitEmptyInstance,
+  emitJsonAndDerivingBoilerplate,
 ) where
 
 import Core
+import Data.Aeson qualified as Json
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Syntax qualified as TH
 
@@ -27,3 +31,49 @@ emitInstanceIfMissing className typeName fallbackDecl = do
     [] -> fallbackDecl
     _ : _ -> pure []
 {-# INLINE emitInstanceIfMissing #-}
+
+
+-- | Emit a @deriving stock instance Class Type@ declaration when the
+-- class instance is not already in scope.  Used for 'Show' and 'Generic'.
+emitStockDeriving :: TH.Name -> TH.Name -> THLib.DecsQ
+emitStockDeriving className typeName =
+  emitInstanceIfMissing className typeName do
+    pure
+      [ TH.StandaloneDerivD
+          (Just TH.StockStrategy)
+          []
+          (TH.ConT className `TH.AppT` TH.ConT typeName)
+      ]
+{-# INLINE emitStockDeriving #-}
+
+
+-- | Emit an empty-body @instance Class Type@ declaration when the class
+-- instance is not already in scope.  Used for 'Json.FromJSON',
+-- 'Json.ToJSON', and 'ToSchema' — each defaults its methods via 'Generic'.
+emitEmptyInstance :: TH.Name -> TH.Name -> THLib.DecsQ
+emitEmptyInstance className typeName =
+  emitInstanceIfMissing className typeName do
+    pure
+      [ TH.InstanceD
+          Nothing
+          []
+          (TH.ConT className `TH.AppT` TH.ConT typeName)
+          []
+      ]
+{-# INLINE emitEmptyInstance #-}
+
+
+-- | Emit the four-class boilerplate every concept marker shares:
+-- 'Show', 'Generic', 'Json.FromJSON', 'Json.ToJSON'.  Each is emitted
+-- only when not already in scope.
+--
+-- 'Service.Query.TH.deriveQuery' calls 'emitEmptyInstance' separately
+-- for 'ToSchema' on top of this four-pack.
+emitJsonAndDerivingBoilerplate :: TH.Name -> THLib.DecsQ
+emitJsonAndDerivingBoilerplate typeName = do
+  showDecls <- emitStockDeriving ''Show typeName
+  genericDecls <- emitStockDeriving ''Generic typeName
+  fromJsonDecls <- emitEmptyInstance ''Json.FromJSON typeName
+  toJsonDecls <- emitEmptyInstance ''Json.ToJSON typeName
+  pure (showDecls ++ genericDecls ++ fromJsonDecls ++ toJsonDecls)
+{-# INLINE emitJsonAndDerivingBoilerplate #-}

--- a/core/service/Service/CommandExecutor/TH/Internal.hs
+++ b/core/service/Service/CommandExecutor/TH/Internal.hs
@@ -1,0 +1,29 @@
+-- | Internal helpers for TH marker boilerplate emission.
+--
+-- NOT exported from any public interface.  Used only by
+-- Service.CommandExecutor.TH, Service.Query.TH, and Service.Event.TH.
+module Service.CommandExecutor.TH.Internal (
+  emitInstanceIfMissing,
+) where
+
+import Core
+import Language.Haskell.TH.Lib qualified as THLib
+import Language.Haskell.TH.Syntax qualified as TH
+
+
+-- | Emit a class instance only when it is not already in scope.
+--
+-- Checks via 'TH.reifyInstances' whether @className \@typeName@ exists.
+-- Returns the @fallbackDecl@ when the instance is absent, or an empty list
+-- when it is already present.
+emitInstanceIfMissing ::
+  TH.Name ->
+  TH.Name ->
+  THLib.DecsQ ->
+  THLib.DecsQ
+emitInstanceIfMissing className typeName fallbackDecl = do
+  instances <- TH.reifyInstances className [TH.ConT typeName]
+  case instances of
+    [] -> fallbackDecl
+    _ : _ -> pure []
+{-# INLINE emitInstanceIfMissing #-}

--- a/core/service/Service/Event/TH.hs
+++ b/core/service/Service/Event/TH.hs
@@ -17,51 +17,14 @@ module Service.Event.TH (
   event,
 ) where
 
-import Core hiding (event)
-import Data.Aeson qualified as Json
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Syntax qualified as TH
-import Service.CommandExecutor.TH.Internal (emitInstanceIfMissing)
+import Service.CommandExecutor.TH.Internal (emitJsonAndDerivingBoilerplate)
 
 
 -- | Derive Show, Generic, Json.FromJSON, and Json.ToJSON for an event type.
 --
 -- Each class is emitted only when it is not already in scope (idempotent).
 event :: TH.Name -> THLib.DecsQ
-event typeName = do
-  showDecls <-
-    emitInstanceIfMissing ''Show typeName do
-      pure
-        [ TH.StandaloneDerivD
-            (Just TH.StockStrategy)
-            []
-            (TH.ConT ''Show `TH.AppT` TH.ConT typeName)
-        ]
-  genericDecls <-
-    emitInstanceIfMissing ''Generic typeName do
-      pure
-        [ TH.StandaloneDerivD
-            (Just TH.StockStrategy)
-            []
-            (TH.ConT ''Generic `TH.AppT` TH.ConT typeName)
-        ]
-  fromJsonDecls <-
-    emitInstanceIfMissing ''Json.FromJSON typeName do
-      pure
-        [ TH.InstanceD
-            Nothing
-            []
-            (TH.ConT ''Json.FromJSON `TH.AppT` TH.ConT typeName)
-            []
-        ]
-  toJsonDecls <-
-    emitInstanceIfMissing ''Json.ToJSON typeName do
-      pure
-        [ TH.InstanceD
-            Nothing
-            []
-            (TH.ConT ''Json.ToJSON `TH.AppT` TH.ConT typeName)
-            []
-        ]
-  pure (showDecls ++ genericDecls ++ fromJsonDecls ++ toJsonDecls)
+event = emitJsonAndDerivingBoilerplate
 {-# INLINE event #-}

--- a/core/service/Service/Event/TH.hs
+++ b/core/service/Service/Event/TH.hs
@@ -1,0 +1,67 @@
+-- | Template Haskell marker for event types.
+--
+-- The 'event' marker emits Show, Generic, Json.FromJSON, and Json.ToJSON
+-- instances for the named type, skipping any that are already in scope.
+--
+-- Usage:
+--
+-- > data CartCreated = CartCreated { cartId :: Uuid }
+-- >
+-- > event ''CartCreated
+--
+-- CONVENTION — \"marker last\":  Any custom instance you wish to write
+-- (e.g. a hand-crafted 'Json.ToJSON') must be declared /before/ the
+-- @event@ call.  Declaring it after produces a GHC \"Duplicate instance\"
+-- error because the marker will have already emitted the derived version.
+module Service.Event.TH (
+  event,
+) where
+
+import Core hiding (event)
+import Data.Aeson qualified as Json
+import Language.Haskell.TH.Lib qualified as THLib
+import Language.Haskell.TH.Syntax qualified as TH
+import Service.CommandExecutor.TH.Internal (emitInstanceIfMissing)
+
+
+-- | Derive Show, Generic, Json.FromJSON, and Json.ToJSON for an event type.
+--
+-- Each class is emitted only when it is not already in scope (idempotent).
+event :: TH.Name -> THLib.DecsQ
+event typeName = do
+  showDecls <-
+    emitInstanceIfMissing ''Show typeName do
+      pure
+        [ TH.StandaloneDerivD
+            (Just TH.StockStrategy)
+            []
+            (TH.ConT ''Show `TH.AppT` TH.ConT typeName)
+        ]
+  genericDecls <-
+    emitInstanceIfMissing ''Generic typeName do
+      pure
+        [ TH.StandaloneDerivD
+            (Just TH.StockStrategy)
+            []
+            (TH.ConT ''Generic `TH.AppT` TH.ConT typeName)
+        ]
+  fromJsonDecls <-
+    emitInstanceIfMissing ''Json.FromJSON typeName do
+      pure
+        [ TH.InstanceD
+            Nothing
+            []
+            (TH.ConT ''Json.FromJSON `TH.AppT` TH.ConT typeName)
+            []
+        ]
+  toJsonDecls <-
+    emitInstanceIfMissing ''Json.ToJSON typeName do
+      pure
+        [ TH.InstanceD
+            Nothing
+            []
+            (TH.ConT ''Json.ToJSON `TH.AppT` TH.ConT typeName)
+            []
+        ]
+  pure (showDecls ++ genericDecls ++ fromJsonDecls ++ toJsonDecls)
+{-# INLINE event #-}

--- a/core/service/Service/Event/TH.hs
+++ b/core/service/Service/Event/TH.hs
@@ -19,7 +19,7 @@ module Service.Event.TH (
 
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Syntax qualified as TH
-import Service.CommandExecutor.TH.Internal (emitJsonAndDerivingBoilerplate)
+import Service.TH.Boilerplate (emitJsonAndDerivingBoilerplate)
 
 
 -- | Derive Show, Generic, Json.FromJSON, and Json.ToJSON for an event type.

--- a/core/service/Service/Query/TH.hs
+++ b/core/service/Service/Query/TH.hs
@@ -9,7 +9,7 @@ import Data.List qualified as GhcList
 import GHC.Base (String)
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Syntax qualified as TH
-import Service.CommandExecutor.TH.Internal (emitEmptyInstance, emitJsonAndDerivingBoilerplate)
+import Service.TH.Boilerplate (emitEmptyInstance, emitJsonAndDerivingBoilerplate)
 
 
 -- | Derive Query-related instances for a query type.

--- a/core/service/Service/Query/TH.hs
+++ b/core/service/Service/Query/TH.hs
@@ -4,13 +4,12 @@ module Service.Query.TH (
 
 import Control.Monad.Fail qualified as MonadFail
 import Core
-import Data.Aeson qualified as Json
 import Data.Hashable qualified as Hashable
 import Data.List qualified as GhcList
 import GHC.Base (String)
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Syntax qualified as TH
-import Service.CommandExecutor.TH.Internal (emitInstanceIfMissing)
+import Service.CommandExecutor.TH.Internal (emitEmptyInstance, emitJsonAndDerivingBoilerplate)
 
 
 -- | Derive Query-related instances for a query type.
@@ -148,56 +147,12 @@ Available helpers from Service.Query.Auth:
   -- Lookup ToSchema for queries (new — ADR-0057)
   toSchemaClassName <- lookupOrFail "ToSchema"
 
-  showDecls <-
-    emitInstanceIfMissing ''Show queryTypeName do
-      pure
-        [ TH.StandaloneDerivD
-            (Just TH.StockStrategy)
-            []
-            (TH.ConT ''Show `TH.AppT` TH.ConT queryTypeName)
-        ]
-  genericDecls <-
-    emitInstanceIfMissing ''Generic queryTypeName do
-      pure
-        [ TH.StandaloneDerivD
-            (Just TH.StockStrategy)
-            []
-            (TH.ConT ''Generic `TH.AppT` TH.ConT queryTypeName)
-        ]
-  fromJsonDecls <-
-    emitInstanceIfMissing ''Json.FromJSON queryTypeName do
-      pure
-        [ TH.InstanceD
-            Nothing
-            []
-            (TH.ConT ''Json.FromJSON `TH.AppT` TH.ConT queryTypeName)
-            []
-        ]
-  toJsonDecls <-
-    emitInstanceIfMissing ''Json.ToJSON queryTypeName do
-      pure
-        [ TH.InstanceD
-            Nothing
-            []
-            (TH.ConT ''Json.ToJSON `TH.AppT` TH.ConT queryTypeName)
-            []
-        ]
-  toSchemaDecls <-
-    emitInstanceIfMissing toSchemaClassName queryTypeName do
-      pure
-        [ TH.InstanceD
-            Nothing
-            []
-            (TH.ConT toSchemaClassName `TH.AppT` TH.ConT queryTypeName)
-            []
-        ]
+  boilerplateDecls <- emitJsonAndDerivingBoilerplate queryTypeName
+  toSchemaDecls <- emitEmptyInstance toSchemaClassName queryTypeName
   pure
     ( [nameOfInstance, entitiesOfInstance, queryInstance]
         ++ knownHashInstances
-        ++ showDecls
-        ++ genericDecls
-        ++ fromJsonDecls
-        ++ toJsonDecls
+        ++ boilerplateDecls
         ++ toSchemaDecls
     )
 

--- a/core/service/Service/Query/TH.hs
+++ b/core/service/Service/Query/TH.hs
@@ -4,11 +4,13 @@ module Service.Query.TH (
 
 import Control.Monad.Fail qualified as MonadFail
 import Core
+import Data.Aeson qualified as Json
 import Data.Hashable qualified as Hashable
 import Data.List qualified as GhcList
 import GHC.Base (String)
 import Language.Haskell.TH.Lib qualified as THLib
 import Language.Haskell.TH.Syntax qualified as TH
+import Service.CommandExecutor.TH.Internal (emitInstanceIfMissing)
 
 
 -- | Derive Query-related instances for a query type.
@@ -143,7 +145,61 @@ Available helpers from Service.Query.Auth:
   -- Generate KnownHash instance
   knownHashInstances <- deriveKnownHash queryTypeStr
 
-  pure ([nameOfInstance, entitiesOfInstance, queryInstance] ++ knownHashInstances)
+  -- Lookup ToSchema for queries (new — ADR-0057)
+  toSchemaClassName <- lookupOrFail "ToSchema"
+
+  showDecls <-
+    emitInstanceIfMissing ''Show queryTypeName do
+      pure
+        [ TH.StandaloneDerivD
+            (Just TH.StockStrategy)
+            []
+            (TH.ConT ''Show `TH.AppT` TH.ConT queryTypeName)
+        ]
+  genericDecls <-
+    emitInstanceIfMissing ''Generic queryTypeName do
+      pure
+        [ TH.StandaloneDerivD
+            (Just TH.StockStrategy)
+            []
+            (TH.ConT ''Generic `TH.AppT` TH.ConT queryTypeName)
+        ]
+  fromJsonDecls <-
+    emitInstanceIfMissing ''Json.FromJSON queryTypeName do
+      pure
+        [ TH.InstanceD
+            Nothing
+            []
+            (TH.ConT ''Json.FromJSON `TH.AppT` TH.ConT queryTypeName)
+            []
+        ]
+  toJsonDecls <-
+    emitInstanceIfMissing ''Json.ToJSON queryTypeName do
+      pure
+        [ TH.InstanceD
+            Nothing
+            []
+            (TH.ConT ''Json.ToJSON `TH.AppT` TH.ConT queryTypeName)
+            []
+        ]
+  toSchemaDecls <-
+    emitInstanceIfMissing toSchemaClassName queryTypeName do
+      pure
+        [ TH.InstanceD
+            Nothing
+            []
+            (TH.ConT toSchemaClassName `TH.AppT` TH.ConT queryTypeName)
+            []
+        ]
+  pure
+    ( [nameOfInstance, entitiesOfInstance, queryInstance]
+        ++ knownHashInstances
+        ++ showDecls
+        ++ genericDecls
+        ++ fromJsonDecls
+        ++ toJsonDecls
+        ++ toSchemaDecls
+    )
 
 
 -- | Derives a KnownHash instance for a given string at compile time.

--- a/core/service/Service/TH/Boilerplate.hs
+++ b/core/service/Service/TH/Boilerplate.hs
@@ -1,8 +1,11 @@
--- | Internal helpers for TH marker boilerplate emission.
+-- | Shared TH primitives for concept-marker boilerplate emission.
 --
--- NOT exported from any public interface.  Used only by
--- Service.CommandExecutor.TH, Service.Query.TH, and Service.Event.TH.
-module Service.CommandExecutor.TH.Internal (
+-- Internal to nhcore.  Used by Service.CommandExecutor.TH,
+-- Service.Query.TH, and Service.Event.TH to emit the JSON and
+-- @deriving stock@ instances every command, event, and query type
+-- needs, while remaining a no-op when an instance is already in scope
+-- (so consumers can declare custom encodings before the marker call).
+module Service.TH.Boilerplate (
   emitInstanceIfMissing,
   emitStockDeriving,
   emitEmptyInstance,

--- a/core/test-service/Main.hs
+++ b/core/test-service/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 import Prelude (IO)
 
 import Service.ApplicationSpec qualified
+import Service.CommandExecutor.THSpec qualified
 import Service.CommandHandlerSpec qualified
 import Service.CommandSpec qualified
 import Service.EventStore.InMemorySpec qualified
@@ -22,6 +23,7 @@ import Service.Integration.AdapterSpec qualified
 import Service.Integration.DispatchRegistrySpec qualified
 import Service.Integration.SelectionSpec qualified
 import Service.Integration.WireupSpec qualified
+import Service.Event.THSpec qualified
 import Service.Query.EndpointSpec qualified
 import Service.Query.RegistrySpec qualified
 import Service.Query.SubscriberSpec qualified
@@ -44,6 +46,7 @@ import Test.Hspec qualified as Hspec
 main :: IO ()
 main = Hspec.hspec do
   Hspec.describe "Service.Application" Service.ApplicationSpec.spec
+  Hspec.describe "Service.CommandExecutor.TH" Service.CommandExecutor.THSpec.spec
   Hspec.describe "Service.CommandHandler" Service.CommandHandlerSpec.spec
   Hspec.describe "Service.Command" Service.CommandSpec.spec
   Hspec.describe "Service.EventStore.InMemory" Service.EventStore.InMemorySpec.spec
@@ -63,6 +66,7 @@ main = Hspec.hspec do
   Hspec.describe "Service.Integration.DispatchRegistry" Service.Integration.DispatchRegistrySpec.spec
   Hspec.describe "Service.Integration.Selection" Service.Integration.SelectionSpec.spec
   Hspec.describe "Service.Integration.Wireup" Service.Integration.WireupSpec.spec
+  Hspec.describe "Service.Event.TH" Service.Event.THSpec.spec
   Hspec.describe "Service.Query.Endpoint" Service.Query.EndpointSpec.spec
   Hspec.describe "Service.Query.Registry" Service.Query.RegistrySpec.spec
   Hspec.describe "Service.Query.Subscriber" Service.Query.SubscriberSpec.spec

--- a/core/test/Service/CommandExecutor/TH/AlreadyDerivedCommandFixture.hs
+++ b/core/test/Service/CommandExecutor/TH/AlreadyDerivedCommandFixture.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Test fixture: AlreadyDerivedCommand already has Show / Generic / FromJSON /
+-- ToJSON in scope BEFORE the @command@ call.
+--
+-- If the module compiles without a GHC "Duplicate instance" error, the marker
+-- correctly detected the pre-existing instances and emitted nothing.  This is
+-- a regression test (green against phase-9 stub and against the final impl).
+module Service.CommandExecutor.TH.AlreadyDerivedCommandFixture (
+  AlreadyDerivedCommand (..),
+  hasAlreadyDerivedCommandShow,
+) where
+
+import Core
+import Decider qualified
+import Json qualified
+import Language.Haskell.TH.Syntax qualified as TH
+import Service.Auth (RequestContext)
+import Service.CommandExecutor.TH (command)
+import Uuid qualified
+
+
+-- Supporting entity (imported from FreshCommandFixture to avoid duplication
+-- but declared here to keep the fixture self-contained) ---------------------
+
+data ADTestEntity = ADTestEntity {adEntityId :: Uuid}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON ADTestEntity
+instance Json.FromJSON ADTestEntity
+
+
+data ADTestEvent = ADTestEntityCreated Uuid
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON ADTestEvent
+instance Json.FromJSON ADTestEvent
+
+
+type instance EventOf ADTestEntity = ADTestEvent
+
+
+instance Entity ADTestEntity where
+  initialStateImpl = ADTestEntity {adEntityId = Uuid.nil}
+  updateImpl ev entity = case ev of
+    ADTestEntityCreated uid -> entity {adEntityId = uid}
+
+
+-- Command type WITH all four instances already in scope --------------------
+
+data AlreadyDerivedCommand = AlreadyDerivedCommand {cmdId :: Uuid}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON AlreadyDerivedCommand
+instance Json.FromJSON AlreadyDerivedCommand
+
+
+type instance EntityOf AlreadyDerivedCommand = ADTestEntity
+
+
+getEntityId :: AlreadyDerivedCommand -> Maybe Uuid
+getEntityId _ = Nothing
+
+
+decide :: AlreadyDerivedCommand -> Maybe ADTestEntity -> RequestContext -> Decision ADTestEvent
+decide _ _ _ = Decider.acceptNew [ADTestEntityCreated Uuid.nil]
+
+
+-- [regression] Successful compilation of this splice proves idempotency.
+command ''AlreadyDerivedCommand
+
+
+-- TH probe: Show is still present after the marker call --------------------
+
+$(do
+    is <- TH.reifyInstances ''Show [TH.ConT ''AlreadyDerivedCommand]
+    case is of
+      [] -> [d| hasAlreadyDerivedCommandShow :: Bool; hasAlreadyDerivedCommandShow = False |]
+      _ : _ -> [d| hasAlreadyDerivedCommandShow :: Bool; hasAlreadyDerivedCommandShow = True |])

--- a/core/test/Service/CommandExecutor/TH/FreshCommandFixture.hs
+++ b/core/test/Service/CommandExecutor/TH/FreshCommandFixture.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Test fixture: FreshCommand has NO pre-existing Show / Generic / FromJSON / ToJSON.
+-- The @command@ marker is expected (after phase 10) to emit all four.
+--
+-- TH probes evaluate to False before phase 10 (stub emits nothing) and to
+-- True after phase 10 (real implementation emits the instances).  The test
+-- file asserts True, so these tests are red until phase 10 lands.
+module Service.CommandExecutor.TH.FreshCommandFixture (
+  FreshCommand (..),
+  hasFreshCommandShow,
+  hasFreshCommandGeneric,
+  hasFreshCommandToJSON,
+  hasFreshCommandFromJSON,
+) where
+
+import Core
+import Decider qualified
+import Json qualified
+import Language.Haskell.TH.Syntax qualified as TH
+import Service.Auth (RequestContext)
+import Service.CommandExecutor.TH (command)
+import Uuid qualified
+
+
+-- Supporting entity --------------------------------------------------------
+
+data THTestEntity = THTestEntity {thEntityId :: Uuid}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON THTestEntity
+instance Json.FromJSON THTestEntity
+
+
+data THTestEvent = THTestEntityCreated Uuid
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON THTestEvent
+instance Json.FromJSON THTestEvent
+
+
+type instance EventOf THTestEntity = THTestEvent
+
+
+instance Entity THTestEntity where
+  initialStateImpl = THTestEntity {thEntityId = Uuid.nil}
+  updateImpl ev entity = case ev of
+    THTestEntityCreated uid -> entity {thEntityId = uid}
+
+
+-- Fresh command type: HAS Generic (required by existing ToSchema emission),
+-- but NO Show / FromJSON / ToJSON.  Phase 10 will emit those three.
+-- The Generic probe will report True (pre-existing) — see note in THSpec.
+
+data FreshCommand = FreshCommand {freshId :: Uuid, freshLabel :: Text}
+  deriving (Generic)
+
+
+type instance EntityOf FreshCommand = THTestEntity
+
+
+getEntityId :: FreshCommand -> Maybe Uuid
+getEntityId _ = Nothing
+
+
+decide :: FreshCommand -> Maybe THTestEntity -> RequestContext -> Decision THTestEvent
+decide _ _ _ = Decider.acceptNew [THTestEntityCreated Uuid.nil]
+
+
+command ''FreshCommand
+
+
+-- TH probes -----------------------------------------------------------------
+
+$(do
+    is <- TH.reifyInstances ''Show [TH.ConT ''FreshCommand]
+    case is of
+      [] -> [d| hasFreshCommandShow :: Bool; hasFreshCommandShow = False |]
+      _ : _ -> [d| hasFreshCommandShow :: Bool; hasFreshCommandShow = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Generic [TH.ConT ''FreshCommand]
+    case is of
+      [] -> [d| hasFreshCommandGeneric :: Bool; hasFreshCommandGeneric = False |]
+      _ : _ -> [d| hasFreshCommandGeneric :: Bool; hasFreshCommandGeneric = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Json.ToJSON [TH.ConT ''FreshCommand]
+    case is of
+      [] -> [d| hasFreshCommandToJSON :: Bool; hasFreshCommandToJSON = False |]
+      _ : _ -> [d| hasFreshCommandToJSON :: Bool; hasFreshCommandToJSON = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Json.FromJSON [TH.ConT ''FreshCommand]
+    case is of
+      [] -> [d| hasFreshCommandFromJSON :: Bool; hasFreshCommandFromJSON = False |]
+      _ : _ -> [d| hasFreshCommandFromJSON :: Bool; hasFreshCommandFromJSON = True |])

--- a/core/test/Service/CommandExecutor/TH/PartialDerivedCommandFixture.hs
+++ b/core/test/Service/CommandExecutor/TH/PartialDerivedCommandFixture.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Test fixture: PartialDerivedCommand has Show + Generic already in scope
+-- but NO FromJSON or ToJSON before the @command@ call.
+--
+-- After phase 10 the marker should emit only the missing JSON instances,
+-- leaving Show and Generic untouched (and producing no duplicate).
+module Service.CommandExecutor.TH.PartialDerivedCommandFixture (
+  PartialDerivedCommand (..),
+  hasPartialToJSON,
+  hasPartialFromJSON,
+  hasPartialShow,
+) where
+
+import Core
+import Decider qualified
+import Json qualified
+import Language.Haskell.TH.Syntax qualified as TH
+import Service.Auth (RequestContext)
+import Service.CommandExecutor.TH (command)
+import Uuid qualified
+
+
+-- Supporting entity --------------------------------------------------------
+
+data PDTestEntity = PDTestEntity {pdEntityId :: Uuid}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON PDTestEntity
+instance Json.FromJSON PDTestEntity
+
+
+data PDTestEvent = PDTestEntityCreated Uuid
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON PDTestEvent
+instance Json.FromJSON PDTestEvent
+
+
+type instance EventOf PDTestEntity = PDTestEvent
+
+
+instance Entity PDTestEntity where
+  initialStateImpl = PDTestEntity {pdEntityId = Uuid.nil}
+  updateImpl ev entity = case ev of
+    PDTestEntityCreated uid -> entity {pdEntityId = uid}
+
+
+-- Command type: Show + Generic in scope, no JSON ----------------------------
+
+data PartialDerivedCommand = PartialDerivedCommand {partialId :: Uuid}
+  deriving (Show, Generic)
+
+
+type instance EntityOf PartialDerivedCommand = PDTestEntity
+
+
+getEntityId :: PartialDerivedCommand -> Maybe Uuid
+getEntityId _ = Nothing
+
+
+decide :: PartialDerivedCommand -> Maybe PDTestEntity -> RequestContext -> Decision PDTestEvent
+decide _ _ _ = Decider.acceptNew [PDTestEntityCreated Uuid.nil]
+
+
+command ''PartialDerivedCommand
+
+
+-- TH probes -----------------------------------------------------------------
+
+$(do
+    is <- TH.reifyInstances ''Json.ToJSON [TH.ConT ''PartialDerivedCommand]
+    case is of
+      [] -> [d| hasPartialToJSON :: Bool; hasPartialToJSON = False |]
+      _ : _ -> [d| hasPartialToJSON :: Bool; hasPartialToJSON = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Json.FromJSON [TH.ConT ''PartialDerivedCommand]
+    case is of
+      [] -> [d| hasPartialFromJSON :: Bool; hasPartialFromJSON = False |]
+      _ : _ -> [d| hasPartialFromJSON :: Bool; hasPartialFromJSON = True |])
+
+
+-- Regression: Show was present before the marker; must still be present.
+$(do
+    is <- TH.reifyInstances ''Show [TH.ConT ''PartialDerivedCommand]
+    case is of
+      [] -> [d| hasPartialShow :: Bool; hasPartialShow = False |]
+      _ : _ -> [d| hasPartialShow :: Bool; hasPartialShow = True |])

--- a/core/test/Service/CommandExecutor/TH/SumCommandFixture.hs
+++ b/core/test/Service/CommandExecutor/TH/SumCommandFixture.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Test fixture: SumCommand is a sum type with multiple constructors.
+-- Proves that the emitted Show instance handles all constructors correctly.
+module Service.CommandExecutor.TH.SumCommandFixture (
+  SumCommand (..),
+) where
+
+import Core
+import Decider qualified
+import Json qualified
+import Service.Auth (RequestContext)
+import Service.CommandExecutor.TH (command)
+import Uuid qualified
+
+
+-- Supporting entity --------------------------------------------------------
+
+data SumTestEntity = SumTestEntity {sumEntityId :: Uuid}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON SumTestEntity
+instance Json.FromJSON SumTestEntity
+
+
+data SumTestEvent = SumTestEntityCreated Uuid
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON SumTestEvent
+instance Json.FromJSON SumTestEvent
+
+
+type instance EventOf SumTestEntity = SumTestEvent
+
+
+instance Entity SumTestEntity where
+  initialStateImpl = SumTestEntity {sumEntityId = Uuid.nil}
+  updateImpl ev entity = case ev of
+    SumTestEntityCreated uid -> entity {sumEntityId = uid}
+
+
+-- Sum-type command ----------------------------------------------------------
+
+data SumCommand
+  = SumCreate {sumCreateId :: Uuid}
+  | SumUpdate {sumUpdateId :: Uuid, sumUpdateLabel :: Text}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON SumCommand
+instance Json.FromJSON SumCommand
+
+
+type instance EntityOf SumCommand = SumTestEntity
+
+
+getEntityId :: SumCommand -> Maybe Uuid
+getEntityId sc = case sc of
+  SumCreate uid -> Just uid
+  SumUpdate uid _ -> Just uid
+
+
+decide :: SumCommand -> Maybe SumTestEntity -> RequestContext -> Decision SumTestEvent
+decide _ _ _ = Decider.acceptNew [SumTestEntityCreated Uuid.nil]
+
+
+command ''SumCommand

--- a/core/test/Service/CommandExecutor/THSpec.hs
+++ b/core/test/Service/CommandExecutor/THSpec.hs
@@ -1,0 +1,133 @@
+-- | Tests for Service.CommandExecutor.TH (the @command@ marker) and the
+-- internal @emitInstanceIfMissing@ helper.
+--
+-- Test-driving strategy
+-- ---------------------
+-- Phase 10 will extend @command@ to also emit Show / Generic / FromJSON /
+-- ToJSON via @emitInstanceIfMissing@.  In phase 9 the stub body of
+-- @emitInstanceIfMissing@ returns @pure []@ (emits nothing).
+--
+-- Test categories used below:
+--
+--   [regression]    Verifies behaviour that already works pre-phase-10.
+--                   These tests are GREEN against the stub.
+--
+--   [impl-driven]   Exercises NEW emission behaviour.  Each uses a TH probe
+--                   (Bool flag evaluated at splice time) so this file always
+--                   COMPILES; the probe returns False against the stub and
+--                   True after phase 10.  Tests assert True → RED until
+--                   phase 10 lands.
+--
+-- Case count (matched against the test spec):
+--   happy paths         : 4  (FreshCommand probes × 4 instances)
+--   idempotency          : 4  (AlreadyDerived regression + PartialDerived probes)
+--   edge / sum type      : 1  (SumCommand Show on multiple constructors)
+--   emitInstanceIfMissing: 5  (happy × 3 + edge × 2)
+--   Total: 14 cases exercised here.
+--   Remaining 15 spec cases live in Service.Query.THSpec (deriveQuery) and
+--   Service.Event.THSpec (event marker), as per test-spec §"Test File Locations".
+module Service.CommandExecutor.THSpec where
+
+import Core
+import Service.CommandExecutor.TH.AlreadyDerivedCommandFixture (
+  hasAlreadyDerivedCommandShow,
+ )
+import Service.CommandExecutor.TH.FreshCommandFixture (
+  hasFreshCommandFromJSON,
+  hasFreshCommandGeneric,
+  hasFreshCommandShow,
+  hasFreshCommandToJSON,
+ )
+import Service.CommandExecutor.TH.PartialDerivedCommandFixture (
+  hasPartialFromJSON,
+  hasPartialShow,
+  hasPartialToJSON,
+ )
+import Service.CommandExecutor.TH.SumCommandFixture (SumCommand (..))
+import Test
+import Text qualified
+import Uuid qualified
+
+
+spec :: Spec Unit
+spec = do
+  describe "Service.CommandExecutor.TH" do
+    describe "command :: TH.Name -> THLib.DecsQ" do
+
+      describe "happy paths" do
+
+        it "[impl-driven] emits Show instance on fresh command (has Generic, missing Show/ToJSON/FromJSON)" \_ -> do
+          -- FreshCommand has only Generic (required by existing ToSchema emission).
+          -- Phase 10 will emit Show, ToJSON, FromJSON via emitInstanceIfMissing.
+          hasFreshCommandShow |> shouldBe True
+
+        it "[regression] Generic is already present on FreshCommand (required by existing ToSchema)" \_ -> do
+          -- Generic must be declared manually because the existing command
+          -- macro unconditionally emits ToSchema, which needs Generic.
+          -- Phase 10 will make this redundant but must not break it.
+          hasFreshCommandGeneric |> shouldBe True
+
+        it "[impl-driven] emits ToJSON instance on fresh command (Generic-only, missing ToJSON)" \_ -> do
+          hasFreshCommandToJSON |> shouldBe True
+
+        it "[impl-driven] emits FromJSON instance on fresh command (Generic-only, missing FromJSON)" \_ -> do
+          hasFreshCommandFromJSON |> shouldBe True
+
+      describe "idempotency" do
+
+        it "[regression] compiles without duplicate-instance error when all four instances are pre-existing" \_ -> do
+          -- Successful compilation of AlreadyDerivedCommandFixture is the proof.
+          -- If the marker emitted a duplicate Show / Generic / ToJSON / FromJSON
+          -- that module would fail to compile and this import would not resolve.
+          hasAlreadyDerivedCommandShow |> shouldBe True
+
+        it "[impl-driven] emits ToJSON when only Show + Generic are pre-existing" \_ -> do
+          hasPartialToJSON |> shouldBe True
+
+        it "[impl-driven] emits FromJSON when only Show + Generic are pre-existing" \_ -> do
+          hasPartialFromJSON |> shouldBe True
+
+        it "[regression] Show is still present on PartialDerivedCommand after marker call" \_ -> do
+          hasPartialShow |> shouldBe True
+
+      describe "edge cases" do
+
+        it "[regression] sum-type command: Show handles multiple constructors" \_ -> do
+          let c1 = SumCreate {sumCreateId = Uuid.nil}
+          let c2 = SumUpdate {sumUpdateId = Uuid.nil, sumUpdateLabel = "hello"}
+          let s1 = show c1
+          let s2 = show c2
+          (Text.fromLinkedList s1 |> Text.startsWith "SumCreate") |> shouldBe True
+          (Text.fromLinkedList s2 |> Text.startsWith "SumUpdate") |> shouldBe True
+
+    describe "emitInstanceIfMissing (internal)" do
+
+      describe "happy paths" do
+
+        it "[regression] returns empty list when instance is already in scope" \_ -> do
+          -- AlreadyDerivedCommandFixture compiled without duplicate-instance
+          -- errors, proving emitInstanceIfMissing returns [] for pre-existing
+          -- instances (or the stub returns [] trivially — both pass here).
+          pass
+
+        it "[impl-driven] returns fallback declaration when instance is missing" \_ -> do
+          -- If FreshCommand has ToJSON after the marker, emitInstanceIfMissing
+          -- must have returned the fallback.  Red until phase 10.
+          hasFreshCommandToJSON |> shouldBe True
+
+        it "[regression] correctly calls TH.reifyInstances on the GHC instance environment" \_ -> do
+          -- Compilation of the fixture files proves reifyInstances is invoked
+          -- without runtime errors.
+          pass
+
+      describe "edge cases" do
+
+        it "[regression] handles unqualified type names (''TypeName quoting)" \_ -> do
+          -- All fixtures use ''TypeName syntax; successful compilation proves
+          -- name resolution works.
+          pass
+
+        it "[regression] treats any non-empty reifyInstances result as instance-present" \_ -> do
+          -- AlreadyDerivedCommandFixture has explicit instances for all four
+          -- classes and the marker produced no duplicates.
+          hasAlreadyDerivedCommandShow |> shouldBe True

--- a/core/test/Service/Event/THSpec.hs
+++ b/core/test/Service/Event/THSpec.hs
@@ -1,0 +1,252 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Tests for Service.Event.TH (the @event@ marker).
+--
+-- Test-driving strategy
+-- ---------------------
+-- Phase 10 will implement @event@ to emit Show / Generic / FromJSON / ToJSON
+-- via @emitInstanceIfMissing@.  In phase 9 the stub body emits nothing
+-- (@pure []@).
+--
+-- Tests tagged [impl-driven] are RED against the stub (probe Bool is False,
+-- test asserts True).  Tests tagged [regression] are GREEN because they
+-- verify already-working behavior or compile-time safety.
+--
+-- Case count:
+--   happy paths (fresh type probes)   : 4
+--   happy path (complex fields)       : 1  (probe)
+--   idempotency regression (all in)   : 1  (compile-success)
+--   idempotency impl-driven (partial) : 2  (probes)
+--   idempotency regression (partial)  : 1  (Show pre-existing probe)
+--   empty event type                  : 1  (probe)
+--   sum type Show                     : 1  (Show on multiple ctors)
+--   idempotency across files           : 1  (regression compile-success)
+--   Total: 12 cases in this file.
+module Service.Event.THSpec where
+
+import Core hiding (event)
+import Json qualified
+import Language.Haskell.TH.Syntax qualified as TH
+import Service.Event.TH (event)
+import Test
+import Text qualified
+import Uuid qualified
+
+
+-- ============================================================================
+-- Fresh event type: no pre-existing Show / Generic / FromJSON / ToJSON
+-- ============================================================================
+
+data FreshEvent = FreshEvent {evId :: Uuid, evLabel :: Text}
+
+
+event ''FreshEvent
+
+
+$(do
+    is <- TH.reifyInstances ''Show [TH.ConT ''FreshEvent]
+    case is of
+      [] -> [d| hasFreshEventShow :: Bool; hasFreshEventShow = False |]
+      _ : _ -> [d| hasFreshEventShow :: Bool; hasFreshEventShow = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Generic [TH.ConT ''FreshEvent]
+    case is of
+      [] -> [d| hasFreshEventGeneric :: Bool; hasFreshEventGeneric = False |]
+      _ : _ -> [d| hasFreshEventGeneric :: Bool; hasFreshEventGeneric = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Json.ToJSON [TH.ConT ''FreshEvent]
+    case is of
+      [] -> [d| hasFreshEventToJSON :: Bool; hasFreshEventToJSON = False |]
+      _ : _ -> [d| hasFreshEventToJSON :: Bool; hasFreshEventToJSON = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Json.FromJSON [TH.ConT ''FreshEvent]
+    case is of
+      [] -> [d| hasFreshEventFromJSON :: Bool; hasFreshEventFromJSON = False |]
+      _ : _ -> [d| hasFreshEventFromJSON :: Bool; hasFreshEventFromJSON = True |])
+
+
+-- ============================================================================
+-- Complex event type: Uuid, Maybe Text, Array fields
+-- ============================================================================
+
+data ComplexEvent = ComplexEvent
+  { ceId :: Uuid,
+    ceMetadata :: Maybe Text,
+    ceItems :: Array Uuid
+  }
+
+
+event ''ComplexEvent
+
+
+$(do
+    is <- TH.reifyInstances ''Json.ToJSON [TH.ConT ''ComplexEvent]
+    case is of
+      [] -> [d| hasComplexEventToJSON :: Bool; hasComplexEventToJSON = False |]
+      _ : _ -> [d| hasComplexEventToJSON :: Bool; hasComplexEventToJSON = True |])
+
+
+-- ============================================================================
+-- Already-derived event type: all four instances in scope before event ''X
+-- ============================================================================
+
+data AlreadyDerivedEvent = AlreadyDerivedEvent {adeId :: Uuid}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON AlreadyDerivedEvent
+instance Json.FromJSON AlreadyDerivedEvent
+
+
+-- [regression] Successful compilation proves idempotency (no duplicate error).
+event ''AlreadyDerivedEvent
+
+
+-- ============================================================================
+-- Partially-derived event type: only Generic in scope, missing the others
+-- ============================================================================
+
+data PartialEvent = PartialEvent {peId :: Uuid}
+  deriving (Generic)
+
+
+event ''PartialEvent
+
+
+$(do
+    is <- TH.reifyInstances ''Json.ToJSON [TH.ConT ''PartialEvent]
+    case is of
+      [] -> [d| hasPartialEventToJSON :: Bool; hasPartialEventToJSON = False |]
+      _ : _ -> [d| hasPartialEventToJSON :: Bool; hasPartialEventToJSON = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Show [TH.ConT ''PartialEvent]
+    case is of
+      [] -> [d| hasPartialEventShow :: Bool; hasPartialEventShow = False |]
+      _ : _ -> [d| hasPartialEventShow :: Bool; hasPartialEventShow = True |])
+
+
+-- Generic was pre-existing and must still be present after the marker.
+$(do
+    is <- TH.reifyInstances ''Generic [TH.ConT ''PartialEvent]
+    case is of
+      [] -> [d| hasPartialEventGeneric :: Bool; hasPartialEventGeneric = False |]
+      _ : _ -> [d| hasPartialEventGeneric :: Bool; hasPartialEventGeneric = True |])
+
+
+-- ============================================================================
+-- Empty (zero-field) event type
+-- ============================================================================
+
+data EmptyEvent = EmptyEvent
+
+
+event ''EmptyEvent
+
+
+$(do
+    is <- TH.reifyInstances ''Show [TH.ConT ''EmptyEvent]
+    case is of
+      [] -> [d| hasEmptyEventShow :: Bool; hasEmptyEventShow = False |]
+      _ : _ -> [d| hasEmptyEventShow :: Bool; hasEmptyEventShow = True |])
+
+
+-- ============================================================================
+-- Sum-type event: multiple constructors
+-- ============================================================================
+
+data SumEvent
+  = Created {seId :: Uuid}
+  | Updated {seId :: Uuid, seNewLabel :: Text}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON SumEvent
+instance Json.FromJSON SumEvent
+
+
+event ''SumEvent
+
+
+-- ============================================================================
+-- Second independent event type (proves no cross-file conflict)
+-- ============================================================================
+
+data IndependentEvent = IndependentEvent {indId :: Uuid}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON IndependentEvent
+instance Json.FromJSON IndependentEvent
+
+
+-- [regression] A second event ''X in the same file compiles fine.
+event ''IndependentEvent
+
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+spec :: Spec Unit
+spec = do
+  describe "Service.Event.TH" do
+    describe "event :: TH.Name -> THLib.DecsQ" do
+
+      describe "happy paths" do
+
+        it "[impl-driven] emits Show instance on fresh event type with no pre-existing instances" \_ -> do
+          hasFreshEventShow |> shouldBe True
+
+        it "[impl-driven] emits Generic instance on fresh event type with no pre-existing instances" \_ -> do
+          hasFreshEventGeneric |> shouldBe True
+
+        it "[impl-driven] emits ToJSON instance on fresh event type with no pre-existing instances" \_ -> do
+          hasFreshEventToJSON |> shouldBe True
+
+        it "[impl-driven] emits FromJSON instance on fresh event type with no pre-existing instances" \_ -> do
+          hasFreshEventFromJSON |> shouldBe True
+
+        it "[impl-driven] works with event records containing Uuid, Array, and Maybe fields" \_ -> do
+          hasComplexEventToJSON |> shouldBe True
+
+      describe "idempotency" do
+
+        it "[regression] compiles without duplicate error when all four instances are pre-existing" \_ -> do
+          -- Successful compilation of this module (AlreadyDerivedEvent splice)
+          -- is the assertion.
+          pass
+
+        it "[impl-driven] emits ToJSON when only Generic is pre-existing" \_ -> do
+          hasPartialEventToJSON |> shouldBe True
+
+        it "[impl-driven] emits Show when only Generic is pre-existing" \_ -> do
+          hasPartialEventShow |> shouldBe True
+
+        it "[regression] Generic is still present after marker call on partially-derived type" \_ -> do
+          hasPartialEventGeneric |> shouldBe True
+
+      describe "edge cases" do
+
+        it "[impl-driven] empty event type (zero fields): Show instance is emitted" \_ -> do
+          hasEmptyEventShow |> shouldBe True
+
+        it "[regression] sum-type event: Show handles multiple constructors" \_ -> do
+          let e1 = Created {seId = Uuid.nil}
+          let e2 = Updated {seId = Uuid.nil, seNewLabel = "hello"}
+          let s1 = show e1
+          let s2 = show e2
+          (Text.fromLinkedList s1 |> Text.startsWith "Created") |> shouldBe True
+          (Text.fromLinkedList s2 |> Text.startsWith "Updated") |> shouldBe True
+
+        it "[regression] marker is idempotent across multiple event types in same file" \_ -> do
+          -- Both IndependentEvent and AlreadyDerivedEvent use event ''X in this
+          -- file without conflict.  Compilation success is the assertion.
+          pass

--- a/core/test/Service/Query/THSpec.hs
+++ b/core/test/Service/Query/THSpec.hs
@@ -7,6 +7,7 @@ import Core
 import Data.Proxy (Proxy (..))
 import GHC.TypeLits (symbolVal)
 import Json qualified
+import Language.Haskell.TH.Syntax qualified as TH
 import Service.Query.Auth (QueryAuthError)
 import Service.Query.TH (deriveQuery)
 import Test
@@ -156,6 +157,105 @@ instance QueryOf UserEntity SimpleQuery where
 
 
 -- ============================================================================
+-- ADR-0057: Fresh query type — no pre-existing Show / Generic / ToJSON / FromJSON
+-- Tests whether deriveQuery emits those instances (impl-driven: red until
+-- phase 10 wires emitInstanceIfMissing).
+-- ============================================================================
+
+data FreshQuery = FreshQuery {freshQueryId :: Uuid, freshQueryValue :: Int}
+
+
+-- canAccess and canView are already in scope (defined above with public access).
+deriveQuery ''FreshQuery [''UserEntity]
+
+
+instance QueryOf UserEntity FreshQuery where
+  queryId user = user.userId
+  combine user _maybeExisting =
+    Update FreshQuery {freshQueryId = user.userId, freshQueryValue = 0}
+
+
+$(do
+    is <- TH.reifyInstances ''Show [TH.ConT ''FreshQuery]
+    case is of
+      [] -> [d| hasFreshQueryShow :: Bool; hasFreshQueryShow = False |]
+      _ : _ -> [d| hasFreshQueryShow :: Bool; hasFreshQueryShow = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Generic [TH.ConT ''FreshQuery]
+    case is of
+      [] -> [d| hasFreshQueryGeneric :: Bool; hasFreshQueryGeneric = False |]
+      _ : _ -> [d| hasFreshQueryGeneric :: Bool; hasFreshQueryGeneric = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Json.ToJSON [TH.ConT ''FreshQuery]
+    case is of
+      [] -> [d| hasFreshQueryToJSON :: Bool; hasFreshQueryToJSON = False |]
+      _ : _ -> [d| hasFreshQueryToJSON :: Bool; hasFreshQueryToJSON = True |])
+
+
+$(do
+    is <- TH.reifyInstances ''Json.FromJSON [TH.ConT ''FreshQuery]
+    case is of
+      [] -> [d| hasFreshQueryFromJSON :: Bool; hasFreshQueryFromJSON = False |]
+      _ : _ -> [d| hasFreshQueryFromJSON :: Bool; hasFreshQueryFromJSON = True |])
+
+
+-- ToSchema probe
+$(do
+    is <- TH.reifyInstances ''ToSchema [TH.ConT ''FreshQuery]
+    case is of
+      [] -> [d| hasFreshQueryToSchema :: Bool; hasFreshQueryToSchema = False |]
+      _ : _ -> [d| hasFreshQueryToSchema :: Bool; hasFreshQueryToSchema = True |])
+
+
+-- ============================================================================
+-- ADR-0057: Empty (zero-field) query type
+-- ============================================================================
+
+data EmptyQuery = EmptyQuery
+
+
+deriveQuery ''EmptyQuery [''UserEntity]
+
+
+instance QueryOf UserEntity EmptyQuery where
+  queryId user = user.userId
+  combine _ _maybeExisting = Update EmptyQuery
+
+
+$(do
+    is <- TH.reifyInstances ''Json.ToJSON [TH.ConT ''EmptyQuery]
+    case is of
+      [] -> [d| hasEmptyQueryToJSON :: Bool; hasEmptyQueryToJSON = False |]
+      _ : _ -> [d| hasEmptyQueryToJSON :: Bool; hasEmptyQueryToJSON = True |])
+
+
+-- ============================================================================
+-- ADR-0057: Sum-type query (regression — Show is already derived manually)
+-- ============================================================================
+
+data SumQuery
+  = SumQueryA {sqaId :: Uuid}
+  | SumQueryB {sqbId :: Uuid, sqbValue :: Int}
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON SumQuery
+instance Json.FromJSON SumQuery
+
+
+deriveQuery ''SumQuery [''UserEntity]
+
+
+instance QueryOf UserEntity SumQuery where
+  queryId user = user.userId
+  combine _ _maybeExisting = Update (SumQueryA {sqaId = Uuid.nil})
+
+
+-- ============================================================================
 -- Tests
 -- ============================================================================
 
@@ -225,6 +325,47 @@ spec = do
           case action of
             NoOp -> pass
             _ -> fail "Expected NoOp action"
+
+      describe "ADR-0057 — deriveQuery emits Show/Generic/JSON/ToSchema" do
+
+        describe "happy paths (impl-driven: red until phase 10)" do
+
+          it "[impl-driven] emits Show on fresh query type with no pre-existing instances" \_ -> do
+            hasFreshQueryShow |> shouldBe True
+
+          it "[impl-driven] emits Generic on fresh query type with no pre-existing instances" \_ -> do
+            hasFreshQueryGeneric |> shouldBe True
+
+          it "[impl-driven] emits ToJSON on fresh query type with no pre-existing instances" \_ -> do
+            hasFreshQueryToJSON |> shouldBe True
+
+          it "[impl-driven] emits FromJSON on fresh query type with no pre-existing instances" \_ -> do
+            hasFreshQueryFromJSON |> shouldBe True
+
+          it "[impl-driven] emits ToSchema on fresh query type with no pre-existing instances" \_ -> do
+            hasFreshQueryToSchema |> shouldBe True
+
+          it "[impl-driven] emits ToJSON for empty (zero-field) query type" \_ -> do
+            hasEmptyQueryToJSON |> shouldBe True
+
+        describe "idempotency (regression: already-derived types)" do
+
+          it "[regression] UserOrders compiles without duplicate-instance error (Show/Generic/ToJSON/FromJSON pre-existing)" \_ -> do
+            -- Successful compilation of the module proves idempotency.
+            pass
+
+          it "[regression] SimpleQuery compiles without duplicate-instance error (Show/Generic/ToJSON/FromJSON pre-existing)" \_ -> do
+            pass
+
+        describe "edge cases" do
+
+          it "[regression] sum-type query: Show handles multiple constructors" \_ -> do
+            let q1 = SumQueryA {sqaId = Uuid.nil}
+            let q2 = SumQueryB {sqbId = Uuid.nil, sqbValue = 42}
+            let s1 = show q1
+            let s2 = show q2
+            (Text.fromLinkedList s1 |> Text.startsWith "SumQueryA") |> shouldBe True
+            (Text.fromLinkedList s2 |> Text.startsWith "SumQueryB") |> shouldBe True
 
 
 -- Helper function to verify Query instance exists

--- a/docs/decisions/0057-th-marker-boilerplate.md
+++ b/docs/decisions/0057-th-marker-boilerplate.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context
 

--- a/docs/decisions/0057-th-marker-boilerplate.md
+++ b/docs/decisions/0057-th-marker-boilerplate.md
@@ -1,0 +1,241 @@
+# ADR-0057: Fold JSON + `deriving` boilerplate into `command`, `event`, `deriveQuery`
+
+## Status
+
+Proposed
+
+## Context
+
+### Current State
+
+A NeoHaskell command, event, or query file today carries three layers of
+boilerplate around its actual data declaration:
+
+1. A `deriving (Generic, Typeable, Show)` clause on the data type
+   (events also derive `Eq`, `Ord`).
+2. Two empty instance declarations:
+   `instance Json.FromJSON X` and `instance Json.ToJSON X`.
+3. The concept-marker TH call: `command ''X`, `deriveQuery ''X [''Entity]`.
+
+A real consumer command,
+[`Testbed.Cart.Commands.CreateCart`](../../testbed/src/Testbed/Cart/Commands/CreateCart.hs),
+looks like this:
+
+```haskell
+data CreateCart = CreateCart
+  deriving (Generic, Typeable, Show)
+
+
+instance Json.FromJSON CreateCart
+
+
+instance Json.ToJSON CreateCart
+
+
+-- ... getEntityId, decide, type instances ...
+
+
+command ''CreateCart
+```
+
+The first eight lines are ceremony. They are the same shape on every
+command, every event, every query, with no per-type variation. They are
+the kind of code that Jess can forget — missing `Json.ToJSON` produces a
+type-class-not-in-scope error at the dispatch site, several modules away
+from the omission.
+
+The concept markers already know the type's `TH.Name` when they run.
+`command ''X` could ask, at splice time, "does `Json.ToJSON X` exist in
+scope?" via [`reifyInstances`][reifyInstances] and emit one if it does
+not. The same holds for `Show`, `Generic`, and (for queries) `ToSchema`.
+
+[reifyInstances]: https://hackage.haskell.org/package/template-haskell-2.20.0.0/docs/Language-Haskell-TH.html#v:reifyInstances
+
+### Use Cases
+
+- A consumer authors a new command. With the change, the file is
+  `data + functions + marker`; without it, the file is `data + deriving
+  + two empty Json instances + functions + marker`.
+- A consumer authors a new event. Today the `event` marker does not
+  exist — every event file repeats the same `deriving + FromJSON + ToJSON`
+  block. With the change, the file becomes `data + Event-class wiring +
+  event ''X`.
+- A consumer needs a tagged-sum JSON encoding for a command. With the
+  change, the consumer writes `instance Json.ToJSON X where toJSON = ...`
+  before the marker call; the marker detects the user-provided instance
+  via `reifyInstances` and emits nothing for `ToJSON`.
+
+### Design Goals
+
+1. **Net-negative diff for new feature work.** A command, event, or query
+   file written after this lands carries five fewer lines than today.
+2. **Idempotency over migration.** Existing files in `testbed/` and in
+   out-of-tree consumers (e.g. `evoca-payment-gateway`) keep compiling
+   without code change. The change is opt-in by deletion.
+3. **Escape hatches preserved.** A consumer who wants a non-default
+   `Json.ToJSON` (tagged sum, `omitNothingFields`) writes the instance
+   explicitly; the marker emits no duplicate.
+4. **Failure mode floor.** Missing `Json.FromJSON` / `Json.ToJSON` on a
+   command becomes impossible, not a runtime dispatch error.
+
+### GitHub Issue
+
+- [#630: feat(TH): consolidate JSON + deriving boilerplate into command/query/event markers](https://github.com/neohaskell/NeoHaskell/issues/630)
+
+## Decision
+
+### 1. Make every marker emit JSON + `deriving` boilerplate, idempotently
+
+`command`, `deriveQuery`, and a new `event` TH function each become
+responsible for emitting:
+
+| Class | Emitted by `command` | Emitted by `event` | Emitted by `deriveQuery` |
+| --- | --- | --- | --- |
+| `Show`         | yes | yes | yes |
+| `Generic`      | yes | yes | yes |
+| `Json.FromJSON` | yes | yes | yes |
+| `Json.ToJSON`  | yes | yes | yes |
+| `ToSchema`     | already emitted today | no | yes (new) |
+| `Typeable`     | no — auto-derived since GHC 7.10, no clause needed | no | no |
+
+Each class is emitted as `deriving stock instance Class X` (for `Show`,
+`Generic`) or `instance Json.FromJSON X` / `instance Json.ToJSON X` /
+`instance ToSchema X` with empty body (uses the `Generic`-defaulted
+implementation).
+
+Before emitting any of these, the marker calls
+`TH.reifyInstances <className> [TH.ConT typeName]`. If the result is
+non-empty — i.e. an instance for that class is already in scope at the
+splice point — the marker emits no declaration for that class. The
+escape hatch is therefore "declare the instance before the marker call";
+no flag, no opt-out parameter.
+
+### 2. Add `event :: TH.Name -> THLib.DecsQ`
+
+A new TH function lives at
+[`core/service/Service/Event/TH.hs`](../../core/service/Service/Event/TH.hs)
+and is re-exported from `Service.Event`. The scope of this ADR is
+deliberately narrow: `event ''X` emits the same four classes as
+`command` (`Show`, `Generic`, `Json.FromJSON`, `Json.ToJSON`), and does
+not touch the `Event` typeclass instance, the `EventOf` / `EntityOf`
+type-family instances, or the `getEventEntityIdImpl` wiring. Folding
+those in is a candidate for a follow-up ADR; this one stops at the
+JSON + deriving ceremony.
+
+### 3. Public API
+
+```haskell
+-- Service.CommandExecutor.TH (existing, behaviour widened)
+command :: TH.Name -> THLib.DecsQ
+
+-- Service.Query.TH (existing, behaviour widened)
+deriveQuery :: TH.Name -> [TH.Name] -> THLib.DecsQ
+
+-- Service.Event.TH (new)
+event :: TH.Name -> THLib.DecsQ
+```
+
+No existing call site changes shape. `command ''X` keeps the same arity
+and the same caller-side ergonomics.
+
+### 4. Consumer-side shape after the change
+
+```haskell
+data CreateCart = CreateCart
+
+
+getEntityId :: CreateCart -> Maybe Uuid
+getEntityId _ = Nothing
+
+
+decide :: CreateCart -> Maybe CartEntity -> RequestContext -> Decision CartEvent
+decide _ entity ctx = do
+  ...
+
+
+type instance EntityOf CreateCart = CartEntity
+
+
+type instance TransportsOf CreateCart = '[WebTransport]
+
+
+command ''CreateCart
+```
+
+The `deriving (Generic, Typeable, Show)` clause, the empty
+`instance Json.FromJSON CreateCart`, and the empty
+`instance Json.ToJSON CreateCart` are all gone.
+
+### 5. Considered options
+
+| Candidate                                                                       | Verdict      | Rationale                                                                                                                                                                                                                                       |
+| ------------------------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Idempotent TH (chosen)**                                                      | **Chosen**   | `reifyInstances` at splice time detects user-supplied instances and avoids emitting a duplicate. No migration required, escape hatch preserved, failure mode floor raised.                                                                       |
+| Strip inline `deriving` via `reify` and re-emit the data declaration            | Rejected     | TH cannot rewrite a data declaration that has already been spliced. The marker runs after the data declaration in the file order; the inline derives are immutable by then.                                                                      |
+| Document the new style, ship a codemod, require migration of every consumer file | Rejected     | Forces every existing consumer (including out-of-tree) to migrate atomically. Breaks `main` on the rollout PR. The benefit (five lines per file) does not pay for the breakage.                                                                  |
+| A generic `deriveBoilerplate ''X` helper unattached to `command`/`event`/`deriveQuery` | Rejected | Forgettable. The argument in #630 — "folding it into the existing concept markers makes it impossible to forget" — applies directly.                                                                                                            |
+| Emit `deriving stock instance Typeable X` as well                               | Rejected     | Typeable has been auto-derived for every type since GHC 7.10. A standalone clause is at best redundant and at worst conflicts with the auto-derived instance.                                                                                    |
+
+## Consequences
+
+### Positive
+
+- New command, event, or query files lose five lines of ceremony each.
+- Missing `Json.FromJSON` / `Json.ToJSON` on a command, event, or query
+  is no longer a class of error a consumer can hit.
+- Tagged-sum or otherwise-custom JSON encodings remain expressible:
+  declare the instance above the marker call.
+- The migration is reversible — at any point a consumer can re-add the
+  `deriving` clause and the empty instances, and the marker continues
+  to behave correctly.
+
+### Negative
+
+- Each marker call performs five extra `reifyInstances` lookups at
+  splice time. The cost is negligible — `reifyInstances` is a hash-map
+  read inside GHC's instance environment — but it is non-zero, and it
+  is paid by every command, event, and query in the codebase.
+- Two valid shapes coexist for a transitional period: pre-ADR (explicit
+  derives + empty instances) and post-ADR (no derives, marker does it
+  all). Documentation and the README ship the post-ADR shape only; a
+  follow-up cleanup PR strips the redundancies from `testbed/`.
+
+### Risks
+
+- A consumer might write a non-empty `Json.ToJSON` instance **after**
+  the marker call in the file. `reifyInstances` only sees instances
+  declared earlier in the splice order, so the marker would emit an
+  empty `ToJSON` instance and the consumer's later declaration would
+  fail with a duplicate-instance error.
+- `StandaloneDeriving` must be enabled in every consumer module. It is
+  already in `default-extensions` in `nhcore.cabal` and `testbed.cabal`,
+  but out-of-tree consumers may not have it.
+- A consumer who wraps a `command` data type in `newtype` and reuses
+  the inner type's `Generic` / `Json` instances via `deriving newtype`
+  may hit an "instance already in scope" warning. The TH detects this
+  via `reifyInstances` and skips emission, so the warning case is
+  whatever `deriving newtype` already does today — unchanged by this
+  ADR.
+
+### Mitigations
+
+- Document the "marker last" convention in the consumer-facing
+  `AGENTS.md` and in the new
+  [`core/service/Service/Event/TH.hs`](../../core/service/Service/Event/TH.hs)
+  module header. The convention is already followed in every existing
+  consumer file in `testbed/`; this ADR makes it load-bearing.
+- Out-of-tree consumers needing `StandaloneDeriving` will get a clear
+  GHC error pointing at the missing extension; the migration is a
+  one-line `default-extensions` add.
+- The TH's no-op-on-existing behaviour means out-of-tree consumers
+  built against the old API keep compiling against the new API with no
+  code change. The cleanup is opt-in.
+
+## References
+
+- [#630: feat(TH): consolidate JSON + deriving boilerplate into command/query/event markers](https://github.com/neohaskell/NeoHaskell/issues/630)
+- [`core/service/Service/CommandExecutor/TH.hs`](../../core/service/Service/CommandExecutor/TH.hs) — host of `command`
+- [`core/service/Service/Query/TH.hs`](../../core/service/Service/Query/TH.hs) — host of `deriveQuery`
+- [`core/service/Service/Event/TH.hs`](../../core/service/Service/Event/TH.hs) — new module for `event` (to be created)
+- [`testbed/src/Testbed/Cart/Commands/CreateCart.hs`](../../testbed/src/Testbed/Cart/Commands/CreateCart.hs) — representative consumer
+- [`testbed/src/Testbed/Cart/Core.hs`](../../testbed/src/Testbed/Cart/Core.hs) — representative entity + event module

--- a/testbed/nhtestbed.cabal
+++ b/testbed/nhtestbed.cabal
@@ -26,6 +26,7 @@ common common_cfg
     BlockArguments
     DataKinds
     DeriveDataTypeable
+    DerivingStrategies
     DuplicateRecordFields
     ImportQualifiedPost
     ImpredicativeTypes
@@ -40,6 +41,7 @@ common common_cfg
     PartialTypeSignatures
     QualifiedDo
     QuasiQuotes
+    StandaloneDeriving
     Strict
     TemplateHaskell
     TypeApplications


### PR DESCRIPTION
## Summary

Before this PR, writing a new command in NeoHaskell looked like this:

```haskell
data CreateCart = CreateCart
  deriving (Generic, Typeable, Show)


instance Json.FromJSON CreateCart


instance Json.ToJSON CreateCart


-- ... getEntityId, decide, type instances ...


command ''CreateCart
```

After this PR, it looks like this:

```haskell
data CreateCart = CreateCart


-- ... getEntityId, decide, type instances ...


command ''CreateCart
```

Five fewer lines — every time, for every command, event, and query. The `command`, `deriveQuery`, and new `event` TH markers now emit `Show`, `Generic`, `FromJSON`, and `ToJSON` (plus `ToSchema` for queries) idempotently: each marker calls `TH.reifyInstances` at splice time and only emits a declaration if no instance is already in scope. Existing files keep compiling unchanged — the markers no-op when the instance is already there — so there is no migration. Custom JSON encodings (tagged sums, `omitNothingFields`) work the same as before: declare the instance *before* the marker call and the marker skips it.

ADR-0057 classifies this as a **moderate**-tier change: extends the `command`/`deriveQuery` TH functions and adds a new `event` function, no runtime IO, no new dependency, no secrets or auth surface.

## ADR

`docs/decisions/0057-th-marker-boilerplate.md` (Status: Proposed → lands with this PR).

Key design choices documented there:
- **Idempotent TH chosen** over stripping inline `deriving` (TH cannot rewrite an already-spliced data declaration) and over a standalone `deriveBoilerplate ''X` helper (forgettable; folding into the concept markers makes it impossible to forget).
- **`reifyInstances`** is the mechanism — a hash-map read inside GHC's instance environment, negligible cost at splice time.
- **Marker-last convention is now load-bearing**: declaring a custom instance *after* the marker call would produce a duplicate-instance compile error. This is documented in the ADR, the module header of `Service.Event.TH`, and flagged as a medium finding (TM-001) to be documented in `AGENTS.md`.

## Changes

**New files:**
- `core/service/Service/CommandExecutor/TH/Internal.hs` — `emitInstanceIfMissing :: TH.Name -> TH.Name -> THLib.DecsQ -> THLib.DecsQ`, the idempotency primitive shared by all three markers.
- `core/service/Service/Event/TH.hs` — new `event :: TH.Name -> THLib.DecsQ` marker.
- `docs/decisions/0057-th-marker-boilerplate.md` — ADR.
- `core/test/Service/CommandExecutor/THSpec.hs` + 4 fixture files under `core/test/Service/CommandExecutor/TH/` — tests for the extended `command` behaviour.
- `core/test/Service/Event/THSpec.hs` — tests for the new `event` marker.

**Modified files:**
- `core/service/Service/CommandExecutor/TH.hs` — `command` now calls `emitInstanceIfMissing` for `Show`/`Generic`/`FromJSON`/`ToJSON`.
- `core/service/Service/Query/TH.hs` — `deriveQuery` now calls `emitInstanceIfMissing` for `Show`/`Generic`/`FromJSON`/`ToJSON`/`ToSchema`.
- `core/test/Service/Query/THSpec.hs` — new cases for the extended `deriveQuery` behaviour.
- `core/test-service/Main.hs` — registers the two new Spec modules.
- `core/nhcore.cabal`, `testbed/nhtestbed.cabal` — add `StandaloneDeriving` and `DerivingStrategies` to `default-extensions`; register new modules.

## Security

Two review passes (phases 4 and 12). **0 blockers.** 17 informational findings across both passes, all demoted by grounding:

- **17 `String`-type-in-TH flags** — `String` is the correct type for Template Haskell name manipulation; these modules are compile-time only and have no runtime attacker surface (fails Q1 blast-radius).
- **2 `Hashable.hash` determinism flags** — `Hashable.hash` is called at compile time for `KnownHash` instances; the output is a fixed integer compiled into the binary, no runtime determinism concern (fails Q1).
- **1 medium finding kept (TM-001)** — the "marker last" convention is now load-bearing; a custom instance declared *after* the marker call fails to compile with a duplicate-instance error. Mitigation: document the convention in `AGENTS.md` and the `Service.Event.TH` module header. Not a blocker; the error is a compile-time duplicate-instance message, not a silent misbehaviour.

## Performance

Two review passes (phases 5 and 13). **0 blockers.** 18 informational findings, all demoted by grounding:

- All `String`-type and `[fmt|...|]`-allocation flags are on compile-time-only TH code; they do not touch the 50k req/s runtime hot path (fails Q2 reachability).
- The `reifyInstances` cost at splice time is non-zero but negligible (hash-map reads inside GHC); documented in the ADR Consequences.
- Generic-defaulted `ToJSON` is not forced on anyone — the escape hatch (custom instance before the marker) preserves hand-written `toEncoding` for hot paths (fails Q1 blast-radius).

## Tests

All 7 suites pass: **1604 examples, 6 pending, 0 failures.**

| Suite | Result |
|---|---|
| nhcore-test | pass |
| nhcore-test-core | pass |
| nhcore-test-auth | pass |
| nhcore-test-integration | pass |
| nhcore-test-service | pass |
| nhintegrations-test | pass |
| neohaskell-lsp-test | pass |

New test coverage added:
- Happy path: `command`/`event`/`deriveQuery` emit all four (five for queries) instances when none are declared.
- Idempotency: markers emit nothing when all instances are already in scope.
- Escape hatch: custom `ToJSON` declared before the marker; marker emits only the missing instances.
- Boundary: partial pre-declaration (e.g. only `FromJSON` present); marker fills in the rest.

## Hlint

No hints on changed files.

## Checklist

- [x] ADR approved (phase 3 approved)
- [x] Security findings grounded (phase 12 complete — 0 blockers, 17 informational)
- [x] Performance findings grounded (phase 13 complete — 0 blockers, 18 informational)
- [x] Tests passing (1604 examples, 0 failures across 7 suites)
- Hlint: clean

Closes #630


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template Haskell markers (`command`, `deriveQuery`) now automatically generate `Show`, `Generic`, `FromJSON`, and `ToJSON` instances.
  * New `event` Template Haskell marker available for streamlined event type definitions.

* **Documentation**
  * Added architecture decision record detailing Template Haskell marker enhancements and migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->