### PR TITLE
Split cloud provisioning into a cached setup script + slim SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,23 +2,22 @@
 #
 # SessionStart hook for Claude Code on the web.
 #
-# NeoHaskell builds entirely through `nix develop --command ...`, so a remote
-# session is only useful once Nix is installed, the haskell.nix toolchain is
-# pulled from the binary caches, and `cabal` can resolve packages. This hook
-# provisions all of that.
+# The heavy provisioning — installing Nix, configuring the binary caches, and
+# warming the haskell.nix dev shell — now lives in the cloud environment's
+# **setup script** (configured in the Claude Code web UI, see
+# scripts/cloud-setup.sh). A setup script runs once and is snapshotted, so
+# /nix/store and the cabal index are already on disk when a session starts and
+# never have to be re-pulled.
 #
-# IMPORTANT — network policy:
-#   The build relies on two Nix binary caches. The environment's network
-#   policy MUST allow outbound HTTPS to:
-#     - cache.iog.io            (haskell.nix / GHC)
-#     - neohaskell.cachix.org   (project + dev-shell tools)
-#     - cache.nixos.org         (nixpkgs)
-#     - releases.nixos.org      (the Nix installer payload)
-#     - github.com / objects.githubusercontent.com / raw.githubusercontent.com
-#     - hackage.haskell.org     (cabal update)
-#   Without the first two, Nix falls back to compiling GHC and every dependency
-#   from source (~30+ min and likely to time out). If you see
-#   "Host not in allowlist" 403s below, widen the environment's network policy.
+# This hook only does the per-session work a snapshot cannot capture:
+#   1. Put Nix on PATH for every Bash tool call (env vars are not snapshotted).
+#   2. Kick a best-effort background `cabal build all` to warm dist-newstyle
+#      (the repo is cloned fresh each session, so a build never carries over).
+#
+# Network policy reminder: the setup script needs outbound HTTPS to the Nix
+# binary caches (cache.iog.io, neohaskell.cachix.org, cache.nixos.org,
+# releases.nixos.org) plus github.com and hackage.haskell.org. Configure these
+# in the environment's allowed hosts.
 #
 set -euo pipefail
 
@@ -27,60 +26,25 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-# Run asynchronously: the session starts immediately while this provisions Nix,
-# the toolchain, and the cabal index in the background. The JSON control line
-# must be the first thing written to stdout. Timeout is generous because a cold
-# dev-shell pull + cabal build can take a while.
+# Run asynchronously so the session is usable immediately while the build warms
+# in the background. The JSON control line must be the first thing on stdout.
 echo '{"async": true, "asyncTimeout": 1800000}'
 
 NIX_PROFILE_BIN="/nix/var/nix/profiles/default/bin"
-NIX_CUSTOM_CONF="/etc/nix/nix.custom.conf"
-
-IOG_KEY="hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-NEO_KEY="neohaskell.cachix.org-1:mo2cLaGbwqbrxs9xhqKK8jeNsn3osi7t6XoAmxSZssc="
-SUBSTITUTERS="https://cache.iog.io https://neohaskell.cachix.org"
 
 log() { printf '\n=== %s ===\n' "$*"; }
 
-# --- 1. Install Nix (idempotent) -------------------------------------------
-# Uses the Determinate nix-installer binary fetched straight from GitHub
-# releases (no dependency on install.determinate.systems, which may be blocked).
-# --prefer-upstream-nix pulls upstream Nix from releases.nixos.org.
-# --init none installs a root-only Nix (the container has no systemd).
+# --- 1. Put Nix on PATH for this hook and all future tool calls -------------
+# The setup-script snapshot leaves Nix on disk, but per-session env vars are not
+# captured, so PATH is re-exported every session via $CLAUDE_ENV_FILE.
 if [ ! -x "${NIX_PROFILE_BIN}/nix" ]; then
-  log "Installing Nix"
-  installer="$(mktemp)"
-  curl --proto '=https' --tlsv1.2 -fsSL \
-    "https://github.com/DeterminateSystems/nix-installer/releases/latest/download/nix-installer-x86_64-linux" \
-    -o "${installer}"
-  chmod +x "${installer}"
-  "${installer}" install linux \
-    --init none \
-    --no-confirm \
-    --prefer-upstream-nix \
-    --diagnostic-endpoint "" \
-    --extra-conf "experimental-features = nix-command flakes" \
-    --extra-conf "accept-flake-config = true" \
-    --extra-conf "extra-substituters = ${SUBSTITUTERS}" \
-    --extra-conf "extra-trusted-public-keys = ${IOG_KEY} ${NEO_KEY}"
-  rm -f "${installer}"
-else
-  log "Nix already installed — skipping installation"
+  echo "WARNING: Nix not found at ${NIX_PROFILE_BIN}." >&2
+  echo "         Configure the environment **setup script** in the Claude Code" >&2
+  echo "         web UI (use scripts/cloud-setup.sh) to install Nix and warm the" >&2
+  echo "         dev shell. Without it this session has no toolchain." >&2
+  exit 0
 fi
 
-# --- 2. Ensure the binary caches are configured ----------------------------
-# Guards against a pre-existing Nix install that lacks our caches.
-if [ ! -f "${NIX_CUSTOM_CONF}" ] || ! grep -q "neohaskell.cachix.org" "${NIX_CUSTOM_CONF}" 2>/dev/null; then
-  log "Writing NeoHaskell cache configuration"
-  {
-    echo "extra-experimental-features = nix-command flakes"
-    echo "accept-flake-config = true"
-    echo "extra-substituters = ${SUBSTITUTERS}"
-    echo "extra-trusted-public-keys = ${IOG_KEY} ${NEO_KEY}"
-  } >> "${NIX_CUSTOM_CONF}"
-fi
-
-# --- 3. Put Nix on PATH for this hook and all future tool calls -------------
 export PATH="${NIX_PROFILE_BIN}:${PATH}"
 if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -q "${NIX_PROFILE_BIN}" "${CLAUDE_ENV_FILE}" 2>/dev/null; then
   echo "export PATH=\"${NIX_PROFILE_BIN}:\$PATH\"" >> "${CLAUDE_ENV_FILE}"
@@ -89,17 +53,13 @@ fi
 log "Nix version"
 nix --version
 
-# --- 4. Warm the dev shell + update the package index ----------------------
-# Entering the dev shell pulls the GHC toolchain (HLS, fourmolu, hlint, cabal,
-# ...) from the caches and runs `cabal update` so package resolution works.
-log "Warming the Nix dev shell and updating the cabal index"
-cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
-nix develop --command cabal update
-
-# --- 5. Best-effort build warm-up ------------------------------------------
-# Compiling the project caches dist-newstyle for faster first edits. Kept
-# best-effort so a build hiccup never blocks the session from starting.
+# --- 2. Best-effort build warm-up -------------------------------------------
+# The dev shell + cabal index come from the snapshot, but the repo is cloned
+# fresh each session so dist-newstyle is empty. Warm it (this hook is already
+# async, so it does not block the session); a build hiccup must never stop the
+# session from starting.
 log "Pre-building the project (best-effort)"
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 if ! nix develop --command cabal build all --disable-documentation; then
   echo "WARNING: 'cabal build all' did not complete. The session will still start;" >&2
   echo "         run it manually once any build issue is resolved." >&2

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Cloud environment SETUP SCRIPT for NeoHaskell.
+#
+# Paste the contents of this file into the Claude Code web UI:
+#   environment settings → "Setup script".
+#
+# It runs ONCE as root before Claude launches; the resulting filesystem is
+# then snapshotted and reused by later sessions, so /nix/store and the cabal
+# index are already on disk and this never re-runs — until you change the
+# script, change the environment's allowed hosts, or the ~7-day cache expires.
+# (Resuming an existing session never re-runs it.)
+#
+# Why a setup script and not only a SessionStart hook:
+#   - Setup scripts are snapshotted → the expensive Nix install + dev-shell
+#     pull happens once, not every session.
+#   - SessionStart hooks run every session and are NOT cached, so anything they
+#     download is re-fetched each time.
+# The companion .claude/hooks/session-start.sh keeps only the per-session work
+# (PATH export + a background build warm-up).
+#
+# Time budget: keep this under ~5 minutes so the environment cache can build.
+# The dev-shell warm in step 3 is the long pole; it should fit when the binary
+# caches below are reachable. If your environment can't pull the toolchain in
+# time and the snapshot fails to build, drop step 3 here and let the
+# SessionStart hook warm the dev shell instead (slower per session).
+#
+# Network: the environment's allowed hosts MUST include the Nix binary caches
+#   cache.iog.io, neohaskell.cachix.org, cache.nixos.org, releases.nixos.org
+# plus github.com / objects.githubusercontent.com and hackage.haskell.org.
+# Without the first two, Nix compiles GHC + every dependency from source and
+# will blow the time budget.
+#
+set -euo pipefail
+
+NIX_PROFILE_BIN="/nix/var/nix/profiles/default/bin"
+NIX_CUSTOM_CONF="/etc/nix/nix.custom.conf"
+
+IOG_KEY="hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+NEO_KEY="neohaskell.cachix.org-1:mo2cLaGbwqbrxs9xhqKK8jeNsn3osi7t6XoAmxSZssc="
+SUBSTITUTERS="https://cache.iog.io https://neohaskell.cachix.org"
+
+log() { printf '\n=== %s ===\n' "$*"; }
+
+# --- 1. Install Nix (idempotent) -------------------------------------------
+# Determinate nix-installer fetched straight from GitHub releases.
+# --prefer-upstream-nix pulls upstream Nix; --init none = root-only (no systemd).
+if [ ! -x "${NIX_PROFILE_BIN}/nix" ]; then
+  log "Installing Nix"
+  installer="$(mktemp)"
+  curl --proto '=https' --tlsv1.2 -fsSL \
+    "https://github.com/DeterminateSystems/nix-installer/releases/latest/download/nix-installer-x86_64-linux" \
+    -o "${installer}"
+  chmod +x "${installer}"
+  "${installer}" install linux \
+    --init none \
+    --no-confirm \
+    --prefer-upstream-nix \
+    --diagnostic-endpoint "" \
+    --extra-conf "experimental-features = nix-command flakes" \
+    --extra-conf "accept-flake-config = true" \
+    --extra-conf "extra-substituters = ${SUBSTITUTERS}" \
+    --extra-conf "extra-trusted-public-keys = ${IOG_KEY} ${NEO_KEY}"
+  rm -f "${installer}"
+else
+  log "Nix already installed — skipping installation"
+fi
+
+export PATH="${NIX_PROFILE_BIN}:${PATH}"
+
+# --- 2. Ensure the binary caches are configured ----------------------------
+if [ ! -f "${NIX_CUSTOM_CONF}" ] || ! grep -q "neohaskell.cachix.org" "${NIX_CUSTOM_CONF}" 2>/dev/null; then
+  log "Writing NeoHaskell cache configuration"
+  {
+    echo "extra-experimental-features = nix-command flakes"
+    echo "accept-flake-config = true"
+    echo "extra-substituters = ${SUBSTITUTERS}"
+    echo "extra-trusted-public-keys = ${IOG_KEY} ${NEO_KEY}"
+  } >> "${NIX_CUSTOM_CONF}"
+fi
+
+# --- 3. Warm the dev shell + update the cabal index ------------------------
+# Pulls GHC + tooling from the caches into /nix/store and populates the cabal
+# index — both land on disk and are captured by the snapshot. Tolerant of a
+# transient cache hiccup: the dev shell simply resolves on first use instead.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "${PROJECT_DIR}" ] || [ ! -f "${PROJECT_DIR}/flake.nix" ]; then
+  for d in /home/user/NeoHaskell "$(pwd)" /root/NeoHaskell /workspace/NeoHaskell; do
+    if [ -f "${d}/flake.nix" ]; then PROJECT_DIR="${d}"; break; fi
+  done
+fi
+
+if [ -n "${PROJECT_DIR}" ] && [ -f "${PROJECT_DIR}/flake.nix" ]; then
+  log "Warming the Nix dev shell and updating the cabal index (${PROJECT_DIR})"
+  cd "${PROJECT_DIR}"
+  nix develop --command cabal update \
+    || echo "WARNING: dev-shell warm / cabal update did not complete; will resolve on first use." >&2
+else
+  echo "NOTE: repo not checked out at setup time; the dev shell will warm on first session instead." >&2
+fi
+
+log "Setup script complete"


### PR DESCRIPTION
## What

Splits the Claude Code on the web provisioning into two pieces:

- **`scripts/cloud-setup.sh`** — a new cloud-environment **setup script** (to be pasted into the web UI) that installs Nix, configures the binary caches, and warms the haskell.nix dev shell + cabal index.
- **`.claude/hooks/session-start.sh`** — refactored down to the slim, per-session half: export Nix on `PATH` (via `$CLAUDE_ENV_FILE`) and kick a best-effort background `cabal build all`.

## Why

The SessionStart hook re-ran the **full** Nix install, dev-shell pull, and `cabal update` on **every** session, because hooks are never cached. Per the [Claude Code on the web docs](https://code.claude.com/docs/en/claude-code-on-the-web#environment-caching), a setup script runs once and its filesystem result is **snapshotted and reused** — so `/nix/store` and the cabal index land on disk before Claude launches and don't have to be re-pulled each session. That's exactly the expensive work we want cached.

The hook keeps only what a snapshot *cannot* capture:
1. Per-session env vars (Nix on `PATH`) — env isn't snapshotted.
2. `dist-newstyle` warm-up — the repo is cloned fresh each session, so a build never carries over.

If Nix is missing, the hook now prints a clear warning pointing at `scripts/cloud-setup.sh` instead of silently leaving the session without a toolchain.

## Caveats (documented in the script headers)

- **~5-minute setup-script budget.** The dev-shell pull is the long pole; if an environment can't fetch the toolchain in time and the snapshot fails to build, drop step 3 from the setup script and let the hook warm the dev shell instead (functional, just slower per session). The system degrades gracefully — the hook bootstraps the build either way.
- **Postgres isn't snapshottable.** The cache captures files, not running processes, so the DB needed for `nhcore-test-service` / integration / full `cabal test` still has to be started per session.

## Notes

This changes only cloud-session provisioning (a setup script + a hook); no library, build, or test code is touched.

https://claude.ai/code/session_013LT47u1Fc5a314eogBPZok

---
_Generated by [Claude Code](https://claude.ai/code/session_013LT47u1Fc5a314eogBPZok)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development environment setup by moving Nix provisioning from per-session initialization to a one-time cloud setup process that gets cached.
  * Streamlined session startup to focus on verification rather than installation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->