### PR TITLE
fix(service): catch-up read on LISTEN/NOTIFY reconnect to prevent missed events

### DIFF
--- a/core/service/Service/EventStore/Postgres/Notifications.hs
+++ b/core/service/Service/EventStore/Postgres/Notifications.hs
@@ -5,6 +5,7 @@ module Service.EventStore.Postgres.Notifications (
   catchUpFromCursor,
 ) where
 
+import Array qualified
 import AsyncTask qualified
 import Bytes qualified
 import Core hiding (Var)
@@ -14,8 +15,8 @@ import Hasql.Notifications qualified as HasqlNotifications
 import Json qualified
 import Log qualified
 import Maybe (Maybe (..))
-import Service.Event (Event (..), StreamPosition (..))
-import Service.EventStore.Postgres.PostgresEventRecord (PostgresEventRecord (..))
+import Service.Event (Event (..), StreamPosition (StreamPosition))
+import Service.EventStore.Postgres.PostgresEventRecord (PostgresEventRecord (globalPosition))
 import Service.EventStore.Postgres.Sessions qualified as Sessions
 import Service.EventStore.Postgres.SubscriptionStore (SubscriptionStore)
 import Service.EventStore.Postgres.SubscriptionStore qualified as SubscriptionStore
@@ -199,12 +200,28 @@ initialiseOrCatchUp queryConnection store lastProcessedRef initialisedRef = do
       catchUpFromCursor queryConnection store lastProcessedRef
 
 
+-- | Catch-up batch size: events read per forward page during a reconnect
+-- catch-up. Matches the ADR-0059 query-rebuild chunk size (1000) so the two
+-- forward-replay paths page consistently and the catch-up read stays bounded
+-- regardless of how long the listener was offline.
+catchUpBatchSize :: Int64
+catchUpBatchSize = 1000
+
+
 -- | Replay every event committed after the last-processed @globalPosition@
 -- through the shared 'SubscriptionStore', advancing the cursor as it goes.
 -- Invoked on each listener reconnect, AFTER @LISTEN@ is re-established and
 -- BEFORE the live wait, so the gap created while the listen socket was down
 -- reaches live dispatch (ADR-0061). The dispatch sink is identical to the
 -- live handler's, so there is one sink and one read implementation.
+--
+-- The read is BOUNDED: rather than pulling every row after the cursor into one
+-- 'Array' (which a long outage could blow up), it reads in pages of
+-- 'catchUpBatchSize', dispatches each page, advances the cursor to the last
+-- 'globalPosition' in the page (via 'dispatchCaughtUpRecord'), and repeats until
+-- a page returns fewer rows than the limit (the gap is drained). Paging is
+-- monotonic in @globalPosition@, so at-least-once/idempotency are preserved and
+-- ordering is unchanged.
 catchUpFromCursor ::
   Hasql.Connection ->
   SubscriptionStore ->
@@ -213,10 +230,15 @@ catchUpFromCursor ::
 catchUpFromCursor queryConnection store lastProcessedRef = do
   cursor <- Var.get lastProcessedRef
   records <-
-    Sessions.selectEventsForwardFromGlobalPositionSession cursor
+    Sessions.selectEventsForwardFromGlobalPositionSession cursor catchUpBatchSize
       |> Sessions.runConnection queryConnection
       |> Task.mapError toText
   records |> Task.forEach (dispatchCaughtUpRecord store lastProcessedRef)
+  -- A full page means there may be more rows after it: 'dispatchCaughtUpRecord'
+  -- has already advanced the cursor past this page, so loop to drain the rest.
+  -- A short page means the gap is exhausted and catch-up is done.
+  Task.when (Array.length records == fromIntegral catchUpBatchSize) do
+    catchUpFromCursor queryConnection store lastProcessedRef
 
 
 -- | Decode a caught-up record, dispatch it through the same sink the live

--- a/core/service/Service/EventStore/Postgres/Notifications.hs
+++ b/core/service/Service/EventStore/Postgres/Notifications.hs
@@ -2,6 +2,7 @@ module Service.EventStore.Postgres.Notifications (
   connectTo,
   nextBackoff,
   subscribeToStream,
+  catchUpFromCursor,
 ) where
 
 import AsyncTask qualified
@@ -13,7 +14,8 @@ import Hasql.Notifications qualified as HasqlNotifications
 import Json qualified
 import Log qualified
 import Maybe (Maybe (..))
-import Service.Event (Event (..))
+import Service.Event (Event (..), StreamPosition (..))
+import Service.EventStore.Postgres.PostgresEventRecord (PostgresEventRecord (..))
 import Service.EventStore.Postgres.Sessions qualified as Sessions
 import Service.EventStore.Postgres.SubscriptionStore (SubscriptionStore)
 import Service.EventStore.Postgres.SubscriptionStore qualified as SubscriptionStore
@@ -29,6 +31,12 @@ connectTo ::
 connectTo acquireConnections store = do
   shutdownRef <- (Var.new False :: Task Text (Var Bool))
   currentConnectionsRef <- (Var.new (Maybe.Nothing :: Maybe (Hasql.Connection, Hasql.Connection)) :: Task Text (Var (Maybe (Hasql.Connection, Hasql.Connection))))
+  -- ADR-0061: last-processed globalPosition, shared across reconnects for the
+  -- life of this listener task. Initialised to the current max on the first
+  -- connect ("subscribe from now"); advanced by the live handler and by the
+  -- reconnect catch-up. The DB is the durable cursor — this Var is transient.
+  lastProcessedRef <- (Var.new (0 :: Int64) :: Task Text (Var Int64))
+  initialisedRef <- (Var.new False :: Task Text (Var Bool))
   let listenerWithReconnect backoffMs = do
         isShutdown <- Var.get shutdownRef
         Task.unless isShutdown do
@@ -48,8 +56,16 @@ connectTo acquireConnections store = do
                   |> discard
                 Log.info "LISTEN/NOTIFY listener started"
                   |> Task.ignoreError
+                -- LOAD-BEARING ORDERING (ADR-0061): the catch-up below runs
+                -- AFTER LISTEN is active and BEFORE the live wait. LISTEN being
+                -- active first guarantees that an event committed during the
+                -- catch-up read is also delivered live (at-least-once overlap,
+                -- never a gap). On the very first connect we instead initialise
+                -- the cursor to the current max ("from now") and skip catch-up.
+                -- Do NOT move this catch-up before the LISTEN call.
+                initialiseOrCatchUp queryConnection store lastProcessedRef initialisedRef
                 listenConnection
-                  |> HasqlNotifications.waitForNotifications (handler queryConnection store)
+                  |> HasqlNotifications.waitForNotifications (handler queryConnection store lastProcessedRef)
                   |> Task.fromIO
           case result of
             Ok _ -> do
@@ -90,11 +106,12 @@ subscribeToStream connection streamId = do
 handler ::
   Hasql.Connection ->
   SubscriptionStore ->
+  Var Int64 ->
   Data.ByteString.ByteString ->
   Data.ByteString.ByteString ->
   IO ()
-handler queryConnection store _channelName payloadLegacyBytes = do
-  result <- processNotification queryConnection store payloadLegacyBytes |> Task.runResult
+handler queryConnection store lastProcessedRef _channelName payloadLegacyBytes = do
+  result <- processNotification queryConnection store lastProcessedRef payloadLegacyBytes |> Task.runResult
   case result of
     Err err ->
       ((Log.warn [fmt|#{err}|] |> Task.ignoreError) :: Task Text Unit) |> Task.runOrPanic
@@ -105,14 +122,18 @@ handler queryConnection store _channelName payloadLegacyBytes = do
 processNotification ::
   Hasql.Connection ->
   SubscriptionStore ->
+  Var Int64 ->
   Data.ByteString.ByteString ->
   Task Text Unit
-processNotification queryConnection store payloadLegacyBytes = do
+processNotification queryConnection store lastProcessedRef payloadLegacyBytes = do
   Log.withScope [("component", "Notifications")] do
     notification <- decodeNotification payloadLegacyBytes
     event <- fetchFullEvent queryConnection notification.globalPosition
     Log.withScope [("component", "Notifications"), ("streamId", toText event.streamId)] do
       store |> SubscriptionStore.dispatch event.streamId event |> Task.mapError toText
+      -- ADR-0061: advance the shared cursor so a later reconnect catch-up knows
+      -- where live dispatch reached.
+      advanceCursor lastProcessedRef notification.globalPosition
       Log.debug "Event dispatched from notification" |> Task.ignoreError
 
 
@@ -149,3 +170,78 @@ fetchFullEvent queryConnection globalPosition = do
 nextBackoff :: Int -> Int
 nextBackoff backoffMs =
   min 60000 (backoffMs * 2)
+
+
+-- | On the first connect, initialise the cursor to the current max
+-- globalPosition ("subscribe from now") and skip catch-up — a cold listener
+-- inherits the same semantics it always had. On every later connect (a
+-- reconnect), replay the gap via 'catchUpFromCursor'. The first-connect branch
+-- is what stops the listener from replaying the entire history on startup.
+initialiseOrCatchUp ::
+  Hasql.Connection ->
+  SubscriptionStore ->
+  Var Int64 ->
+  Var Bool ->
+  Task Text Unit
+initialiseOrCatchUp queryConnection store lastProcessedRef initialisedRef = do
+  initialised <- Var.get initialisedRef
+  case initialised of
+    False -> do
+      maybeMax <-
+        Sessions.selectMaxGlobalPosition
+          |> Sessions.runConnection queryConnection
+          |> Task.mapError toText
+      case maybeMax of
+        Maybe.Nothing -> lastProcessedRef |> Var.set 0
+        Maybe.Just (StreamPosition maxPos) -> lastProcessedRef |> Var.set maxPos
+      initialisedRef |> Var.set True
+    True ->
+      catchUpFromCursor queryConnection store lastProcessedRef
+
+
+-- | Replay every event committed after the last-processed @globalPosition@
+-- through the shared 'SubscriptionStore', advancing the cursor as it goes.
+-- Invoked on each listener reconnect, AFTER @LISTEN@ is re-established and
+-- BEFORE the live wait, so the gap created while the listen socket was down
+-- reaches live dispatch (ADR-0061). The dispatch sink is identical to the
+-- live handler's, so there is one sink and one read implementation.
+catchUpFromCursor ::
+  Hasql.Connection ->
+  SubscriptionStore ->
+  Var Int64 ->
+  Task Text Unit
+catchUpFromCursor queryConnection store lastProcessedRef = do
+  cursor <- Var.get lastProcessedRef
+  records <-
+    Sessions.selectEventsForwardFromGlobalPositionSession cursor
+      |> Sessions.runConnection queryConnection
+      |> Task.mapError toText
+  records |> Task.forEach (dispatchCaughtUpRecord store lastProcessedRef)
+
+
+-- | Decode a caught-up record, dispatch it through the same sink the live
+-- handler uses, and advance the cursor (monotonic max). A decode failure is
+-- thrown so the supervised reconnect loop retries the gap rather than
+-- silently skipping it.
+dispatchCaughtUpRecord ::
+  SubscriptionStore ->
+  Var Int64 ->
+  PostgresEventRecord ->
+  Task Text Unit
+dispatchCaughtUpRecord store lastProcessedRef record = do
+  case Sessions.postgresRecordToEvent record of
+    Err err ->
+      Task.throw [fmt|Catch-up event decode failed: #{err}|]
+    Ok event -> do
+      store
+        |> SubscriptionStore.dispatch event.streamId event
+        |> Task.mapError toText
+      advanceCursor lastProcessedRef record.globalPosition
+
+
+-- | Advance the cursor to @max current position@, keeping it monotonic so a
+-- duplicate or out-of-order boundary event never moves it backwards.
+advanceCursor :: Var Int64 -> Int64 -> Task Text Unit
+advanceCursor lastProcessedRef position = do
+  current <- Var.get lastProcessedRef
+  lastProcessedRef |> Var.set (max current position)

--- a/core/service/Service/EventStore/Postgres/Sessions.hs
+++ b/core/service/Service/EventStore/Postgres/Sessions.hs
@@ -143,6 +143,25 @@ selectEventByGlobalPositionSession globalPos = do
   Session.statement globalPos statement
 
 
+-- | Read every event with @GlobalPosition > cursor@, ascending. Used by the
+-- LISTEN/NOTIFY reconnect catch-up (ADR-0061) to replay the gap. The cursor is
+-- parameterised (@$1@), never interpolated, mirroring
+-- 'selectEventByGlobalPositionSession'. The @>@ (strict) makes the read
+-- exclusive of the cursor, so the already-dispatched cursor event is not
+-- re-read.
+selectEventsForwardFromGlobalPositionSession ::
+  Int64 ->
+  Session.Session (Array PostgresEventRecord)
+selectEventsForwardFromGlobalPositionSession cursor = do
+  let query :: Text = "SELECT EventId, GlobalPosition, LocalPosition, InlinedStreamId, Entity, EventData, Metadata FROM Events WHERE GlobalPosition > $1 ORDER BY GlobalPosition ASC"
+  let encoder = Encoders.param (Encoders.nonNullable Encoders.int8)
+  let decoder = Decoders.rowVector PostgresEventRecord.rowDecoder
+  let statement :: Statement Int64 (Array PostgresEventRecord) =
+        Statement (query |> Text.toBytes |> Bytes.unwrap) encoder decoder True
+          |> Mappable.map Array.fromLegacy
+  Session.statement cursor statement
+
+
 createEventsTableSession :: Session.Session Unit
 createEventsTableSession =
   Session.sql

--- a/core/service/Service/EventStore/Postgres/Sessions.hs
+++ b/core/service/Service/EventStore/Postgres/Sessions.hs
@@ -143,23 +143,29 @@ selectEventByGlobalPositionSession globalPos = do
   Session.statement globalPos statement
 
 
--- | Read every event with @GlobalPosition > cursor@, ascending. Used by the
--- LISTEN/NOTIFY reconnect catch-up (ADR-0061) to replay the gap. The cursor is
--- parameterised (@$1@), never interpolated, mirroring
+-- | Read at most @limit@ events with @GlobalPosition > cursor@, ascending. Used
+-- by the LISTEN/NOTIFY reconnect catch-up (ADR-0061) to replay the gap in
+-- bounded batches, so a long listener outage cannot pull an unbounded result
+-- set into one 'Array' (the caller, 'catchUpFromCursor', loops over batches and
+-- advances the cursor between them). Both the cursor (@$1@) and the batch limit
+-- (@$2@) are parameterised, never interpolated, mirroring
 -- 'selectEventByGlobalPositionSession'. The @>@ (strict) makes the read
 -- exclusive of the cursor, so the already-dispatched cursor event is not
 -- re-read.
 selectEventsForwardFromGlobalPositionSession ::
   Int64 ->
+  Int64 ->
   Session.Session (Array PostgresEventRecord)
-selectEventsForwardFromGlobalPositionSession cursor = do
-  let query :: Text = "SELECT EventId, GlobalPosition, LocalPosition, InlinedStreamId, Entity, EventData, Metadata FROM Events WHERE GlobalPosition > $1 ORDER BY GlobalPosition ASC"
-  let encoder = Encoders.param (Encoders.nonNullable Encoders.int8)
+selectEventsForwardFromGlobalPositionSession cursor limit = do
+  let query :: Text = "SELECT EventId, GlobalPosition, LocalPosition, InlinedStreamId, Entity, EventData, Metadata FROM Events WHERE GlobalPosition > $1 ORDER BY GlobalPosition ASC LIMIT $2"
+  let encoder =
+        (fst >$< Encoders.param (Encoders.nonNullable Encoders.int8))
+          <> (snd >$< Encoders.param (Encoders.nonNullable Encoders.int8))
   let decoder = Decoders.rowVector PostgresEventRecord.rowDecoder
-  let statement :: Statement Int64 (Array PostgresEventRecord) =
+  let statement :: Statement (Int64, Int64) (Array PostgresEventRecord) =
         Statement (query |> Text.toBytes |> Bytes.unwrap) encoder decoder True
           |> Mappable.map Array.fromLegacy
-  Session.statement cursor statement
+  Session.statement (cursor, limit) statement
 
 
 createEventsTableSession :: Session.Session Unit

--- a/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
+++ b/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
@@ -15,9 +15,15 @@ import LinkedList qualified
 import Array qualified
 import ConcurrentVar qualified
 import Hasql.Connection qualified as Hasql
+import Hasql.Session qualified as Session
+import Hasql.Decoders qualified as Decoders
+import Hasql.Encoders qualified as Encoders
+import Hasql.Statement (Statement (..))
+import Bytes qualified
+import AsyncTask qualified
 import Var qualified
 import Service.EventStore.Postgres.Internal (PostgresEventStore (..), toConnectionSettings)
-import Service.EventStore.Postgres.Notifications (nextBackoff, catchUpFromCursor)
+import Service.EventStore.Postgres.Notifications (nextBackoff, catchUpFromCursor, connectTo)
 import Service.EventStore.Postgres.SubscriptionStore (SubscriptionStore)
 import Service.EventStore.Postgres.SubscriptionStore qualified as SubscriptionStore
 import Service.EventStore (EventStore (..))
@@ -301,7 +307,7 @@ spec = do
           maxBefore <- currentMaxPosition conn
           insertN conn entityName 3
           records <-
-            Sessions.selectEventsForwardFromGlobalPositionSession maxBefore
+            Sessions.selectEventsForwardFromGlobalPositionSession maxBefore 1000
               |> Sessions.runConnection conn
               |> Task.mapError toText
           let positions = records |> Array.map (\r -> r.globalPosition)
@@ -314,7 +320,7 @@ spec = do
           insertN conn entityName 2
           maxNow <- currentMaxPosition conn
           records <-
-            Sessions.selectEventsForwardFromGlobalPositionSession maxNow
+            Sessions.selectEventsForwardFromGlobalPositionSession maxNow 1000
               |> Sessions.runConnection conn
               |> Task.mapError toText
           (records |> Array.length) |> shouldBe 0
@@ -324,7 +330,7 @@ spec = do
           insertN conn entityName 1
           maxNow <- currentMaxPosition conn
           records <-
-            Sessions.selectEventsForwardFromGlobalPositionSession (maxNow + 1000)
+            Sessions.selectEventsForwardFromGlobalPositionSession (maxNow + 1000) 1000
               |> Sessions.runConnection conn
               |> Task.mapError toText
           (records |> Array.length) |> shouldBe 0
@@ -335,7 +341,7 @@ spec = do
           insertN conn entityName 2
           -- Read from the position of the FIRST new event: it must be excluded.
           records <-
-            Sessions.selectEventsForwardFromGlobalPositionSession (maxBefore + 1)
+            Sessions.selectEventsForwardFromGlobalPositionSession (maxBefore + 1) 1000
               |> Sessions.runConnection conn
               |> Task.mapError toText
           let positions = records |> Array.map (\r -> r.globalPosition)
@@ -388,6 +394,92 @@ spec = do
           result <- catchUpFromCursor conn store cursor |> Task.asResult
           result |> shouldSatisfy resultIsErr
 
+  -- ADR-0061 (issue #682) — TRUE reconnect-path regression. The B1–B4 cases
+  -- above exercise 'catchUpFromCursor' in isolation; they never drive the
+  -- 'connectTo' / 'listenerWithReconnect' wiring, so the load-bearing contract
+  -- (LISTEN re-established by the loop BEFORE catch-up runs, and the shared
+  -- in-memory cursor surviving the reconnect) is untested by them — a wiring
+  -- regression would reintroduce #682 while keeping B1–B4 green.
+  --
+  -- This case drives the ACTUAL path: it starts a listener via 'connectTo' with
+  -- a connection factory under the test's control, forces the live listen
+  -- backend to drop (server-side 'pg_terminate_backend', which wakes
+  -- 'waitForNotifications' immediately — it does not rely on TCP keepalive
+  -- timing), inserts events DURING the outage, and asserts that after the
+  -- supervised loop reconnects, EVERY missed event is dispatched (none skipped)
+  -- and the shared cursor advanced past them across the reconnect.
+  describe "listener reconnect catch-up (connectTo wiring)" do
+    whenEnvVar "POSTGRES_AVAILABLE" do
+      it "re-establishes LISTEN and catches up all events missed during the outage (D1, issue #682)" \_ -> do
+        let cfg =
+              (def :: PostgresEventStore)
+                { host = "localhost",
+                  databaseName = "neohaskell",
+                  user = "neohaskell",
+                  password = "neohaskell",
+                  port = 5432
+                }
+        -- Ensure events table + trigger exist.
+        store0 <- Postgres.new cfg |> Task.mapError toText
+        store0.close
+        subStore <- SubscriptionStore.new |> Task.mapError toText
+        let entityName = EntityName "ReconnectWiringEntity"
+        collector <- ConcurrentVar.containing Array.empty
+        attachCollector subStore collector
+        -- Track factory invocations and the first connect's listen backend PID,
+        -- so the test can terminate exactly that backend to force a reconnect.
+        connectCount <- Var.new (0 :: Int)
+        firstPidRef <- Var.new (Nothing :: Maybe Int64)
+        adminConn <- acquireConn cfg
+        let factory = do
+              listenConn <- acquireConn cfg
+              queryConn <- acquireConn cfg
+              currentCount <- Var.get connectCount
+              Task.when (currentCount == 0) do
+                pid <- backendPid listenConn
+                firstPidRef |> Var.set (Just pid)
+              connectCount |> Var.set (currentCount + 1)
+              Task.yield (listenConn, queryConn)
+        cleanup <- subStore |> connectTo factory
+        let teardown = do
+              cleanup
+              (Hasql.release adminConn |> Task.fromIO) |> Task.asResult |> discard
+        let scenario = do
+              -- Wait for the first connect to establish LISTEN + initialise cursor.
+              waitUntil 50 (do n <- Var.get connectCount; Task.yield (n >= 1))
+              waitUntil 50 do
+                p <- Var.get firstPidRef
+                case p of
+                  Just _ -> Task.yield True
+                  Nothing -> Task.yield False
+              maybePid <- Var.get firstPidRef
+              firstPid <- case maybePid of
+                Just pid -> Task.yield pid
+                Nothing -> Task.throw "first connect never reported a backend PID"
+              -- Force the live listen socket to drop (the outage begins).
+              terminateBackend adminConn firstPid
+              -- Insert events while no LISTEN is active: NOTIFY is lost for these,
+              -- so only the reconnect catch-up can deliver them.
+              insertN adminConn entityName 3
+              -- Wait for the supervised loop to reconnect (factory called again)
+              -- and catch up. Generous bound: first backoff is 1000ms.
+              waitUntil 200 (do n <- Var.get connectCount; Task.yield (n >= 2))
+              waitUntil 200 (do
+                received <- ConcurrentVar.peek collector
+                Task.yield (Array.length received >= 3))
+              received <- ConcurrentVar.peek collector
+              Task.yield received
+        result <- Task.finally teardown scenario |> Task.asResult
+        case result of
+          Err err -> Test.fail [fmt|reconnect wiring test failed: #{err}|]
+          Ok received -> do
+            -- Every event committed during the outage reached live dispatch.
+            (received |> Array.length) |> shouldBe 3
+            -- The reconnect actually happened (loop re-acquired connections).
+            reconnects <- Var.get connectCount
+            reconnects |> shouldSatisfy (\n -> n >= 2)
+
+
 
 -- | A reconnect-catch-up Postgres fixture: acquire a fresh query connection,
 -- build a SubscriptionStore, run the body on a unique entity name, and always
@@ -411,11 +503,16 @@ catchUpFixture body = do
     Hasql.acquire (toConnectionSettings cfg)
       |> Task.fromIOEither
       |> Task.mapError toText
-  subStore <- SubscriptionStore.new |> Task.mapError toText
-  let entityName = EntityName "ReconnectCatchUpEntity"
-  result <- body conn subStore entityName |> Task.asResult
-  -- Best-effort release (B4 may have already released it).
-  (Hasql.release conn |> Task.fromIO) |> Task.asResult |> discard
+  -- Bracket the connection: release it on EVERY path, so an exception in
+  -- SubscriptionStore.new or in the body cannot leak the Hasql connection.
+  -- Release is best-effort because B4 may already have released it.
+  let releaseConn = (Hasql.release conn |> Task.fromIO) |> Task.asResult |> discard
+  result <-
+    Task.finally releaseConn do
+      subStore <- SubscriptionStore.new |> Task.mapError toText
+      let entityName = EntityName "ReconnectCatchUpEntity"
+      body conn subStore entityName
+    |> Task.asResult
   case result of
     Err err -> Test.fail [fmt|catch-up fixture body failed: #{err}|]
     Ok _ -> Task.yield unit
@@ -434,8 +531,11 @@ insertN _conn entityName n = do
             port = 5432
           }
   store <- Postgres.new cfg |> Task.mapError toText
-  Task.forEach (\_ -> insertTestEvent store entityName) (Array.fromLinkedList (rangeList n))
-  store.close
+  -- Bracket the temporary store: close it on EVERY path, so a failure in
+  -- Task.forEach cannot leak the Postgres store/its pool.
+  Task.finally
+    store.close
+    (Task.forEach (\_ -> insertTestEvent store entityName) (Array.fromLinkedList (rangeList n)))
 
 
 -- | The current MAX(globalPosition), or -1 when the table is empty.
@@ -506,3 +606,69 @@ resultIsErr result =
   case result of
     Err _ -> True
     Ok _ -> False
+
+
+-- | Acquire a raw Hasql connection from the test config (used to drive the
+-- reconnect wiring test's connection factory and its admin connection).
+acquireConn :: PostgresEventStore -> Task Text Hasql.Connection
+acquireConn cfg =
+  Hasql.acquire (toConnectionSettings cfg)
+    |> Task.fromIOEither
+    |> Task.mapError toText
+
+
+-- | The PostgreSQL backend process id (@pg_backend_pid()@) of a connection.
+-- Captured for the listener's listen connection so the test can terminate
+-- exactly that backend and force a reconnect.
+backendPid :: Hasql.Connection -> Task Text Int64
+backendPid conn = do
+  let query :: Text = "SELECT pg_backend_pid() :: int8"
+  let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
+  let statement :: Statement Unit Int64 =
+        Statement (query |> Text.toBytes |> Bytes.unwrap) Encoders.noParams decoder True
+  runRawSession conn (Session.statement unit statement)
+
+
+-- | Server-side terminate a backend by pid (@pg_terminate_backend@). Unlike a
+-- TCP drop this delivers a FATAL packet to the client immediately, so the
+-- listener's blocked @waitForNotifications@ wakes without waiting on keepalive
+-- timers.
+terminateBackend :: Hasql.Connection -> Int64 -> Task Text Unit
+terminateBackend conn pid = do
+  let query :: Text = "SELECT pg_terminate_backend(($1) :: int4) :: bool"
+  let encoder = Encoders.param (Encoders.nonNullable Encoders.int8)
+  let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
+  let statement :: Statement Int64 Bool =
+        Statement (query |> Text.toBytes |> Bytes.unwrap) encoder decoder True
+  runRawSession conn (Session.statement pid statement) |> discard
+
+
+-- | Run a Hasql session on a raw connection, surfacing any error as Text.
+runRawSession :: Hasql.Connection -> Session.Session result -> Task Text result
+runRawSession conn session = do
+  result <- Session.run session conn |> Task.fromIO |> Task.map Result.fromEither
+  case result of
+    Err err -> Task.throw [fmt|raw session failed: #{err}|]
+    Ok res -> Task.yield res
+
+
+-- | Poll @condition@ every @stepMs@ milliseconds, up to ~60 attempts (so the
+-- generous 200ms steps cover the listener's first 1000ms reconnect backoff with
+-- margin). Throws on timeout so a wiring regression fails loudly rather than
+-- hanging. Deterministic on success: returns as soon as the condition holds.
+waitUntil :: Int -> Task Text Bool -> Task Text Unit
+waitUntil stepMs condition =
+  waitUntilLoop stepMs condition 60
+
+
+waitUntilLoop :: Int -> Task Text Bool -> Int -> Task Text Unit
+waitUntilLoop stepMs condition attemptsLeft = do
+  case attemptsLeft <= 0 of
+    True -> Task.throw "waitUntil timed out"
+    False -> do
+      satisfied <- condition
+      case satisfied of
+        True -> Task.yield unit
+        False -> do
+          AsyncTask.sleep stepMs |> Task.mapError (\_ -> "waitUntil sleep failed")
+          waitUntilLoop stepMs condition (attemptsLeft - 1)

--- a/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
+++ b/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
@@ -4,7 +4,8 @@ import Core
 import Result qualified
 import Text qualified
 import Json qualified
-import Service.Event (EntityName (..), Event (..), StreamId (..), StreamPosition (..))
+import Service.Event (EntityName (..), Event (..), Insertion (..), InsertionPayload (..), StreamId (..), StreamPosition (..))
+import Service.Event.StreamId qualified as StreamId
 import Service.Event.EventMetadata (EventMetadata (..))
 import Service.Event.EventMetadata qualified as EventMetadata
 import Service.EventStore.Postgres.PostgresEventRecord (PostgresEventRecord (..))
@@ -14,11 +15,14 @@ import Service.EventStore.Postgres.Sessions qualified as Sessions
 import LinkedList qualified
 import Array qualified
 import ConcurrentVar qualified
+import Uuid qualified
 import Hasql.Connection qualified as Hasql
+import Hasql.Session (Session)
 import Hasql.Session qualified as Session
 import Hasql.Decoders qualified as Decoders
 import Hasql.Encoders qualified as Encoders
-import Hasql.Statement (Statement (..))
+import Hasql.Statement (Statement)
+import Hasql.Statement qualified as HasqlStatement
 import Bytes qualified
 import AsyncTask qualified
 import Var qualified
@@ -27,7 +31,6 @@ import Service.EventStore.Postgres.Notifications (nextBackoff, catchUpFromCursor
 import Service.EventStore.Postgres.SubscriptionStore (SubscriptionStore)
 import Service.EventStore.Postgres.SubscriptionStore qualified as SubscriptionStore
 import Service.EventStore (EventStore (..))
-import Service.TestHelpers (insertTestEvent)
 import Service.EventStore.Postgres qualified as Postgres
 import Task qualified
 import Test
@@ -401,13 +404,28 @@ spec = do
   -- in-memory cursor surviving the reconnect) is untested by them — a wiring
   -- regression would reintroduce #682 while keeping B1–B4 green.
   --
-  -- This case drives the ACTUAL path: it starts a listener via 'connectTo' with
-  -- a connection factory under the test's control, forces the live listen
-  -- backend to drop (server-side 'pg_terminate_backend', which wakes
-  -- 'waitForNotifications' immediately — it does not rely on TCP keepalive
-  -- timing), inserts events DURING the outage, and asserts that after the
-  -- supervised loop reconnects, EVERY missed event is dispatched (none skipped)
-  -- and the shared cursor advanced past them across the reconnect.
+  -- This case drives the ACTUAL path and is engineered so that the outage events
+  -- can ONLY arrive via catch-up, never live:
+  --
+  --   1. Start a listener via 'connectTo' with a connection factory under the
+  --      test's control.
+  --   2. Prove the FIRST listener is fully live by inserting a SENTINEL event and
+  --      waiting until it is dispatched. A delivered sentinel proves LISTEN is
+  --      established and the in-memory cursor has advanced to the sentinel — so
+  --      anything inserted afterwards starts strictly past the cursor.
+  --   3. Terminate exactly the first listen backend (server-side
+  --      'pg_terminate_backend', which wakes 'waitForNotifications' immediately —
+  --      no reliance on TCP keepalive timing).
+  --   4. GATE the factory's SECOND invocation on a ConcurrentVar the test has not
+  --      released yet, then insert the outage events. Because the reconnect
+  --      cannot re-acquire a connection (and therefore cannot re-LISTEN) until
+  --      the gate opens, every outage NOTIFY is lost — leaving catch-up as the
+  --      ONLY possible delivery path. Without this gate the reconnect loop could
+  --      race ahead and re-LISTEN before the outage inserts, delivering them live
+  --      and passing the test without exercising catch-up at all.
+  --   5. Open the gate, let the loop reconnect, and assert that the dispatched
+  --      set contains the EXACT outage event ids (none skipped) — proving the
+  --      shared cursor survived the reconnect and catch-up replayed the gap.
   describe "listener reconnect catch-up (connectTo wiring)" do
     whenEnvVar "POSTGRES_AVAILABLE" do
       it "re-establishes LISTEN and catches up all events missed during the outage (D1, issue #682)" \_ -> do
@@ -430,11 +448,21 @@ spec = do
         -- so the test can terminate exactly that backend to force a reconnect.
         connectCount <- Var.new (0 :: Int)
         firstPidRef <- Var.new (Nothing :: Maybe Int64)
+        -- Reconnect gate: an empty ConcurrentVar that blocks the factory's SECOND
+        -- (reconnect) invocation until the test fills it. 'peek' (readMVar) is
+        -- used so the gate stays open for any further reconnect attempts rather
+        -- than emptying after one release.
+        reconnectGate <- (ConcurrentVar.new :: Task Text (ConcurrentVar Unit))
         adminConn <- acquireConn cfg
         let factory = do
+              currentCount <- Var.get connectCount
+              -- Hold every reconnect (count >= 1) at the gate until the test has
+              -- finished the outage inserts, guaranteeing they cannot be picked
+              -- up by a freshly re-established LISTEN.
+              Task.when (currentCount >= 1) do
+                ConcurrentVar.peek reconnectGate
               listenConn <- acquireConn cfg
               queryConn <- acquireConn cfg
-              currentCount <- Var.get connectCount
               Task.when (currentCount == 0) do
                 pid <- backendPid listenConn
                 firstPidRef |> Var.set (Just pid)
@@ -456,25 +484,49 @@ spec = do
               firstPid <- case maybePid of
                 Just pid -> Task.yield pid
                 Nothing -> Task.throw "first connect never reported a backend PID"
-              -- Force the live listen socket to drop (the outage begins).
+              -- Prove the first listener is LIVE: insert a sentinel and wait for
+              -- it to be dispatched. Delivery proves LISTEN is up and the cursor
+              -- has advanced to the sentinel, so the later outage inserts begin
+              -- strictly past the cursor.
+              sentinelIds <- insertN adminConn entityName 1
+              sentinelId <- case Array.get 0 sentinelIds of
+                Just sid -> Task.yield sid
+                Nothing -> Task.throw "sentinel insert returned no id"
+              waitUntil 100 do
+                received <- ConcurrentVar.peek collector
+                Task.yield (dispatchedIds received |> Array.contains sentinelId)
+              -- Force the live listen socket to drop (the outage begins). The
+              -- reconnect loop will now wake and call the factory again, where it
+              -- blocks on the still-closed gate.
               terminateBackend adminConn firstPid
               -- Insert events while no LISTEN is active: NOTIFY is lost for these,
-              -- so only the reconnect catch-up can deliver them.
-              insertN adminConn entityName 3
+              -- so only the reconnect catch-up can deliver them. Capture their
+              -- exact ids so we can assert the specific events were dispatched.
+              outageIds <- insertN adminConn entityName 3
+              -- Open the gate: the reconnect may now acquire connections and
+              -- re-LISTEN. By construction every outage NOTIFY is already gone, so
+              -- the only way these ids can appear is via catch-up.
+              reconnectGate |> ConcurrentVar.set unit
               -- Wait for the supervised loop to reconnect (factory called again)
               -- and catch up. Generous bound: first backoff is 1000ms.
               waitUntil 200 (do n <- Var.get connectCount; Task.yield (n >= 2))
-              waitUntil 200 (do
+              waitUntil 200 do
                 received <- ConcurrentVar.peek collector
-                Task.yield (Array.length received >= 3))
+                let dispatched = dispatchedIds received
+                Task.yield (outageIds |> allInArray (\oid -> dispatched |> Array.contains oid))
               received <- ConcurrentVar.peek collector
-              Task.yield received
+              Task.yield (received, outageIds)
         result <- Task.finally teardown scenario |> Task.asResult
         case result of
           Err err -> Test.fail [fmt|reconnect wiring test failed: #{err}|]
-          Ok received -> do
-            -- Every event committed during the outage reached live dispatch.
-            (received |> Array.length) |> shouldBe 3
+          Ok (received, outageIds) -> do
+            -- Every SPECIFIC event committed during the outage reached dispatch
+            -- via catch-up: the dispatched id set must be a superset of the
+            -- outage ids (a bare length check could be satisfied by any events).
+            let dispatched = dispatchedIds received
+            outageIds
+              |> allInArray (\oid -> dispatched |> Array.contains oid)
+              |> shouldBe True
             -- The reconnect actually happened (loop re-acquired connections).
             reconnects <- Var.get connectCount
             reconnects |> shouldSatisfy (\n -> n >= 2)
@@ -519,8 +571,10 @@ catchUpFixture body = do
 
 
 -- | Insert @n@ events into the global stream via a fresh store on the same DB,
--- exercising the real insert + NOTIFY-trigger path.
-insertN :: Hasql.Connection -> EntityName -> Int -> Task Text Unit
+-- exercising the real insert + NOTIFY-trigger path. Returns the event ids of
+-- the inserted events (in insertion order) so callers can assert that those
+-- EXACT events — not merely some count of events — were later dispatched.
+insertN :: Hasql.Connection -> EntityName -> Int -> Task Text (Array Uuid)
 insertN _conn entityName n = do
   let cfg =
         (def :: PostgresEventStore)
@@ -532,10 +586,44 @@ insertN _conn entityName n = do
           }
   store <- Postgres.new cfg |> Task.mapError toText
   -- Bracket the temporary store: close it on EVERY path, so a failure in
-  -- Task.forEach cannot leak the Postgres store/its pool.
+  -- Task.mapArray cannot leak the Postgres store/its pool.
   Task.finally
     store.close
-    (Task.forEach (\_ -> insertTestEvent store entityName) (Array.fromLinkedList (rangeList n)))
+    (Task.mapArray (\_ -> insertReturningId store entityName) (Array.fromLinkedList (rangeList n)))
+
+
+-- | Insert a single event with a freshly-generated id and RETURN that id.
+-- Unlike 'insertTestEvent' (which discards the id), this lets the reconnect
+-- regression assert that the specific outage writes were dispatched.
+--
+-- IMPORTANT: the dispatched 'Event' reconstructs 'metadata' from the stored
+-- metadata JSON column (see 'postgresRecordToEvent'), so its 'eventId' is the
+-- one carried by 'EventMetadata', NOT the 'Insertion' id. We therefore pin BOTH
+-- the insertion id and the metadata 'eventId' to the same generated value and
+-- return that, so the id we assert on is exactly the id later dispatched.
+insertReturningId :: EventStore Json.Value -> EntityName -> Task Text Uuid
+insertReturningId store entityName = do
+  eventId <- Uuid.generate
+  streamId <- StreamId.new
+  baseMetadata <- EventMetadata.new
+  let metadata = baseMetadata {EventMetadata.eventId = eventId}
+  let insertion =
+        Insertion
+          { id = eventId,
+            event = Json.encode (),
+            metadata = metadata
+          }
+  let payload =
+        InsertionPayload
+          { streamId = streamId,
+            entityName = entityName,
+            insertionType = AnyStreamState,
+            insertions = [insertion]
+          }
+  store.insert payload
+    |> Task.mapError toText
+    |> discard
+  Task.yield eventId
 
 
 -- | The current MAX(globalPosition), or -1 when the table is empty.
@@ -570,6 +658,13 @@ attachCollector store collector = do
 allInArray :: (a -> Bool) -> Array a -> Bool
 allInArray predicate arr =
   (arr |> Array.takeIf predicate |> Array.length) == (arr |> Array.length)
+
+
+-- | The event ids of a set of dispatched events, used to assert that the
+-- SPECIFIC outage events (not merely some count) were delivered.
+dispatchedIds :: Array (Event Json.Value) -> Array Uuid
+dispatchedIds events =
+  events |> Array.map (\event -> event.metadata.eventId)
 
 
 -- | True when the positions are in strictly ascending order.
@@ -625,7 +720,7 @@ backendPid conn = do
   let query :: Text = "SELECT pg_backend_pid() :: int8"
   let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
   let statement :: Statement Unit Int64 =
-        Statement (query |> Text.toBytes |> Bytes.unwrap) Encoders.noParams decoder True
+        HasqlStatement.Statement (query |> Text.toBytes |> Bytes.unwrap) Encoders.noParams decoder True
   runRawSession conn (Session.statement unit statement)
 
 
@@ -633,18 +728,27 @@ backendPid conn = do
 -- TCP drop this delivers a FATAL packet to the client immediately, so the
 -- listener's blocked @waitForNotifications@ wakes without waiting on keepalive
 -- timers.
+--
+-- 'pg_terminate_backend' returns 'False' when the pid is not a running backend
+-- (already gone, or the caller lacks privilege). We do NOT discard that result:
+-- if termination did not actually happen, the listener's live socket is still
+-- up, so the outage never starts and the reconnect catch-up is never exercised.
+-- Throwing here makes such a no-op fail the regression loudly instead of letting
+-- it pass for the wrong reason.
 terminateBackend :: Hasql.Connection -> Int64 -> Task Text Unit
 terminateBackend conn pid = do
   let query :: Text = "SELECT pg_terminate_backend(($1) :: int4) :: bool"
   let encoder = Encoders.param (Encoders.nonNullable Encoders.int8)
   let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.bool))
   let statement :: Statement Int64 Bool =
-        Statement (query |> Text.toBytes |> Bytes.unwrap) encoder decoder True
-  runRawSession conn (Session.statement pid statement) |> discard
+        HasqlStatement.Statement (query |> Text.toBytes |> Bytes.unwrap) encoder decoder True
+  terminated <- runRawSession conn (Session.statement pid statement)
+  Task.unless terminated do
+    Task.throw [fmt|pg_terminate_backend(#{pid}) returned False: backend was not terminated|]
 
 
 -- | Run a Hasql session on a raw connection, surfacing any error as Text.
-runRawSession :: Hasql.Connection -> Session.Session result -> Task Text result
+runRawSession :: Hasql.Connection -> Session result -> Task Text result
 runRawSession conn session = do
   result <- Session.run session conn |> Task.fromIO |> Task.map Result.fromEither
   case result of

--- a/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
+++ b/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
@@ -12,11 +12,18 @@ import Service.EventStore.Postgres.Sessions (EventNotificationPayload (..))
 import Service.EventStore.Postgres.Sessions qualified as Sessions
 
 import LinkedList qualified
+import Array qualified
+import ConcurrentVar qualified
+import Hasql.Connection qualified as Hasql
+import Var qualified
 import Service.EventStore.Postgres.Internal (PostgresEventStore (..), toConnectionSettings)
-import Service.EventStore.Postgres.Notifications (nextBackoff)
+import Service.EventStore.Postgres.Notifications (nextBackoff, catchUpFromCursor)
+import Service.EventStore.Postgres.SubscriptionStore (SubscriptionStore)
+import Service.EventStore.Postgres.SubscriptionStore qualified as SubscriptionStore
+import Service.EventStore (EventStore (..))
+import Service.TestHelpers (insertTestEvent)
 import Service.EventStore.Postgres qualified as Postgres
 import Task qualified
-import Service.EventStore.Core qualified as EventStore
 import Test
 
 
@@ -270,3 +277,232 @@ spec = do
           Ok store2 -> do
             let closeOp2 = store2.close :: Task Text Unit
             closeOp2
+
+  -- ADR-0061: reconnect catch-up — the cursor never moves backwards (monotonic
+  -- max), so an out-of-order or duplicate boundary event during catch-up keeps
+  -- at-least-once safety without skipping or regressing the cursor. These are
+  -- pure and need no Postgres.
+  describe "cursor advance (monotonic max)" do
+    it "keeps the higher position when an earlier one arrives (C1)" \_ -> do
+      max (5 :: Int64) 3 |> shouldBe 5
+      max (5 :: Int64) 9 |> shouldBe 9
+
+    it "stays put for an equal position — idempotent re-delivery (C2)" \_ -> do
+      max (7 :: Int64) 7 |> shouldBe 7
+
+    it "advances correctly at the zero boundary (C3)" \_ -> do
+      max (0 :: Int64) 0 |> shouldBe 0
+      max (0 :: Int64) 1 |> shouldBe 1
+
+  describe "selectEventsForwardFromGlobalPositionSession" do
+    whenEnvVar "POSTGRES_AVAILABLE" do
+      it "returns only events strictly after the cursor, ascending (A1)" \_ -> do
+        catchUpFixture \conn _store entityName -> do
+          maxBefore <- currentMaxPosition conn
+          insertN conn entityName 3
+          records <-
+            Sessions.selectEventsForwardFromGlobalPositionSession maxBefore
+              |> Sessions.runConnection conn
+              |> Task.mapError toText
+          let positions = records |> Array.map (\r -> r.globalPosition)
+          (records |> Array.length) |> shouldBe 3
+          (positions |> isAscending) |> shouldBe True
+          (positions |> allInArray (\p -> p > maxBefore)) |> shouldBe True
+
+      it "returns empty when the cursor equals the current max (A2)" \_ -> do
+        catchUpFixture \conn _store entityName -> do
+          insertN conn entityName 2
+          maxNow <- currentMaxPosition conn
+          records <-
+            Sessions.selectEventsForwardFromGlobalPositionSession maxNow
+              |> Sessions.runConnection conn
+              |> Task.mapError toText
+          (records |> Array.length) |> shouldBe 0
+
+      it "returns empty when the cursor is above the current max (A3)" \_ -> do
+        catchUpFixture \conn _store entityName -> do
+          insertN conn entityName 1
+          maxNow <- currentMaxPosition conn
+          records <-
+            Sessions.selectEventsForwardFromGlobalPositionSession (maxNow + 1000)
+              |> Sessions.runConnection conn
+              |> Task.mapError toText
+          (records |> Array.length) |> shouldBe 0
+
+      it "is exclusive of the cursor position (A4)" \_ -> do
+        catchUpFixture \conn _store entityName -> do
+          maxBefore <- currentMaxPosition conn
+          insertN conn entityName 2
+          -- Read from the position of the FIRST new event: it must be excluded.
+          records <-
+            Sessions.selectEventsForwardFromGlobalPositionSession (maxBefore + 1)
+              |> Sessions.runConnection conn
+              |> Task.mapError toText
+          let positions = records |> Array.map (\r -> r.globalPosition)
+          (positions |> allInArray (\p -> p > maxBefore + 1)) |> shouldBe True
+
+  describe "catchUpFromCursor (reconnect catch-up)" do
+    whenEnvVar "POSTGRES_AVAILABLE" do
+      it "dispatches every event committed during the outage — no events skipped (B1, issue #682)" \_ -> do
+        catchUpFixture \conn store entityName -> do
+          collector <- ConcurrentVar.containing Array.empty
+          attachCollector store collector
+          maxBefore <- currentMaxPosition conn
+          cursor <- Var.new maxBefore
+          -- Simulate the outage: events commit while no LISTEN is active.
+          insertN conn entityName 3
+          -- Reconnect catch-up replays the gap.
+          catchUpFromCursor conn store cursor
+          received <- ConcurrentVar.peek collector
+          (received |> Array.length) |> shouldBe 3
+
+      it "dispatches nothing when there is no gap (B2)" \_ -> do
+        catchUpFixture \conn store entityName -> do
+          insertN conn entityName 2
+          collector <- ConcurrentVar.containing Array.empty
+          attachCollector store collector
+          maxNow <- currentMaxPosition conn
+          cursor <- Var.new maxNow
+          catchUpFromCursor conn store cursor
+          received <- ConcurrentVar.peek collector
+          (received |> Array.length) |> shouldBe 0
+
+      it "advances the cursor to the last caught-up position (B3)" \_ -> do
+        catchUpFixture \conn store entityName -> do
+          collector <- ConcurrentVar.containing Array.empty
+          attachCollector store collector
+          maxBefore <- currentMaxPosition conn
+          cursor <- Var.new maxBefore
+          insertN conn entityName 3
+          maxAfter <- currentMaxPosition conn
+          catchUpFromCursor conn store cursor
+          finalCursor <- Var.get cursor
+          finalCursor |> shouldBe maxAfter
+
+      it "propagates a read failure rather than silently skipping the gap (B4)" \_ -> do
+        catchUpFixture \conn store entityName -> do
+          let _ = entityName
+          -- Close the connection, then attempt catch-up: the read must error.
+          Hasql.release conn |> Task.fromIO
+          cursor <- Var.new (0 :: Int64)
+          result <- catchUpFromCursor conn store cursor |> Task.asResult
+          result |> shouldSatisfy resultIsErr
+
+
+-- | A reconnect-catch-up Postgres fixture: acquire a fresh query connection,
+-- build a SubscriptionStore, run the body on a unique entity name, and always
+-- release the connection afterwards.
+catchUpFixture ::
+  (Hasql.Connection -> SubscriptionStore -> EntityName -> Task Text Unit) ->
+  Task Text Unit
+catchUpFixture body = do
+  let cfg =
+        PostgresEventStore
+          { host = "localhost",
+            databaseName = "neohaskell",
+            user = "neohaskell",
+            password = "neohaskell",
+            port = 5432
+          }
+  -- Ensure the events table + trigger exist by creating a store once.
+  store0 <- Postgres.new cfg |> Task.mapError toText
+  store0.close
+  conn <-
+    Hasql.acquire (toConnectionSettings cfg)
+      |> Task.fromIOEither
+      |> Task.mapError toText
+  subStore <- SubscriptionStore.new |> Task.mapError toText
+  let entityName = EntityName "ReconnectCatchUpEntity"
+  result <- body conn subStore entityName |> Task.asResult
+  -- Best-effort release (B4 may have already released it).
+  (Hasql.release conn |> Task.fromIO) |> Task.asResult |> discard
+  case result of
+    Err err -> Test.fail [fmt|catch-up fixture body failed: #{err}|]
+    Ok _ -> Task.yield unit
+
+
+-- | Insert @n@ events into the global stream via a fresh store on the same DB,
+-- exercising the real insert + NOTIFY-trigger path.
+insertN :: Hasql.Connection -> EntityName -> Int -> Task Text Unit
+insertN _conn entityName n = do
+  let cfg =
+        PostgresEventStore
+          { host = "localhost",
+            databaseName = "neohaskell",
+            user = "neohaskell",
+            password = "neohaskell",
+            port = 5432
+          }
+  store <- Postgres.new cfg |> Task.mapError toText
+  Task.forEach (\_ -> insertTestEvent store entityName) (Array.fromLinkedList (rangeList n))
+  store.close
+
+
+-- | The current MAX(globalPosition), or -1 when the table is empty.
+currentMaxPosition :: Hasql.Connection -> Task Text Int64
+currentMaxPosition conn = do
+  maybeMax <-
+    Sessions.selectMaxGlobalPosition
+      |> Sessions.runConnection conn
+      |> Task.mapError toText
+  case maybeMax of
+    Nothing -> Task.yield (-1)
+    Just (StreamPosition p) -> Task.yield p
+
+
+-- | Register a global subscription that appends every dispatched event to the
+-- collector.
+attachCollector ::
+  SubscriptionStore ->
+  ConcurrentVar.ConcurrentVar (Array (Event Json.Value)) ->
+  Task Text Unit
+attachCollector store collector = do
+  let callback event = do
+        collector |> ConcurrentVar.modify (\events -> events |> Array.push event)
+        Task.yield unit
+  store
+    |> SubscriptionStore.addGlobalSubscription callback
+    |> Task.mapError toText
+    |> discard
+
+
+-- | True when every element of the array satisfies the predicate.
+allInArray :: (a -> Bool) -> Array a -> Bool
+allInArray predicate arr =
+  (arr |> Array.takeIf predicate |> Array.length) == (arr |> Array.length)
+
+
+-- | True when the positions are in strictly ascending order.
+isAscending :: Array Int64 -> Bool
+isAscending arr =
+  checkAscending (Array.toLinkedList arr)
+
+
+checkAscending :: LinkedList Int64 -> Bool
+checkAscending xs =
+  case xs of
+    [] -> True
+    [_] -> True
+    (a : b : rest) -> a < b && checkAscending (b : rest)
+
+
+-- | A list @[1 .. n]@ used only to drive @n@ inserts.
+rangeList :: Int -> LinkedList Int
+rangeList n =
+  if n <= 0
+    then []
+    else buildRange 1 n
+
+
+buildRange :: Int -> Int -> LinkedList Int
+buildRange lo hi =
+  if lo > hi
+    then []
+    else lo : buildRange (lo + 1) hi
+
+
+resultIsErr :: Result err val -> Bool
+resultIsErr result =
+  case result of
+    Err _ -> True
+    Ok _ -> False

--- a/docs/decisions/0061-listener-reconnect-catchup.md
+++ b/docs/decisions/0061-listener-reconnect-catchup.md
@@ -138,18 +138,25 @@ listener and is discarded only when the listener is cancelled.
 `subscribeToAllEventsFromPositionImpl` feeds catch-up events to a
 **single** callback because it is registering **one** subscription. The
 listener is different: it is the shared delivery channel for **all**
-live subscriptions. So the listener's catch-up reuses the *read* half
-of the existing path — read events forward from a position via the
-EventStore's forward-read — but sinks each event into
+live subscriptions. So the listener's catch-up uses a dedicated
+position-based forward read but sinks each event into
 `SubscriptionStore.dispatch event.streamId event`, the exact sink the
-live `processNotification` already uses (Notifications.hs line 115).
+live `processNotification` already uses (Notifications.hs).
 
-Concretely, the catch-up step calls the existing position-based read
-(`readAllEventsForwardFrom` / `selectMaxGlobalPosition` in
-`Internal.hs`) over the listener's `queryConnection`, iterates the
-returned events in `globalPosition` order, and for each one runs the
-same dispatch the live handler runs. This keeps one dispatch sink and
-one read implementation; the reconnect path adds only the glue.
+Concretely, the catch-up step calls
+`selectEventsForwardFromGlobalPositionSession cursor limit` (added in
+`Service.EventStore.Postgres.Sessions`) over the listener's
+`queryConnection`. That session reads at most `limit` rows with
+`GlobalPosition > $1 ORDER BY GlobalPosition ASC LIMIT $2` — the strict
+`>` boundary makes the read exclusive of the already-dispatched cursor,
+and the `LIMIT` keeps each read bounded. `catchUpFromCursor` loops:
+read a batch (`limit` = the ADR-0059 rebuild chunk size, 1000),
+dispatch each event in `globalPosition` order through the live sink,
+advance the in-memory cursor to the last position in the batch, and
+repeat until a batch returns fewer than `limit` rows (the gap is
+drained). This keeps one dispatch sink and a bounded reconnect read; a
+long outage cannot pull the whole gap into one `Array`. The reconnect
+path adds only the batched read and the loop glue.
 
 ### 4. Idempotency and at-least-once semantics
 
@@ -246,7 +253,9 @@ connectTo ::
 ```
 
 The catch-up is an internal helper invoked inside the reconnect loop,
-reusing the existing forward-read from `Internal.hs`.
+using the batched forward read
+`selectEventsForwardFromGlobalPositionSession` in
+`Service.EventStore.Postgres.Sessions`.
 
 ## Consequences
 
@@ -255,9 +264,11 @@ reusing the existing forward-read from `Internal.hs`.
 - **The silent lost-NOTIFY gap is closed** — events inserted while the
   listener is down reach live projections and integrations after
   reconnect. This is the highest-value correctness item in epic #679.
-- **One read implementation, one dispatch sink** — the reconnect path
-  reuses the tested forward-read and the existing `SubscriptionStore`
-  fan-out; no parallel catch-up logic to keep in sync.
+- **One dispatch sink, one bounded read** — the reconnect path sinks
+  catch-up events through the existing `SubscriptionStore` fan-out (the
+  same sink the live handler uses) and reads the gap with a single
+  batched forward session (`selectEventsForwardFromGlobalPositionSession`);
+  no parallel dispatch logic to keep in sync, and the read is memory-bounded.
 - **No persistence, no migration, no new dependency** — the events
   table is the only durable cursor; the in-memory `Var` is the only new
   state, scoped to the listener's lifetime.
@@ -270,8 +281,12 @@ reusing the existing forward-read from `Internal.hs`.
   dispatched twice. Acceptable because projection apply is idempotent by
   `globalPosition`, but it is a behavioural note worth recording.
 - **Catch-up cost is `O(events-in-the-gap)`** — a very long outage means
-  a larger catch-up read on reconnect. Bounded by the actual gap, not by
-  total log size, so it is proportional to downtime and self-limiting.
+  more catch-up rows to replay on reconnect. The work is bounded by the
+  actual gap, not by total log size, so it is proportional to downtime and
+  self-limiting. Memory is additionally bounded per reconnect: the read
+  pages in batches of 1000 (`selectEventsForwardFromGlobalPositionSession`
+  with a `LIMIT`), so even a multi-hour outage never pulls the whole gap
+  into one `Array`.
 
 ### Risks
 
@@ -317,5 +332,6 @@ reusing the existing forward-read from `Internal.hs`.
 - [#661: Scale-to-zero shutdown cluster](https://github.com/neohaskell/NeoHaskell/issues/661)
 - [#662: Scale-to-zero shutdown cluster](https://github.com/neohaskell/NeoHaskell/issues/662)
 - [core/service/Service/EventStore/Postgres/Notifications.hs](../../core/service/Service/EventStore/Postgres/Notifications.hs)
+- [core/service/Service/EventStore/Postgres/Sessions.hs](../../core/service/Service/EventStore/Postgres/Sessions.hs)
 - [core/service/Service/EventStore/Postgres/Internal.hs](../../core/service/Service/EventStore/Postgres/Internal.hs)
 - [core/service/Service/EventStore/Postgres/SubscriptionStore.hs](../../core/service/Service/EventStore/Postgres/SubscriptionStore.hs)

--- a/docs/decisions/0061-listener-reconnect-catchup.md
+++ b/docs/decisions/0061-listener-reconnect-catchup.md
@@ -1,0 +1,321 @@
+# ADR-0061: Replay from Last globalPosition on LISTEN/NOTIFY Listener Reconnect
+
+> Issue: [#682 — WI-3: Replay from last globalPosition on LISTEN/NOTIFY listener reconnect](https://github.com/neohaskell/NeoHaskell/issues/682)
+
+## Status
+
+Proposed
+
+## Context
+
+### Current State
+
+The Postgres EventStore drives **live** projections and outbound
+integrations through a single supervised `LISTEN/NOTIFY` listener.
+`Service.EventStore.Postgres.Notifications.connectTo`
+(`core/service/Service/EventStore/Postgres/Notifications.hs` lines
+25–76) opens a `(listenConnection, queryConnection)` pair, issues
+`LISTEN "global"`, and blocks in `waitForNotifications`. Every `NOTIFY`
+carries a lightweight payload; the handler reads the full event by its
+`globalPosition` and pushes it into `SubscriptionStore.dispatch`, which
+fans it out to every registered global / entity / stream subscription.
+
+When the listen connection dies (Flexible Server maintenance restart,
+failover, transient network drop), `listenerWithReconnect` (lines
+32–64) catches the failure, sleeps an exponential backoff, re-acquires
+the connection pair, and **re-issues `LISTEN`**. That is the whole
+reconnect path — it performs **no catch-up read**.
+
+`NOTIFY` is not durable. Postgres delivers a notification only to
+sessions that are actively `LISTEN`ing at the moment the transaction
+commits. Any event whose row was inserted (and whose trigger fired
+`NOTIFY`) during the window between the connection dying and the new
+`LISTEN` taking effect is **never delivered to the new session**. The
+event is durably stored in the events table, so historical reads and a
+fresh subscription's catch-up still see it — but **live dispatch
+silently skips it**. Projections built from live dispatch drift; an
+outbound integration that should have reacted never fires. Nothing logs
+an error, because from the listener's point of view nothing went wrong.
+
+The fix already exists for a different entry point. New subscriptions
+created via `subscribeToAllEventsFromPositionImpl`
+(`core/service/Service/EventStore/Postgres/Internal.hs` lines 667–728)
+run a `catchUp` loop that reads every event forward from a starting
+`globalPosition` and feeds it through the subscriber callback before
+attaching the live subscription. The reconnect loop needs the same
+catch-up, applied to the shared `SubscriptionStore` rather than to one
+callback.
+
+### Use Cases
+
+- **Flexible Server maintenance restart** — Azure restarts the database
+  for a patch. The listener's TCP connection drops, events keep being
+  inserted by other app replicas (or queued commands draining after the
+  restart), and the listener reconnects seconds later. Every event
+  inserted during the outage must reach live projections.
+- **Transient network drop / failover** — a brief partition kills the
+  listen socket; the keepalive (ADR-0037) detects the dead socket and
+  the loop reconnects. Catch-up closes the gap with no operator action.
+- **Cold-path command drain after a stall** — a backlog of commands
+  commits in a burst right as the listener is mid-reconnect; without
+  catch-up the burst is partially or wholly lost from live dispatch.
+
+### Design Goals
+
+1. **No event silently skipped from live dispatch across a reconnect** —
+   this is a correctness fix; the acceptance bar is zero skipped events.
+2. **Reuse the proven catch-up read path**, not a second
+   implementation — the forward-read-from-position loop already exists
+   and is tested; the reconnect path routes through the same mechanism.
+3. **Track the last-processed `globalPosition` across reconnects** so
+   catch-up knows where the gap starts, without persisting anything new
+   (the events table is already the durable source of truth).
+4. **At-least-once is acceptable; at-most-once is not** — duplicate
+   delivery of a boundary event is tolerable because event replay is
+   idempotent by `globalPosition`; a dropped event is not tolerable.
+5. **No new public API and no new vocabulary for Jess** — the listener
+   is framework-internal; the fix must be invisible to application code.
+
+### GitHub Issue
+
+- [#682: WI-3 — Replay from last globalPosition on LISTEN/NOTIFY listener reconnect](https://github.com/neohaskell/NeoHaskell/issues/682)
+
+## Decision
+
+### 1. Insert a catch-up read into the reconnect loop, before live wait
+
+`listenerWithReconnect` re-issues `LISTEN` and then immediately blocks
+in `waitForNotifications`. We insert one step **between** them: after
+`LISTEN` is established on the fresh connection but before the live
+wait begins, replay every event from the last-processed
+`globalPosition` (exclusive) up to the current max, dispatching each
+through the same `SubscriptionStore` the live handler uses.
+
+Ordering is load-bearing. `LISTEN` must be active **before** the
+catch-up read takes its max-position snapshot, so an event committed
+*during* the catch-up read is either picked up by the read or delivered
+live by the now-active `LISTEN` (overlap, never gap). Issuing the
+catch-up before `LISTEN` would reopen the exact window we are closing.
+
+| Candidate | Verdict | Rationale |
+|-----------|---------|-----------|
+| Catch-up before `LISTEN` | Rejected | Reopens the lost-NOTIFY window for events committed between the read snapshot and `LISTEN` taking effect. |
+| Catch-up after `LISTEN`, before live wait | **Chosen** | `LISTEN` active first guarantees overlap (at-least-once), never a gap. |
+| No catch-up; rely on periodic full re-subscribe | Rejected | Re-derives the entire log on every reconnect — `O(eventCount)` per drop; defeats the live-dispatch design. |
+| Persist a checkpoint table for the listener | Rejected | The events table is already the durable cursor; a second persisted cursor adds a write path and a new failure mode (ADR-0059 owns persistent query cursors — this is a transient in-memory cursor). |
+
+### 2. Track last-processed position in a Var owned by `connectTo`
+
+The listener async task created by `connectTo` outlives every
+individual reconnect — `listenerWithReconnect` recurses within the same
+task. We add a `Var Int64` (last-processed `globalPosition`,
+`StreamPosition`-typed) allocated **once** in `connectTo`'s scope,
+alongside the existing `shutdownRef` and `currentConnectionsRef`. It is:
+
+- **Initialised** to the current max `globalPosition` at listener start,
+  so the first connection does not replay the entire history (a fresh
+  listener inherits the same "subscribe from now" semantics it has
+  today — historical replay is the job of `subscribeFromPosition`, not
+  the live listener).
+- **Advanced** by the live notification handler each time an event is
+  dispatched, so it always reflects the high-water mark of what live
+  dispatch has delivered.
+- **Read** by the catch-up step on each reconnect to know where the gap
+  begins, and **advanced** again as catch-up dispatches each event.
+
+Because the Var lives in the async task's closure (not in a connection
+or in the database), it survives every reconnect for the life of the
+listener and is discarded only when the listener is cancelled.
+
+| Candidate | Verdict | Rationale |
+|-----------|---------|-----------|
+| `Var Int64` in `connectTo` closure | **Chosen** | Survives reconnect, no persistence, matches the existing `Var`-based state in `connectTo`. |
+| Re-query max position from DB on each reconnect as the cursor | Rejected | The DB max is *ahead* of what live dispatch delivered during the outage; using it as the start would skip exactly the gap events we must replay. |
+| Persist the cursor in a Postgres row | Rejected | Adds a durable write path for a value the events table already implies; out of scope (correctness fix, not a new subsystem). |
+
+### 3. Route catch-up through `SubscriptionStore.dispatch`, not a new subscription
+
+`subscribeToAllEventsFromPositionImpl` feeds catch-up events to a
+**single** callback because it is registering **one** subscription. The
+listener is different: it is the shared delivery channel for **all**
+live subscriptions. So the listener's catch-up reuses the *read* half
+of the existing path — read events forward from a position via the
+EventStore's forward-read — but sinks each event into
+`SubscriptionStore.dispatch event.streamId event`, the exact sink the
+live `processNotification` already uses (Notifications.hs line 115).
+
+Concretely, the catch-up step calls the existing position-based read
+(`readAllEventsForwardFrom` / `selectMaxGlobalPosition` in
+`Internal.hs`) over the listener's `queryConnection`, iterates the
+returned events in `globalPosition` order, and for each one runs the
+same dispatch the live handler runs. This keeps one dispatch sink and
+one read implementation; the reconnect path adds only the glue.
+
+### 4. Idempotency and at-least-once semantics
+
+Catch-up is **at-least-once**. A `NOTIFY` that arrived just before the
+socket died might have been dispatched live *and* fall inside the
+catch-up range, so a boundary event can be delivered twice. This is
+safe:
+
+- The `SubscriptionStore` already filters per subscription on
+  `startingGlobalPosition` with `eventPos >= startPos`
+  (`SubscriptionStore.dispatch`, lines 167–169), so a subscription that
+  started after the duplicate's position ignores it.
+- Event-sourced projection apply is **idempotent by `globalPosition`** —
+  re-applying an already-seen event is a no-op for any correct read
+  model. ADR-0059's checkpointed rebuild relies on the same property.
+- The handler's existing per-callback error isolation
+  (`wrapCallback` / `runAllIgnoringErrors`) means a duplicate that *does*
+  upset one subscriber cannot stall the others.
+
+We explicitly **reject** trying to make delivery exactly-once
+(deduplication table, two-phase ack) — it would add a write path and
+contention for a guarantee event sourcing does not need.
+
+### 5. No new public API
+
+The change is entirely inside `connectTo` (and a small internal helper
+shared with the forward-read path). `EventStore`'s public surface,
+`Application` wiring, and every subscription API are untouched. Jess
+never sees this; existing apps gain the correctness fix on upgrade with
+no code change.
+
+### 5a. Interaction with full service restart (scope boundary)
+
+This ADR (WI-3) scopes **only the in-process listener reconnect** — the
+case where the `LISTEN` socket drops (Flexible Server maintenance,
+failover, transient network blip) **while the app process stays alive**.
+In that case the in-memory `lastProcessedRef` cursor described above is
+exactly what closes the gap. The cases below are **out of scope**;
+they are recorded only so a reader does not mistake the in-memory cursor
+for a cross-restart durability mechanism.
+
+- **Full service restart is out of scope and is already handled
+  elsewhere.** On a full restart (process crash, redeploy, ACA
+  scale-to-zero), the in-memory `lastProcessedRef` cursor is lost and a
+  fresh listener initialises **"from now"** at the current max
+  `globalPosition` (the same "subscribe from now" semantics the listener
+  has today). The listener does **not** attempt to replay across a
+  restart — and it does not need to. **Read-model projections recover via
+  the persistent `QueryObjectStore` checkpoints plus the startup rebuild
+  from [ADR-0059 (#650)](0059-async-query-rebuild-with-persistent-checkpoints.md)**:
+  on boot, each query rebuilds forward from its durable checkpoint, so
+  projection correctness across a restart depends on that persisted
+  cursor, **not** on this ADR's in-memory listener cursor. The two cursors
+  are deliberately separate: ADR-0059 owns the durable, cross-restart
+  query cursor; this ADR owns the transient, in-memory live-dispatch
+  cursor that only has to survive a reconnect *within* one process.
+
+- **Outbound-integration subscribers across a restart are a separate,
+  out-of-scope concern.** Unlike read-model projections, outbound
+  integration subscribers do **not** today have a persistent
+  per-subscriber checkpoint, so an event committed while the process is
+  down is not automatically re-delivered to them on the next boot.
+  Closing that gap is explicitly **not** part of WI-3 — it is tracked
+  separately under
+  [#571](https://github.com/neohaskell/NeoHaskell/issues/571), and it
+  interacts with the scale-to-zero graceful-shutdown cluster
+  ([#252](https://github.com/neohaskell/NeoHaskell/issues/252) /
+  [#653](https://github.com/neohaskell/NeoHaskell/issues/653) /
+  [#661](https://github.com/neohaskell/NeoHaskell/issues/661) /
+  [#662](https://github.com/neohaskell/NeoHaskell/issues/662)). This ADR
+  neither solves nor regresses that case; it only closes the
+  same-process reconnect gap.
+
+### 6. Type Definitions
+
+No new public types. The internal cursor is the existing position type:
+
+```haskell
+-- Internal to connectTo's closure (illustrative, not a new export):
+-- last-processed global position, shared across reconnects
+lastProcessedRef :: Var Int64
+```
+
+### 7. Public API
+
+No additions or changes to the public API. `connectTo`'s signature is
+unchanged:
+
+```haskell
+connectTo ::
+  Task Text (Hasql.Connection, Hasql.Connection) ->
+  SubscriptionStore ->
+  Task Text (Task Text Unit)
+```
+
+The catch-up is an internal helper invoked inside the reconnect loop,
+reusing the existing forward-read from `Internal.hs`.
+
+## Consequences
+
+### Positive
+
+- **The silent lost-NOTIFY gap is closed** — events inserted while the
+  listener is down reach live projections and integrations after
+  reconnect. This is the highest-value correctness item in epic #679.
+- **One read implementation, one dispatch sink** — the reconnect path
+  reuses the tested forward-read and the existing `SubscriptionStore`
+  fan-out; no parallel catch-up logic to keep in sync.
+- **No persistence, no migration, no new dependency** — the events
+  table is the only durable cursor; the in-memory `Var` is the only new
+  state, scoped to the listener's lifetime.
+- **Invisible to applications** — no new vocabulary, no config knob, no
+  API change; Jess gets the fix for free on upgrade.
+
+### Negative
+
+- **At-least-once on the reconnect boundary** — a boundary event may be
+  dispatched twice. Acceptable because projection apply is idempotent by
+  `globalPosition`, but it is a behavioural note worth recording.
+- **Catch-up cost is `O(events-in-the-gap)`** — a very long outage means
+  a larger catch-up read on reconnect. Bounded by the actual gap, not by
+  total log size, so it is proportional to downtime and self-limiting.
+
+### Risks
+
+- **Cursor under-advance on a partial dispatch** — if the live handler
+  advances `lastProcessedRef` before a callback failure is fully
+  absorbed, a later catch-up might not re-cover that event. Mitigated by
+  advancing the cursor on successful read/dispatch and leaning on
+  at-least-once: under-advance causes a re-deliver (safe), never a skip.
+- **Catch-up read itself fails mid-reconnect** — if the forward-read
+  errors, the reconnect attempt fails and the supervised loop retries
+  with backoff, so the gap is retried rather than lost.
+- **Ordering regression** — if a future refactor moves the catch-up
+  before `LISTEN`, the gap reopens silently. Mitigated by the regression
+  test (below) and a comment marking the ordering as load-bearing.
+
+### Mitigations
+
+- **Regression test (acceptance criterion):** kill the listen
+  connection mid-stream, insert events during the outage, force a
+  reconnect, and assert **no events are skipped** from live dispatch
+  after reconnect. Lives in
+  `core/test/Service/EventStore/Postgres/NotificationsSpec.hs`
+  (Postgres-gated, self-skips when `POSTGRES_AVAILABLE` is unset).
+- **Empirical validation:** verify against an induced Flexible Server
+  maintenance restart on the direct `5432` endpoint (insert during the
+  outage, confirm catch-up recovers it) — per epic #679's validation
+  checklist.
+- **Load-bearing-ordering comment** at the catch-up call site so a
+  future reader does not reorder `LISTEN` and catch-up.
+
+## References
+
+- [#682: WI-3 — Replay from last globalPosition on listener reconnect](https://github.com/neohaskell/NeoHaskell/issues/682)
+- [#679: Epic — Deploy-readiness on Azure Database for PostgreSQL Flexible Server](https://github.com/neohaskell/NeoHaskell/issues/679)
+- [ADR-0037: LISTEN connection keepalives + supervised reconnect loop (#397)](0037-postgres-listen-keepalive-reconnect.md)
+- [ADR-0039: Connection-leak lifecycle + EventStore.close (#439)](0039-fix-listen-notify-connection-leak.md)
+- [ADR-0059: Async query rebuild with persistent checkpoints (#650)](0059-async-query-rebuild-with-persistent-checkpoints.md)
+- [#401: Structured logging at silent-failure points (this closes one)](https://github.com/neohaskell/NeoHaskell/issues/401)
+- [#399: Sibling silent-failure on the command path](https://github.com/neohaskell/NeoHaskell/issues/399)
+- [#571: Outbound-integration subscriber recovery across restart (out of scope here)](https://github.com/neohaskell/NeoHaskell/issues/571)
+- [#252: Scale-to-zero graceful shutdown](https://github.com/neohaskell/NeoHaskell/issues/252)
+- [#653: Scale-to-zero shutdown cluster](https://github.com/neohaskell/NeoHaskell/issues/653)
+- [#661: Scale-to-zero shutdown cluster](https://github.com/neohaskell/NeoHaskell/issues/661)
+- [#662: Scale-to-zero shutdown cluster](https://github.com/neohaskell/NeoHaskell/issues/662)
+- [core/service/Service/EventStore/Postgres/Notifications.hs](../../core/service/Service/EventStore/Postgres/Notifications.hs)
+- [core/service/Service/EventStore/Postgres/Internal.hs](../../core/service/Service/EventStore/Postgres/Internal.hs)
+- [core/service/Service/EventStore/Postgres/SubscriptionStore.hs](../../core/service/Service/EventStore/Postgres/SubscriptionStore.hs)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -70,6 +70,7 @@ ADRs document significant architectural decisions made during the development of
 | [0054](0054-multi-tenant-command-query-support.md) | Multi-Tenant Support for Commands and Queries | Accepted |
 | [0055](0055-declarative-integrations-with-fakes.md) | Declarative Integrations with Real/Fake Parity | Proposed |
 | [0056](0056-request-context-timestamp-as-datetime.md) | Retype `RequestContext.timestamp` as `DateTime` | Proposed |
+| [0061](0061-listener-reconnect-catchup.md) | Replay from Last globalPosition on LISTEN/NOTIFY Listener Reconnect | Proposed |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## What & why

NeoHaskell's live subscriptions/projections ride on PostgreSQL `LISTEN/NOTIFY`. The supervised reconnect loop re-issues `LISTEN` after a dropped listen connection (maintenance restart, failover, transient network drop) — but `NOTIFY` is not durable, so any event committed **while the listener was down** produced no notification and was **silently skipped** from live dispatch. No error, no log: projections and outbound integrations just missed those events.

## What changed

On every (re)connect, the listener now does a **position-based catch-up read** before resuming live dispatch:

- `Sessions.hs` — new `selectEventsForwardFromGlobalPositionSession` (`WHERE GlobalPosition > $1 ORDER BY GlobalPosition ASC`, exclusive of the cursor).
- `Notifications.hs` — an in-memory `globalPosition` cursor in `connectTo`: initialised "from now" on first connect, advanced by live dispatch, and `catchUpFromCursor` runs **after `LISTEN` is active but before the live wait**. That ordering is load-bearing: the active `LISTEN` and the catch-up read overlap, so an event is either replayed or delivered live — never dropped. Catch-up reuses the existing forward-read path and sinks into the same `SubscriptionStore.dispatch` the live handler uses.
- At-least-once on the reconnect boundary is safe: `dispatch` already filters per-subscription by position and projections are idempotent by `globalPosition`.

### Scope (see ADR-0061)
This covers the **in-process** listener reconnect. A **full service restart** (crash / redeploy / scale-to-zero) loses the in-memory cursor and starts "from now"; read-model projections recover via ADR-0059's persistent QueryObjectStore checkpoints, not this cursor. Outbound-subscriber recovery across a restart is out of scope (tracked by #571 and the scale-to-zero cluster #252/#653/#661/#662).

## Testing

- 11 new `NotificationsSpec` tests, incl. the acceptance test: insert events during a listener outage → assert **no events skipped** after catch-up (plus forward-read, cursor-advance, error-propagation).
- `cabal build all` ✅ · `cabal test all` with PostgreSQL live → **0 failures** across all suites · `hlint` clean.

## References
- ADR: `docs/decisions/0061-listener-reconnect-catchup.md`
- Part of #679 (Azure Flexible Server deploy-readiness epic)

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Postgres `LISTEN/NOTIFY` listener reconnect to replay missed events after outages using the last processed `globalPosition` (exclusive).
  * Ensured the reconnect catch-up cursor advances monotonically for both live notifications and replay, avoiding backward movement.
  * Updated catch-up behavior to surface read/decoding failures instead of silently skipping events.

* **Tests**
  * Added Postgres integration and end-to-end coverage for reconnection/catch-up, including cursor boundaries, ordering, gap replay correctness, and failure propagation.

* **Documentation**
  * Added ADR-0061 documenting the reconnect replay approach and its correctness guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->