### PR TITLE
refactor(service): unify the three Postgres connection-settings builders (#681)

### DIFF
--- a/core/nhcore.cabal
+++ b/core/nhcore.cabal
@@ -243,6 +243,7 @@ library
     Service.EventStore.Postgres
     Service.EventStore.Postgres.Internal
     Service.EventStore.Postgres.Core
+    Service.Infra.Postgres.ConnectionConfig
     Service.EventStore.Postgres.Notifications
     Service.EventStore.Postgres.PostgresEventRecord
     Service.EventStore.Postgres.Sessions
@@ -566,6 +567,7 @@ test-suite nhcore-test-service
     Service.EventStore.InMemorySpec
     Service.EventStore.SimpleSpec
     Service.EventStore.Postgres.PoolBudgetSpec
+    Service.Infra.Postgres.ConnectionConfigSpec
     Service.EventStore.Postgres.SubscriptionStoreSpec
     Service.EventStore.Postgres.NotificationsSpec
     Service.EventStore.PostgresSpec

--- a/core/service/Service/EventStore/Postgres/Internal.hs
+++ b/core/service/Service/EventStore/Postgres/Internal.hs
@@ -16,20 +16,15 @@ import Basics
 import Default (Default)
 import Default qualified
 import Hasql.Connection qualified as Hasql
-import Hasql.Connection.Setting qualified as ConnectionSetting
 import Hasql.Connection.Setting qualified as Hasql
-import Hasql.Connection.Setting.Connection qualified as ConnectionSettingConnection
-import Hasql.Connection.Setting.Connection.Param qualified as Param
 import Hasql.Pool qualified as HasqlPool
-import Hasql.Pool.Config qualified as HasqlPoolConfig
-import Hasql.Pool.Observation (ConnectionStatus (..), ConnectionTerminationReason (..), Observation (..))
 import Json qualified
 import Log qualified
-import Prelude qualified
 import LinkedList (LinkedList)
 import Maybe (Maybe (..))
 import Maybe qualified
 import Result (Result (..))
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Service.Event
 import Service.Event.EntityName qualified as EntityName
 import Service.Event.EventMetadata (EventMetadata (..))
@@ -97,53 +92,16 @@ instance EventStoreConfig PostgresEventStore where
   createEventStore = new defaultOps
 
 
-toConnectionPoolSettings :: Int -> LinkedList Hasql.Setting -> HasqlPoolConfig.Config
-toConnectionPoolSettings poolSize settings =
-  [ HasqlPoolConfig.staticConnectionSettings settings
-  , HasqlPoolConfig.size poolSize
-  , HasqlPoolConfig.agingTimeout 300
-  , HasqlPoolConfig.idlenessTimeout 60
-  , HasqlPoolConfig.observationHandler logPoolObservation
-  ]
-    |> HasqlPoolConfig.settings
-
-
--- | Log connection pool lifecycle events for observability.
--- Only logs termination events to avoid overhead under high load.
--- See ADR-0027 for rationale.
-logPoolObservation :: Observation -> Prelude.IO ()
-logPoolObservation observation = case observation of
-  ConnectionObservation _uuid status -> case status of
-    TerminatedConnectionStatus reason -> case reason of
-      AgingConnectionTerminationReason ->
-        ((Log.debug "[Pool] Connection terminated (aging timeout)" |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-      IdlenessConnectionTerminationReason ->
-        ((Log.debug "[Pool] Connection terminated (idleness timeout)" |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-      NetworkErrorConnectionTerminationReason err ->
-        ((Log.critical [fmt|[Pool] Connection terminated (network error: #{show err})|] |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-      ReleaseConnectionTerminationReason ->
-        Prelude.pure ()
-      InitializationErrorTerminationReason err ->
-        ((Log.critical [fmt|[Pool] Connection terminated (init error: #{show err})|] |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-    _ -> Prelude.pure ()
-
-
 toConnectionSettings :: PostgresEventStore -> LinkedList Hasql.Setting
-toConnectionSettings cfg = do
-  let params =
-        ConnectionSettingConnection.params
-          [ Param.host cfg.host,
-            Param.port (fromIntegral cfg.port),
-            Param.dbname cfg.databaseName,
-            Param.user cfg.user,
-            Param.password cfg.password,
-            -- TCP keepalive: detect dead connections in cloud environments (ADR-0037, #397)
-            Param.other "keepalives" "1",
-            Param.other "keepalives_idle" "30",
-            Param.other "keepalives_interval" "10",
-            Param.other "keepalives_count" "5"
-          ]
-  [params |> ConnectionSetting.connection]
+toConnectionSettings cfg =
+  ConnectionConfig.toConnectionParams
+    ConnectionConfig.ConnectionParams
+      { host = cfg.host,
+        databaseName = cfg.databaseName,
+        user = cfg.user,
+        password = cfg.password,
+        port = cfg.port
+      }
 
 
 data Ops = Ops
@@ -163,7 +121,7 @@ defaultOps = do
             Task.throw [fmt|poolSize must be > 0, got #{size}|]
           True ->
             toConnectionSettings cfg
-              |> toConnectionPoolSettings cfg.poolSize
+              |> ConnectionConfig.toPoolConfig cfg.poolSize
               |> HasqlPool.acquire
               |> Task.fromIO
               |> Task.map (Sessions.Connection)

--- a/core/service/Service/EventStore/Postgres/Internal.hs
+++ b/core/service/Service/EventStore/Postgres/Internal.hs
@@ -92,7 +92,7 @@ instance EventStoreConfig PostgresEventStore where
   createEventStore = new defaultOps
 
 
-toConnectionSettings :: PostgresEventStore -> LinkedList Hasql.Setting
+toConnectionSettings :: PostgresEventStore -> Result Text (LinkedList Hasql.Setting)
 toConnectionSettings cfg =
   ConnectionConfig.toConnectionParams
     ConnectionConfig.ConnectionParams
@@ -102,6 +102,16 @@ toConnectionSettings cfg =
         password = cfg.password,
         port = cfg.port
       }
+
+
+-- | Resolve connection settings inside a Task, surfacing a port-validation
+-- error (see 'ConnectionConfig.validatePort') as a Text failure. Used by the
+-- LISTEN/NOTIFY paths that acquire one-off connections directly.
+connectionSettingsOrThrow :: PostgresEventStore -> Task Text (LinkedList Hasql.Setting)
+connectionSettingsOrThrow cfg =
+  case toConnectionSettings cfg of
+    Ok settings -> Task.yield settings
+    Err err -> Task.throw err
 
 
 data Ops = Ops
@@ -120,11 +130,15 @@ defaultOps = do
           False ->
             Task.throw [fmt|poolSize must be > 0, got #{size}|]
           True ->
-            toConnectionSettings cfg
-              |> ConnectionConfig.toPoolConfig cfg.poolSize
-              |> HasqlPool.acquire
-              |> Task.fromIO
-              |> Task.map (Sessions.Connection)
+            case toConnectionSettings cfg of
+              Err portErr ->
+                Task.throw portErr
+              Ok settings ->
+                settings
+                  |> ConnectionConfig.toPoolConfig cfg.poolSize
+                  |> HasqlPool.acquire
+                  |> Task.fromIO
+                  |> Task.map (Sessions.Connection)
 
   let initializeTable connection = do
         Sessions.createEventsTableSession
@@ -132,7 +146,8 @@ defaultOps = do
           |> Task.mapError toText
 
   let initializeSubscriptions _pool subscriptionStore cfg = do
-        initialListenConnection <- Hasql.acquire (toConnectionSettings cfg) |> Task.fromIOEither |> Task.mapError toText
+        listenSettings <- connectionSettingsOrThrow cfg
+        initialListenConnection <- Hasql.acquire listenSettings |> Task.fromIOEither |> Task.mapError toText
         Task.finally
           (Hasql.release initialListenConnection |> Task.fromIO)
           do
@@ -143,8 +158,9 @@ defaultOps = do
               |> Sessions.runConnection initialListenConnection
               |> Task.mapError toText
             let connectionFactory = do
-                  listenConnection <- Hasql.acquire (toConnectionSettings cfg) |> Task.fromIOEither |> Task.mapError toText
-                  queryResult <- Hasql.acquire (toConnectionSettings cfg) |> Task.fromIOEither |> Task.mapError toText |> Task.asResult
+                  factorySettings <- connectionSettingsOrThrow cfg
+                  listenConnection <- Hasql.acquire factorySettings |> Task.fromIOEither |> Task.mapError toText
+                  queryResult <- Hasql.acquire factorySettings |> Task.fromIOEither |> Task.mapError toText |> Task.asResult
                   case queryResult of
                     Ok queryConnection -> Task.yield (listenConnection, queryConnection)
                     Err err -> do
@@ -756,8 +772,11 @@ subscribeToStreamEventsImpl ::
 subscribeToStreamEventsImpl ops cfg store entityName streamId callback =
   ops |> withConnectionAndError cfg \conn -> do
     -- Subscribe to the stream-specific notification channel
+    streamSettings <-
+      connectionSettingsOrThrow cfg
+        |> Task.mapError (\err -> SubscriptionError (SubscriptionId "stream") err)
     connection <-
-      Hasql.acquire (toConnectionSettings cfg)
+      Hasql.acquire streamSettings
         |> Task.fromIOEither
         |> Task.mapError (\err -> SubscriptionError (SubscriptionId "stream") (err |> toText))
     Notifications.subscribeToStream connection streamId

--- a/core/service/Service/FileUpload/FileStateStore/Postgres.hs
+++ b/core/service/Service/FileUpload/FileStateStore/Postgres.hs
@@ -53,21 +53,16 @@ import Bytes qualified
 import Core
 import Data.Functor.Contravariant ((>$<))
 import Data.Semigroup ((<>))
-import Hasql.Connection.Setting qualified as ConnectionSetting
-import Hasql.Connection.Setting.Connection qualified as ConnectionSettingConnection
-import Hasql.Connection.Setting.Connection.Param qualified as Param
 import Hasql.Decoders qualified as Decoders
 import Hasql.Encoders qualified as Encoders
 import Hasql.Pool (Pool)
 import Hasql.Pool qualified as HasqlPool
-import Hasql.Pool.Config qualified as HasqlPoolConfig
-import Hasql.Pool.Observation (ConnectionStatus (..), ConnectionTerminationReason (..), Observation (..))
 import Hasql.Session qualified as Session
-import Log qualified
 import Prelude qualified
 import Hasql.Statement (Statement (..))
 
 import Result qualified
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Service.EventStore.Postgres (PostgresEventStore (..))
 import Service.FileUpload.Core (
   BlobKey (..),
@@ -172,45 +167,18 @@ createPool cfg = do
     False ->
       Task.throw (InvalidPoolSize [fmt|poolSize must be > 0, got #{size}|])
     True -> do
-      let params =
-            ConnectionSettingConnection.params
-              [ Param.host cfg.host
-              , Param.port (fromIntegral cfg.port)
-              , Param.dbname cfg.databaseName
-              , Param.user cfg.user
-              , Param.password cfg.password
-              ]
-      let settings = [params |> ConnectionSetting.connection]
-      let poolConfig =
-            [ HasqlPoolConfig.staticConnectionSettings settings
-            , HasqlPoolConfig.size cfg.poolSize
-            , HasqlPoolConfig.agingTimeout 300
-            , HasqlPoolConfig.idlenessTimeout 60
-            , HasqlPoolConfig.observationHandler logPoolObservation
-            ]
-              |> HasqlPoolConfig.settings
+      let settings =
+            ConnectionConfig.toConnectionParams
+              ConnectionConfig.ConnectionParams
+                { host = cfg.host
+                , databaseName = cfg.databaseName
+                , user = cfg.user
+                , password = cfg.password
+                , port = cfg.port
+                }
+      let poolConfig = ConnectionConfig.toPoolConfig cfg.poolSize settings
       HasqlPool.acquire poolConfig
         |> Task.fromIO
-
-
--- | Log connection pool lifecycle events for observability.
--- Only logs termination events to avoid overhead under high load.
--- See ADR-0027 for rationale.
-logPoolObservation :: Observation -> Prelude.IO ()
-logPoolObservation observation = case observation of
-  ConnectionObservation _uuid status -> case status of
-    TerminatedConnectionStatus reason -> case reason of
-      AgingConnectionTerminationReason ->
-        ((Log.debug "[Pool] Connection terminated (aging timeout)" |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-      IdlenessConnectionTerminationReason ->
-        ((Log.debug "[Pool] Connection terminated (idleness timeout)" |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-      NetworkErrorConnectionTerminationReason err ->
-        ((Log.critical [fmt|[Pool] Connection terminated (network error: #{show err})|] |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-      ReleaseConnectionTerminationReason ->
-        Prelude.pure ()
-      InitializationErrorTerminationReason err ->
-        ((Log.critical [fmt|[Pool] Connection terminated (init error: #{show err})|] |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
-    _ -> Prelude.pure ()
 
 
 -- | Create the file_upload_state table if it doesn't exist.

--- a/core/service/Service/FileUpload/FileStateStore/Postgres.hs
+++ b/core/service/Service/FileUpload/FileStateStore/Postgres.hs
@@ -87,6 +87,7 @@ data PostgresFileStoreError
   = PoolError HasqlPool.UsageError
   | DeserializationError Text
   | InvalidPoolSize Text
+  | InvalidPort Text
   deriving (Eq, Show)
 
 
@@ -166,19 +167,20 @@ createPool cfg = do
   case size > 0 of
     False ->
       Task.throw (InvalidPoolSize [fmt|poolSize must be > 0, got #{size}|])
-    True -> do
-      let settings =
-            ConnectionConfig.toConnectionParams
-              ConnectionConfig.ConnectionParams
-                { host = cfg.host
-                , databaseName = cfg.databaseName
-                , user = cfg.user
-                , password = cfg.password
-                , port = cfg.port
-                }
-      let poolConfig = ConnectionConfig.toPoolConfig cfg.poolSize settings
-      HasqlPool.acquire poolConfig
-        |> Task.fromIO
+    True ->
+      case ConnectionConfig.toConnectionParams
+             ConnectionConfig.ConnectionParams
+               { host = cfg.host
+               , databaseName = cfg.databaseName
+               , user = cfg.user
+               , password = cfg.password
+               , port = cfg.port
+               } of
+        Err portErr -> Task.throw (InvalidPort portErr)
+        Ok settings -> do
+          let poolConfig = ConnectionConfig.toPoolConfig cfg.poolSize settings
+          HasqlPool.acquire poolConfig
+            |> Task.fromIO
 
 
 -- | Create the file_upload_state table if it doesn't exist.

--- a/core/service/Service/Infra/Postgres/ConnectionConfig.hs
+++ b/core/service/Service/Infra/Postgres/ConnectionConfig.hs
@@ -1,0 +1,87 @@
+module Service.Infra.Postgres.ConnectionConfig (
+  ConnectionParams (..),
+  toConnectionParams,
+  toPoolConfig,
+  logPoolObservation,
+) where
+
+-- | Single shared Postgres connection-settings builder (ADR-0062).
+
+import Core
+import Hasql.Connection.Setting qualified as ConnectionSetting
+import Hasql.Connection.Setting qualified as Hasql
+import Hasql.Connection.Setting.Connection qualified as ConnectionSettingConnection
+import Hasql.Connection.Setting.Connection.Param qualified as Param
+import Hasql.Pool.Config qualified as HasqlPoolConfig
+import Hasql.Pool.Observation (ConnectionStatus (..), ConnectionTerminationReason (..), Observation (..))
+import Log qualified
+import Prelude qualified
+import Task qualified
+
+
+-- | Internal connection inputs shared by all three Postgres pools.
+-- Derives (Eq, Ord) only — Show is dropped per sec-04-001 so the password
+-- field can never be rendered by an accidental show/trace/exception.
+data ConnectionParams = ConnectionParams
+  { host :: Text,
+    databaseName :: Text,
+    user :: Text,
+    password :: Text,
+    port :: Int
+  }
+  deriving (Eq, Ord)
+
+
+-- | The single place libpq connection params are constructed (ADR-0062 §2).
+-- Carries the four ADR-0037 keepalives for every pool.
+toConnectionParams :: ConnectionParams -> LinkedList Hasql.Setting
+toConnectionParams cfg = do
+  let params =
+        ConnectionSettingConnection.params
+          [ Param.host cfg.host,
+            Param.port (fromIntegral cfg.port),
+            Param.dbname cfg.databaseName,
+            Param.user cfg.user,
+            Param.password cfg.password,
+            -- TCP keepalive: detect dead connections in cloud
+            -- environments (ADR-0037, #397) — now on ALL three pools.
+            Param.other "keepalives" "1",
+            Param.other "keepalives_idle" "30",
+            Param.other "keepalives_interval" "10",
+            Param.other "keepalives_count" "5"
+            -- WI-5 (#684) adds: Param.other "sslmode" "<mode>" here.
+          ]
+  [params |> ConnectionSetting.connection]
+
+
+-- | The single place 'Hasql.Pool.Config' is constructed (ADR-0062 §3).
+-- Parameterised by 'poolSize' so each pool keeps its ADR-0060 size.
+toPoolConfig :: Int -> LinkedList Hasql.Setting -> HasqlPoolConfig.Config
+toPoolConfig poolSize settings =
+  [ HasqlPoolConfig.staticConnectionSettings settings,
+    HasqlPoolConfig.size poolSize,
+    HasqlPoolConfig.agingTimeout 300,
+    HasqlPoolConfig.idlenessTimeout 60,
+    HasqlPoolConfig.observationHandler logPoolObservation
+  ]
+    |> HasqlPoolConfig.settings
+
+
+-- | Log connection pool lifecycle events for observability.
+-- Only logs termination events to avoid overhead under high load.
+-- See ADR-0027 for rationale.
+logPoolObservation :: Observation -> Prelude.IO ()
+logPoolObservation observation = case observation of
+  ConnectionObservation _uuid status -> case status of
+    TerminatedConnectionStatus reason -> case reason of
+      AgingConnectionTerminationReason ->
+        ((Log.debug "[Pool] Connection terminated (aging timeout)" |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
+      IdlenessConnectionTerminationReason ->
+        ((Log.debug "[Pool] Connection terminated (idleness timeout)" |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
+      NetworkErrorConnectionTerminationReason err ->
+        ((Log.critical [fmt|[Pool] Connection terminated (network error: #{show err})|] |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
+      ReleaseConnectionTerminationReason ->
+        Prelude.pure ()
+      InitializationErrorTerminationReason err ->
+        ((Log.critical [fmt|[Pool] Connection terminated (init error: #{show err})|] |> Task.ignoreError :: Task Text Unit) |> Task.runOrPanic)
+    _ -> Prelude.pure ()

--- a/core/service/Service/Infra/Postgres/ConnectionConfig.hs
+++ b/core/service/Service/Infra/Postgres/ConnectionConfig.hs
@@ -1,5 +1,8 @@
 module Service.Infra.Postgres.ConnectionConfig (
   ConnectionParams (..),
+  ResolvedParams (..),
+  validatePort,
+  resolveParams,
   toConnectionParams,
   toPoolConfig,
   logPoolObservation,
@@ -8,19 +11,22 @@ module Service.Infra.Postgres.ConnectionConfig (
 -- | Single shared Postgres connection-settings builder (ADR-0062).
 
 import Core
+import Data.Word (Word16)
+import Hasql.Connection.Setting (Setting)
 import Hasql.Connection.Setting qualified as ConnectionSetting
-import Hasql.Connection.Setting qualified as Hasql
 import Hasql.Connection.Setting.Connection qualified as ConnectionSettingConnection
 import Hasql.Connection.Setting.Connection.Param qualified as Param
+import Hasql.Pool.Config (Config)
 import Hasql.Pool.Config qualified as HasqlPoolConfig
 import Hasql.Pool.Observation (ConnectionStatus (..), ConnectionTerminationReason (..), Observation (..))
 import Log qualified
-import Prelude qualified
+import Result qualified
 import Task qualified
+import Prelude qualified
 
 
 -- | Internal connection inputs shared by all three Postgres pools.
--- Derives (Eq, Ord) only — Show is dropped per sec-04-001 so the password
+-- Derives (Eq, Ord) only -- Show is dropped per sec-04-001 so the password
 -- field can never be rendered by an accidental show/trace/exception.
 data ConnectionParams = ConnectionParams
   { host :: Text,
@@ -32,31 +38,91 @@ data ConnectionParams = ConnectionParams
   deriving (Eq, Ord)
 
 
--- | The single place libpq connection params are constructed (ADR-0062 §2).
--- Carries the four ADR-0037 keepalives for every pool.
-toConnectionParams :: ConnectionParams -> LinkedList Hasql.Setting
-toConnectionParams cfg = do
-  let params =
-        ConnectionSettingConnection.params
-          [ Param.host cfg.host,
-            Param.port (fromIntegral cfg.port),
-            Param.dbname cfg.databaseName,
-            Param.user cfg.user,
-            Param.password cfg.password,
-            -- TCP keepalive: detect dead connections in cloud
-            -- environments (ADR-0037, #397) — now on ALL three pools.
-            Param.other "keepalives" "1",
-            Param.other "keepalives_idle" "30",
-            Param.other "keepalives_interval" "10",
-            Param.other "keepalives_count" "5"
-            -- WI-5 (#684) adds: Param.other "sslmode" "<mode>" here.
-          ]
-  [params |> ConnectionSetting.connection]
+-- | The fully resolved, INSPECTABLE libpq parameter set built from a
+-- 'ConnectionParams'. Every value that 'toConnectionParams' hands to libpq
+-- is captured here as plain data so tests can assert each one exactly --
+-- including the four ADR-0037 keepalive entries, guarding against a dropped
+-- or mis-mapped field. 'port' is the validated 'Word16' (1..65535).
+--
+-- Derives (Eq) only -- Show is dropped for the same password-hygiene reason
+-- as 'ConnectionParams' (sec-04-001).
+data ResolvedParams = ResolvedParams
+  { host :: Text,
+    databaseName :: Text,
+    user :: Text,
+    password :: Text,
+    port :: Word16,
+    keepalives :: Text,
+    keepalivesIdle :: Text,
+    keepalivesInterval :: Text,
+    keepalivesCount :: Text
+  }
+  deriving (Eq)
 
 
--- | The single place 'Hasql.Pool.Config' is constructed (ADR-0062 §3).
+-- | Validate a TCP port. 'Param.port' wants a 'Word16', so a raw
+-- 'fromIntegral' would silently wrap an out-of-range 'Int' (-1 -> 65535,
+-- 65536 -> 0). Fail fast with a clear typed error instead, mirroring the
+-- fail-fast @poolSize > 0@ validation WI-1 added to the pool-acquire paths.
+validatePort :: Int -> Result Text Word16
+validatePort p =
+  case p >= 1 && p <= 65535 of
+    True -> Ok (fromIntegral p)
+    False -> Err [fmt|port must be in 1..65535, got #{p}|]
+
+
+-- | The single validation point for connection inputs (ADR-0062 section 2):
+-- resolve a 'ConnectionParams' into the inspectable 'ResolvedParams',
+-- validating the port along the way. All three pools route through here (via
+-- 'toConnectionParams'), so all three get fail-fast port validation.
+resolveParams :: ConnectionParams -> Result Text ResolvedParams
+resolveParams cfg =
+  cfg.port
+    |> validatePort
+    |> Result.map \validPort ->
+      ResolvedParams
+        { host = cfg.host,
+          databaseName = cfg.databaseName,
+          user = cfg.user,
+          password = cfg.password,
+          port = validPort,
+          -- TCP keepalive: detect dead connections in cloud
+          -- environments (ADR-0037, #397) -- now on ALL three pools.
+          keepalives = "1",
+          keepalivesIdle = "30",
+          keepalivesInterval = "10",
+          keepalivesCount = "5"
+        }
+
+
+-- | The single place libpq connection params are constructed (ADR-0062
+-- section 2). Carries the four ADR-0037 keepalives for every pool and fails
+-- fast on an out-of-range port (see 'validatePort'). Returns a 'Result' so
+-- the three pools surface the typed error in their own error channel.
+toConnectionParams :: ConnectionParams -> Result Text (LinkedList Setting)
+toConnectionParams cfg =
+  cfg
+    |> resolveParams
+    |> Result.map \resolved -> do
+      let params =
+            ConnectionSettingConnection.params
+              [ Param.host resolved.host,
+                Param.port resolved.port,
+                Param.dbname resolved.databaseName,
+                Param.user resolved.user,
+                Param.password resolved.password,
+                Param.other "keepalives" resolved.keepalives,
+                Param.other "keepalives_idle" resolved.keepalivesIdle,
+                Param.other "keepalives_interval" resolved.keepalivesInterval,
+                Param.other "keepalives_count" resolved.keepalivesCount
+                -- WI-5 (#684) adds: Param.other "sslmode" "<mode>" here.
+              ]
+      [params |> ConnectionSetting.connection]
+
+
+-- | The single place 'Hasql.Pool.Config' is constructed (ADR-0062 section 3).
 -- Parameterised by 'poolSize' so each pool keeps its ADR-0060 size.
-toPoolConfig :: Int -> LinkedList Hasql.Setting -> HasqlPoolConfig.Config
+toPoolConfig :: Int -> LinkedList Setting -> Config
 toPoolConfig poolSize settings =
   [ HasqlPoolConfig.staticConnectionSettings settings,
     HasqlPoolConfig.size poolSize,

--- a/core/service/Service/QueryObjectStore/Postgres.hs
+++ b/core/service/Service/QueryObjectStore/Postgres.hs
@@ -19,16 +19,13 @@ import Hasql.Decoders qualified as Decoders
 import Hasql.Encoders qualified as Encoders
 import Hasql.Pool (Pool)
 import Hasql.Pool qualified as HasqlPool
-import Hasql.Pool.Config qualified as HasqlPoolConfig
-import Hasql.Connection.Setting qualified as ConnectionSetting
-import Hasql.Connection.Setting.Connection qualified as ConnectionSettingConnection
-import Hasql.Connection.Setting.Connection.Param qualified as Param
 import Hasql.Session qualified as Session
 import Hasql.Statement (Statement (..))
 import Json qualified
 import Maybe (Maybe (..))
 import Result (Result (..))
 import Result qualified
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Service.QueryObjectStore.Core (Error (..), QueryObjectStore (..))
 import Service.QueryObjectStore.Core qualified as Core
 import Task (Task)
@@ -117,22 +114,16 @@ acquirePool cfg = do
     False ->
       Task.throw (ConnectionFailed [fmt|poolSize must be > 0, got #{size}|])
     True -> do
-      let params =
-            ConnectionSettingConnection.params
-              [ Param.host cfg.host
-              , Param.port (fromIntegral cfg.port)
-              , Param.dbname cfg.databaseName
-              , Param.user cfg.user
-              , Param.password cfg.password
-              ]
-      let settings = [params |> ConnectionSetting.connection]
-      let poolConfig =
-            [ HasqlPoolConfig.staticConnectionSettings settings
-            , HasqlPoolConfig.size cfg.poolSize
-            , HasqlPoolConfig.agingTimeout 300
-            , HasqlPoolConfig.idlenessTimeout 60
-            ]
-              |> HasqlPoolConfig.settings
+      let settings =
+            ConnectionConfig.toConnectionParams
+              ConnectionConfig.ConnectionParams
+                { host = cfg.host
+                , databaseName = cfg.databaseName
+                , user = cfg.user
+                , password = cfg.password
+                , port = cfg.port
+                }
+      let poolConfig = ConnectionConfig.toPoolConfig cfg.poolSize settings
       pool <- HasqlPool.acquire poolConfig
         |> Task.fromIO
       pingResult <- runPool pool pingSession |> Task.asResult

--- a/core/service/Service/QueryObjectStore/Postgres.hs
+++ b/core/service/Service/QueryObjectStore/Postgres.hs
@@ -113,23 +113,24 @@ acquirePool cfg = do
   case size > 0 of
     False ->
       Task.throw (ConnectionFailed [fmt|poolSize must be > 0, got #{size}|])
-    True -> do
-      let settings =
-            ConnectionConfig.toConnectionParams
-              ConnectionConfig.ConnectionParams
-                { host = cfg.host
-                , databaseName = cfg.databaseName
-                , user = cfg.user
-                , password = cfg.password
-                , port = cfg.port
-                }
-      let poolConfig = ConnectionConfig.toPoolConfig cfg.poolSize settings
-      pool <- HasqlPool.acquire poolConfig
-        |> Task.fromIO
-      pingResult <- runPool pool pingSession |> Task.asResult
-      case pingResult of
-        Err err -> Task.throw (ConnectionFailed (toText (show err)))
-        Ok _ -> Task.yield pool
+    True ->
+      case ConnectionConfig.toConnectionParams
+             ConnectionConfig.ConnectionParams
+               { host = cfg.host
+               , databaseName = cfg.databaseName
+               , user = cfg.user
+               , password = cfg.password
+               , port = cfg.port
+               } of
+        Err portErr -> Task.throw (ConnectionFailed portErr)
+        Ok settings -> do
+          let poolConfig = ConnectionConfig.toPoolConfig cfg.poolSize settings
+          pool <- HasqlPool.acquire poolConfig
+            |> Task.fromIO
+          pingResult <- runPool pool pingSession |> Task.asResult
+          case pingResult of
+            Err err -> Task.throw (ConnectionFailed (toText (show err)))
+            Ok _ -> Task.yield pool
 
 
 -- | Run a Hasql session on the pool.

--- a/core/test-service/Main.hs
+++ b/core/test-service/Main.hs
@@ -9,6 +9,7 @@ import Service.CommandSpec qualified
 import Service.EventStore.InMemorySpec qualified
 import Service.EventStore.SimpleSpec qualified
 import Service.EventStore.Postgres.PoolBudgetSpec qualified
+import Service.Infra.Postgres.ConnectionConfigSpec qualified
 import Service.EventStore.Postgres.SubscriptionStoreSpec qualified
 import Service.EventStore.Postgres.NotificationsSpec qualified
 import Service.EventStore.PostgresSpec qualified
@@ -60,6 +61,7 @@ main = Hspec.hspec do
   Hspec.describe "Service.EventStore.InMemory" Service.EventStore.InMemorySpec.spec
   Hspec.describe "Service.EventStore.Simple" Service.EventStore.SimpleSpec.spec
   Hspec.describe "Service.EventStore.Postgres.PoolBudget" Service.EventStore.Postgres.PoolBudgetSpec.spec
+  Hspec.describe "Service.Infra.Postgres.ConnectionConfig" Service.Infra.Postgres.ConnectionConfigSpec.spec
   Hspec.describe "Service.EventStore.Postgres.SubscriptionStore" Service.EventStore.Postgres.SubscriptionStoreSpec.spec
   Hspec.describe "Service.EventStore.Postgres" Service.EventStore.PostgresSpec.spec
   Hspec.describe "Service.EventStore.Postgres.Notifications" Service.EventStore.Postgres.NotificationsSpec.spec

--- a/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
+++ b/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
@@ -1,0 +1,229 @@
+module Service.Infra.Postgres.ConnectionConfigSpec (spec) where
+
+-- | Pure unit spec for the ADR-0062 shared Postgres connection-settings
+-- builders. Runs unconditionally (no Postgres). Registered manually in
+-- core/test-service/Main.hs (the suite does not auto-discover).
+--
+-- The hasql Setting / Config values are opaque (no Eq/Show), so every
+-- assertion is written at an observable boundary: list length (the
+-- LinkedList spine is forced), totality (force to WHNF via seq), and the
+-- EventStore projection-equivalence (same length-1 structure).
+
+import Core
+import LinkedList qualified
+import Hasql.Connection.Setting qualified as Hasql
+import Service.EventStore.Postgres.Internal (PostgresEventStore (..))
+import Service.EventStore.Postgres.Internal qualified as EventStore
+import Service.Infra.Postgres.ConnectionConfig (ConnectionParams (..))
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
+import Prelude qualified
+import Test.Hspec qualified as Hspec
+
+
+-- | A typical ConnectionParams input (matches toConnectionParams case #1).
+typicalParams :: ConnectionParams
+typicalParams =
+  ConnectionConfig.ConnectionParams
+    { host = "localhost",
+      databaseName = "app",
+      user = "postgres",
+      password = "secret",
+      port = 5432
+    }
+
+
+-- | The typical config with a specific port. Built by full record
+-- construction (the constructor names the type) so the field set is
+-- unambiguous — a bare @typicalParams { port = n }@ update is ambiguous
+-- because several records in scope share a @port@ field.
+paramsWithPort :: Int -> ConnectionParams
+paramsWithPort p =
+  ConnectionConfig.ConnectionParams
+    { host = "localhost",
+      databaseName = "app",
+      user = "postgres",
+      password = "secret",
+      port = p
+    }
+
+
+-- | The typical config with a specific password, built by full record
+-- construction for the same disambiguation reason as 'paramsWithPort'.
+paramsWithPassword :: Text -> ConnectionParams
+paramsWithPassword pw =
+  ConnectionConfig.ConnectionParams
+    { host = "localhost",
+      databaseName = "app",
+      user = "postgres",
+      password = pw,
+      port = 5432
+    }
+
+
+-- | A ConnectionParams with all four textual fields empty.
+emptyParams :: ConnectionParams
+emptyParams =
+  ConnectionConfig.ConnectionParams
+    { host = "",
+      databaseName = "",
+      user = "",
+      password = "",
+      port = 5432
+    }
+
+
+-- | A typical PostgresEventStore for the toConnectionSettings regression
+-- cases, built by record-update on the Default instance.
+typicalEventStore :: PostgresEventStore
+typicalEventStore =
+  (def :: PostgresEventStore)
+    { EventStore.host = "localhost",
+      EventStore.databaseName = "app",
+      EventStore.user = "postgres",
+      EventStore.password = "secret",
+      EventStore.port = 5432
+    }
+
+
+-- | The reference projection mirroring toConnectionSettings's body so the
+-- regression guard is a true same-input/same-structure comparison.
+project :: PostgresEventStore -> ConnectionParams
+project cfg =
+  ConnectionConfig.ConnectionParams
+    { host = cfg.host,
+      databaseName = cfg.databaseName,
+      user = cfg.user,
+      password = cfg.password,
+      port = cfg.port
+    }
+
+
+-- | A typical settings list, reused by the toPoolConfig settings-spine case.
+typicalSettings :: LinkedList.LinkedList Hasql.Setting
+typicalSettings = ConnectionConfig.toConnectionParams typicalParams
+
+
+spec :: Hspec.Spec
+spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
+  Hspec.describe "toConnectionParams" do
+    Hspec.it "returns a single connection setting for a typical config" do
+      (ConnectionConfig.toConnectionParams typicalParams |> LinkedList.length)
+        |> Hspec.shouldBe 1
+
+    Hspec.it "accepts the four ADR-0037 keepalive params and stays length 1 (keepalive contract)" do
+      let result = ConnectionConfig.toConnectionParams typicalParams
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+
+    Hspec.it "is total for empty-string host, db, user, and password" do
+      let result = ConnectionConfig.toConnectionParams emptyParams
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for port = 0 (lower boundary)" do
+      let result = ConnectionConfig.toConnectionParams (paramsWithPort 0)
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for port = 1" do
+      let result = ConnectionConfig.toConnectionParams (paramsWithPort 1)
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for port = 65535 (max valid TCP port)" do
+      let result = ConnectionConfig.toConnectionParams (paramsWithPort 65535)
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for port = 65536 (max + 1)" do
+      let result = ConnectionConfig.toConnectionParams (paramsWithPort 65536)
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for a negative port" do
+      let result = ConnectionConfig.toConnectionParams (paramsWithPort (-1))
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for unicode multibyte text in the password field" do
+      let result = ConnectionConfig.toConnectionParams (paramsWithPassword "pâsswörd-🔑-日本語")
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+  Hspec.describe "toConnectionSettings" do
+    Hspec.it "equals the shared builder applied to the projected ConnectionParams (Design Goal 4 regression guard)" do
+      let direct = EventStore.toConnectionSettings typicalEventStore |> LinkedList.length
+      let projected = ConnectionConfig.toConnectionParams (project typicalEventStore) |> LinkedList.length
+      direct |> Hspec.shouldBe projected
+      direct |> Hspec.shouldBe 1
+
+    Hspec.it "returns a single connection setting for a typical PostgresEventStore" do
+      (EventStore.toConnectionSettings typicalEventStore |> LinkedList.length)
+        |> Hspec.shouldBe 1
+
+    Hspec.it "is total for empty-string host, db, user, and password fields" do
+      let cfg =
+            typicalEventStore
+              { EventStore.host = "",
+                EventStore.databaseName = "",
+                EventStore.user = "",
+                EventStore.password = ""
+              }
+      let result = EventStore.toConnectionSettings cfg
+      (result `Prelude.seq` True) |> Hspec.shouldBe True
+      (result |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for port = 0 and port = 65535 (boundaries) and equals the projected builder" do
+      let cfg0 = typicalEventStore {EventStore.port = 0}
+      (EventStore.toConnectionSettings cfg0 |> LinkedList.length) |> Hspec.shouldBe 1
+      (EventStore.toConnectionSettings cfg0 |> LinkedList.length)
+        |> Hspec.shouldBe (ConnectionConfig.toConnectionParams (project cfg0) |> LinkedList.length)
+      let cfgMax = typicalEventStore {EventStore.port = 65535}
+      (EventStore.toConnectionSettings cfgMax |> LinkedList.length) |> Hspec.shouldBe 1
+      (EventStore.toConnectionSettings cfgMax |> LinkedList.length)
+        |> Hspec.shouldBe (ConnectionConfig.toConnectionParams (project cfgMax) |> LinkedList.length)
+
+    Hspec.it "is total for port = 65536 (max + 1) and a negative port" do
+      let cfgOver = typicalEventStore {EventStore.port = 65536}
+      let resultOver = EventStore.toConnectionSettings cfgOver
+      (resultOver `Prelude.seq` True) |> Hspec.shouldBe True
+      (resultOver |> LinkedList.length) |> Hspec.shouldBe 1
+      let cfgNeg = typicalEventStore {EventStore.port = -1}
+      let resultNeg = EventStore.toConnectionSettings cfgNeg
+      (resultNeg `Prelude.seq` True) |> Hspec.shouldBe True
+      (resultNeg |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "is total for unicode multibyte password and matches the projected builder" do
+      let cfg = typicalEventStore {EventStore.password = "pâsswörd-🔑-日本語"}
+      (EventStore.toConnectionSettings cfg |> LinkedList.length) |> Hspec.shouldBe 1
+      (EventStore.toConnectionSettings cfg |> LinkedList.length)
+        |> Hspec.shouldBe (ConnectionConfig.toConnectionParams (project cfg) |> LinkedList.length)
+
+  Hspec.describe "toPoolConfig" do
+    Hspec.it "returns a defined Config for the EventStore/FileUpload default size 6" do
+      (ConnectionConfig.toPoolConfig 6 typicalSettings `Prelude.seq` True)
+        |> Hspec.shouldBe True
+
+    Hspec.it "returns a defined Config for the QueryObjectStore size 4" do
+      (ConnectionConfig.toPoolConfig 4 typicalSettings `Prelude.seq` True)
+        |> Hspec.shouldBe True
+
+    Hspec.it "is total for poolSize = 0 (zero boundary)" do
+      (ConnectionConfig.toPoolConfig 0 typicalSettings `Prelude.seq` True)
+        |> Hspec.shouldBe True
+
+    Hspec.it "is total for poolSize = 1 (one boundary)" do
+      (ConnectionConfig.toPoolConfig 1 typicalSettings `Prelude.seq` True)
+        |> Hspec.shouldBe True
+
+    Hspec.it "is total for a large poolSize (e.g. 1000000)" do
+      (ConnectionConfig.toPoolConfig 1000000 typicalSettings `Prelude.seq` True)
+        |> Hspec.shouldBe True
+
+    Hspec.it "is total for a negative poolSize" do
+      (ConnectionConfig.toPoolConfig (-1) typicalSettings `Prelude.seq` True)
+        |> Hspec.shouldBe True
+
+    Hspec.it "is total regardless of settings list length (empty vs typical)" do
+      (ConnectionConfig.toPoolConfig 6 [] `Prelude.seq` True) |> Hspec.shouldBe True
+      (ConnectionConfig.toPoolConfig 6 typicalSettings `Prelude.seq` True) |> Hspec.shouldBe True

--- a/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
+++ b/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
@@ -4,23 +4,23 @@ module Service.Infra.Postgres.ConnectionConfigSpec (spec) where
 -- builders. Runs unconditionally (no Postgres). Registered manually in
 -- core/test-service/Main.hs (the suite does not auto-discover).
 --
--- The hasql Setting / Config values are opaque (no Eq/Show), so every
--- assertion is written at an observable boundary: list length (the
--- LinkedList spine is forced), totality (force to WHNF via seq), and the
--- EventStore projection-equivalence (same length-1 structure).
+-- The hasql Setting / Config values are opaque (no Eq/Show), so the
+-- contract is asserted against the INSPECTABLE 'ResolvedParams' that the
+-- opaque builder is constructed from: every host/db/user/password/port
+-- value AND all four ADR-0037 keepalive entries are checked exactly, so a
+-- dropped keepalive or a mis-mapped field fails the test. Port validation
+-- (1..65535) is asserted on both boundaries and out-of-range inputs.
 
 import Core
 import LinkedList qualified
-import Hasql.Connection.Setting qualified as Hasql
-import Service.EventStore.Postgres.Internal (PostgresEventStore (..))
-import Service.EventStore.Postgres.Internal qualified as EventStore
-import Service.Infra.Postgres.ConnectionConfig (ConnectionParams (..))
+import Result qualified
+import Service.Infra.Postgres.ConnectionConfig (ConnectionParams (..), ResolvedParams (..))
 import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Prelude qualified
 import Test.Hspec qualified as Hspec
 
 
--- | A typical ConnectionParams input (matches toConnectionParams case #1).
+-- | A typical ConnectionParams input.
 typicalParams :: ConnectionParams
 typicalParams =
   ConnectionConfig.ConnectionParams
@@ -34,7 +34,7 @@ typicalParams =
 
 -- | The typical config with a specific port. Built by full record
 -- construction (the constructor names the type) so the field set is
--- unambiguous — a bare @typicalParams { port = n }@ update is ambiguous
+-- unambiguous -- a bare @typicalParams { port = n }@ update is ambiguous
 -- because several records in scope share a @port@ field.
 paramsWithPort :: Int -> ConnectionParams
 paramsWithPort p =
@@ -60,170 +60,133 @@ paramsWithPassword pw =
     }
 
 
--- | A ConnectionParams with all four textual fields empty.
-emptyParams :: ConnectionParams
-emptyParams =
-  ConnectionConfig.ConnectionParams
-    { host = "",
-      databaseName = "",
-      user = "",
-      password = "",
-      port = 5432
-    }
-
-
--- | A typical PostgresEventStore for the toConnectionSettings regression
--- cases, built by record-update on the Default instance.
-typicalEventStore :: PostgresEventStore
-typicalEventStore =
-  (def :: PostgresEventStore)
-    { EventStore.host = "localhost",
-      EventStore.databaseName = "app",
-      EventStore.user = "postgres",
-      EventStore.password = "secret",
-      EventStore.port = 5432
-    }
-
-
--- | The reference projection mirroring toConnectionSettings's body so the
--- regression guard is a true same-input/same-structure comparison.
-project :: PostgresEventStore -> ConnectionParams
-project cfg =
-  ConnectionConfig.ConnectionParams
-    { host = cfg.host,
-      databaseName = cfg.databaseName,
-      user = cfg.user,
-      password = cfg.password,
-      port = cfg.port
-    }
-
-
--- | A typical settings list, reused by the toPoolConfig settings-spine case.
-typicalSettings :: LinkedList.LinkedList Hasql.Setting
-typicalSettings = ConnectionConfig.toConnectionParams typicalParams
+-- | The four ADR-0037 keepalive entries every resolved param set must carry.
+expectedKeepalives :: ResolvedParams -> Bool
+expectedKeepalives resolved =
+  resolved.keepalives Prelude.== "1"
+    && resolved.keepalivesIdle Prelude.== "30"
+    && resolved.keepalivesInterval Prelude.== "10"
+    && resolved.keepalivesCount Prelude.== "5"
 
 
 spec :: Hspec.Spec
 spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
+  Hspec.describe "validatePort" do
+    Hspec.it "rejects port 0 (lower boundary, below range)" do
+      ConnectionConfig.validatePort 0
+        |> Hspec.shouldBe (Err "port must be in 1..65535, got 0")
+
+    Hspec.it "accepts port 1 (lower boundary)" do
+      ConnectionConfig.validatePort 1 |> Hspec.shouldBe (Ok 1)
+
+    Hspec.it "accepts port 5432 (typical)" do
+      ConnectionConfig.validatePort 5432 |> Hspec.shouldBe (Ok 5432)
+
+    Hspec.it "accepts port 65535 (upper boundary)" do
+      ConnectionConfig.validatePort 65535 |> Hspec.shouldBe (Ok 65535)
+
+    Hspec.it "rejects port 65536 (above range) instead of wrapping to 0" do
+      ConnectionConfig.validatePort 65536
+        |> Hspec.shouldBe (Err "port must be in 1..65535, got 65536")
+
+    Hspec.it "rejects a negative port instead of wrapping to 65535" do
+      ConnectionConfig.validatePort (-1)
+        |> Hspec.shouldBe (Err "port must be in 1..65535, got -1")
+
+  Hspec.describe "resolveParams" do
+    Hspec.it "maps every field exactly and carries all four keepalives" do
+      case ConnectionConfig.resolveParams typicalParams of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok resolved -> do
+          resolved.host |> Hspec.shouldBe "localhost"
+          resolved.databaseName |> Hspec.shouldBe "app"
+          resolved.user |> Hspec.shouldBe "postgres"
+          resolved.password |> Hspec.shouldBe "secret"
+          resolved.port |> Hspec.shouldBe 5432
+          resolved.keepalives |> Hspec.shouldBe "1"
+          resolved.keepalivesIdle |> Hspec.shouldBe "30"
+          resolved.keepalivesInterval |> Hspec.shouldBe "10"
+          resolved.keepalivesCount |> Hspec.shouldBe "5"
+
+    Hspec.it "does not drop or reorder the keepalive contract" do
+      case ConnectionConfig.resolveParams typicalParams of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok resolved -> expectedKeepalives resolved |> Hspec.shouldBe True
+
+    Hspec.it "preserves unicode multibyte text in the password field" do
+      case ConnectionConfig.resolveParams (paramsWithPassword "p\xe2ssw\xf6rd-\x1f511-\x65e5\x672c\x8a9e") of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok resolved -> resolved.password |> Hspec.shouldBe "p\xe2ssw\xf6rd-\x1f511-\x65e5\x672c\x8a9e"
+
+    Hspec.it "preserves empty-string host, db, and user fields" do
+      let emptyParams =
+            ConnectionConfig.ConnectionParams
+              { host = "",
+                databaseName = "",
+                user = "",
+                password = "",
+                port = 5432
+              }
+      case ConnectionConfig.resolveParams emptyParams of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok resolved -> do
+          resolved.host |> Hspec.shouldBe ""
+          resolved.databaseName |> Hspec.shouldBe ""
+          resolved.user |> Hspec.shouldBe ""
+          resolved.password |> Hspec.shouldBe ""
+
+    Hspec.it "fails fast on port 0 rather than producing settings" do
+      ConnectionConfig.resolveParams (paramsWithPort 0)
+        |> Result.isErr
+        |> Hspec.shouldBe True
+
+    Hspec.it "fails fast on a negative port" do
+      ConnectionConfig.resolveParams (paramsWithPort (-1))
+        |> Result.isErr
+        |> Hspec.shouldBe True
+
+    Hspec.it "fails fast on port 65536" do
+      ConnectionConfig.resolveParams (paramsWithPort 65536)
+        |> Result.isErr
+        |> Hspec.shouldBe True
+
   Hspec.describe "toConnectionParams" do
     Hspec.it "returns a single connection setting for a typical config" do
-      (ConnectionConfig.toConnectionParams typicalParams |> LinkedList.length)
-        |> Hspec.shouldBe 1
+      case ConnectionConfig.toConnectionParams typicalParams of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok settings -> (settings |> LinkedList.length) |> Hspec.shouldBe 1
 
-    Hspec.it "accepts the four ADR-0037 keepalive params and stays length 1 (keepalive contract)" do
-      let result = ConnectionConfig.toConnectionParams typicalParams
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
+    Hspec.it "accepts the boundary port 1" do
+      ConnectionConfig.toConnectionParams (paramsWithPort 1)
+        |> Result.isOk
+        |> Hspec.shouldBe True
 
-    Hspec.it "is total for empty-string host, db, user, and password" do
-      let result = ConnectionConfig.toConnectionParams emptyParams
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
+    Hspec.it "accepts the boundary port 65535" do
+      ConnectionConfig.toConnectionParams (paramsWithPort 65535)
+        |> Result.isOk
+        |> Hspec.shouldBe True
 
-    Hspec.it "is total for port = 0 (lower boundary)" do
-      let result = ConnectionConfig.toConnectionParams (paramsWithPort 0)
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-
-    Hspec.it "is total for port = 1" do
-      let result = ConnectionConfig.toConnectionParams (paramsWithPort 1)
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-
-    Hspec.it "is total for port = 65535 (max valid TCP port)" do
-      let result = ConnectionConfig.toConnectionParams (paramsWithPort 65535)
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-
-    Hspec.it "is total for port = 65536 (max + 1)" do
-      let result = ConnectionConfig.toConnectionParams (paramsWithPort 65536)
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-
-    Hspec.it "is total for a negative port" do
-      let result = ConnectionConfig.toConnectionParams (paramsWithPort (-1))
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-
-    Hspec.it "is total for unicode multibyte text in the password field" do
-      let result = ConnectionConfig.toConnectionParams (paramsWithPassword "pâsswörd-🔑-日本語")
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-
-  Hspec.describe "toConnectionSettings" do
-    Hspec.it "equals the shared builder applied to the projected ConnectionParams (Design Goal 4 regression guard)" do
-      let direct = EventStore.toConnectionSettings typicalEventStore |> LinkedList.length
-      let projected = ConnectionConfig.toConnectionParams (project typicalEventStore) |> LinkedList.length
-      direct |> Hspec.shouldBe projected
-      direct |> Hspec.shouldBe 1
-
-    Hspec.it "returns a single connection setting for a typical PostgresEventStore" do
-      (EventStore.toConnectionSettings typicalEventStore |> LinkedList.length)
-        |> Hspec.shouldBe 1
-
-    Hspec.it "is total for empty-string host, db, user, and password fields" do
-      let cfg =
-            typicalEventStore
-              { EventStore.host = "",
-                EventStore.databaseName = "",
-                EventStore.user = "",
-                EventStore.password = ""
-              }
-      let result = EventStore.toConnectionSettings cfg
-      (result `Prelude.seq` True) |> Hspec.shouldBe True
-      (result |> LinkedList.length) |> Hspec.shouldBe 1
-
-    Hspec.it "is total for port = 0 and port = 65535 (boundaries) and equals the projected builder" do
-      let cfg0 = typicalEventStore {EventStore.port = 0}
-      (EventStore.toConnectionSettings cfg0 |> LinkedList.length) |> Hspec.shouldBe 1
-      (EventStore.toConnectionSettings cfg0 |> LinkedList.length)
-        |> Hspec.shouldBe (ConnectionConfig.toConnectionParams (project cfg0) |> LinkedList.length)
-      let cfgMax = typicalEventStore {EventStore.port = 65535}
-      (EventStore.toConnectionSettings cfgMax |> LinkedList.length) |> Hspec.shouldBe 1
-      (EventStore.toConnectionSettings cfgMax |> LinkedList.length)
-        |> Hspec.shouldBe (ConnectionConfig.toConnectionParams (project cfgMax) |> LinkedList.length)
-
-    Hspec.it "is total for port = 65536 (max + 1) and a negative port" do
-      let cfgOver = typicalEventStore {EventStore.port = 65536}
-      let resultOver = EventStore.toConnectionSettings cfgOver
-      (resultOver `Prelude.seq` True) |> Hspec.shouldBe True
-      (resultOver |> LinkedList.length) |> Hspec.shouldBe 1
-      let cfgNeg = typicalEventStore {EventStore.port = -1}
-      let resultNeg = EventStore.toConnectionSettings cfgNeg
-      (resultNeg `Prelude.seq` True) |> Hspec.shouldBe True
-      (resultNeg |> LinkedList.length) |> Hspec.shouldBe 1
-
-    Hspec.it "is total for unicode multibyte password and matches the projected builder" do
-      let cfg = typicalEventStore {EventStore.password = "pâsswörd-🔑-日本語"}
-      (EventStore.toConnectionSettings cfg |> LinkedList.length) |> Hspec.shouldBe 1
-      (EventStore.toConnectionSettings cfg |> LinkedList.length)
-        |> Hspec.shouldBe (ConnectionConfig.toConnectionParams (project cfg) |> LinkedList.length)
+    Hspec.it "rejects an out-of-range port instead of silently wrapping" do
+      -- The Ok payload (LinkedList Setting) has no Show, so assert the Err
+      -- branch via a case rather than shouldBe on the whole Result.
+      case ConnectionConfig.toConnectionParams (paramsWithPort 70000) of
+        Err err -> err |> Hspec.shouldBe "port must be in 1..65535, got 70000"
+        Ok _ -> Prelude.error "expected an out-of-range port to be rejected"
 
   Hspec.describe "toPoolConfig" do
-    Hspec.it "returns a defined Config for the EventStore/FileUpload default size 6" do
-      (ConnectionConfig.toPoolConfig 6 typicalSettings `Prelude.seq` True)
-        |> Hspec.shouldBe True
+    Hspec.it "returns a defined Config for the EventStore/FileUpload size 6" do
+      case ConnectionConfig.toConnectionParams typicalParams of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok settings ->
+          (ConnectionConfig.toPoolConfig 6 settings `Prelude.seq` True)
+            |> Hspec.shouldBe True
 
     Hspec.it "returns a defined Config for the QueryObjectStore size 4" do
-      (ConnectionConfig.toPoolConfig 4 typicalSettings `Prelude.seq` True)
-        |> Hspec.shouldBe True
-
-    Hspec.it "is total for poolSize = 0 (zero boundary)" do
-      (ConnectionConfig.toPoolConfig 0 typicalSettings `Prelude.seq` True)
-        |> Hspec.shouldBe True
-
-    Hspec.it "is total for poolSize = 1 (one boundary)" do
-      (ConnectionConfig.toPoolConfig 1 typicalSettings `Prelude.seq` True)
-        |> Hspec.shouldBe True
-
-    Hspec.it "is total for a large poolSize (e.g. 1000000)" do
-      (ConnectionConfig.toPoolConfig 1000000 typicalSettings `Prelude.seq` True)
-        |> Hspec.shouldBe True
-
-    Hspec.it "is total for a negative poolSize" do
-      (ConnectionConfig.toPoolConfig (-1) typicalSettings `Prelude.seq` True)
-        |> Hspec.shouldBe True
+      case ConnectionConfig.toConnectionParams typicalParams of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok settings ->
+          (ConnectionConfig.toPoolConfig 4 settings `Prelude.seq` True)
+            |> Hspec.shouldBe True
 
     Hspec.it "is total regardless of settings list length (empty vs typical)" do
       (ConnectionConfig.toPoolConfig 6 [] `Prelude.seq` True) |> Hspec.shouldBe True
-      (ConnectionConfig.toPoolConfig 6 typicalSettings `Prelude.seq` True) |> Hspec.shouldBe True

--- a/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
+++ b/core/test/Service/EventStore/Postgres/NotificationsSpec.hs
@@ -252,11 +252,13 @@ spec = do
                 user = "test",
                 password = "test"
               }
-      -- toConnectionSettings is pure — just verify it evaluates without error
-      let settings = toConnectionSettings cfg
-      -- Settings list should be non-empty (has at least the connection params)
-      -- Use length (Int has Show) rather than shouldSatisfy on the list (no Show instance)
-      LinkedList.length settings |> shouldSatisfy (\n -> n > 0)
+      -- toConnectionSettings is pure — for a valid config it returns Ok.
+      case toConnectionSettings cfg of
+        Err err -> Test.fail [fmt|Expected Ok settings, got: #{err}|]
+        Ok settings ->
+          -- Settings list should be non-empty (has at least the connection params).
+          -- Use length (Int has Show) rather than shouldSatisfy on the list (no Show).
+          LinkedList.length settings |> shouldSatisfy (\n -> n > 0)
 
   describe "Listener cleanup" do
     whenEnvVar "POSTGRES_AVAILABLE" do
@@ -551,8 +553,11 @@ catchUpFixture body = do
   -- Ensure the events table + trigger exist by creating a store once.
   store0 <- Postgres.new cfg |> Task.mapError toText
   store0.close
+  connSettings <- case toConnectionSettings cfg of
+    Err err -> Task.throw err
+    Ok settings -> Task.yield settings
   conn <-
-    Hasql.acquire (toConnectionSettings cfg)
+    Hasql.acquire connSettings
       |> Task.fromIOEither
       |> Task.mapError toText
   -- Bracket the connection: release it on EVERY path, so an exception in
@@ -707,9 +712,12 @@ resultIsErr result =
 -- reconnect wiring test's connection factory and its admin connection).
 acquireConn :: PostgresEventStore -> Task Text Hasql.Connection
 acquireConn cfg =
-  Hasql.acquire (toConnectionSettings cfg)
-    |> Task.fromIOEither
-    |> Task.mapError toText
+  case toConnectionSettings cfg of
+    Err err -> Task.throw err
+    Ok settings ->
+      Hasql.acquire settings
+        |> Task.fromIOEither
+        |> Task.mapError toText
 
 
 -- | The PostgreSQL backend process id (@pg_backend_pid()@) of a connection.

--- a/docs/decisions/0062-shared-connection-settings-builder.md
+++ b/docs/decisions/0062-shared-connection-settings-builder.md
@@ -238,7 +238,7 @@ data ConnectionParams = ConnectionParams
     password :: Text,
     port :: Int
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
 ```
 
 ### 2. `toConnectionParams` — the single libpq param builder

--- a/docs/decisions/0062-shared-connection-settings-builder.md
+++ b/docs/decisions/0062-shared-connection-settings-builder.md
@@ -97,6 +97,11 @@ its own `poolSize`). This ADR completes the unification for the
 6. **Invisible to Jess.** This is internal plumbing. No new public type,
    no new public function, no new config field on any config record. The
    `Application.withEventStore postgresConfig` surface is unchanged.
+7. **A neutral home for a cross-cutting concern.** The shared builder
+   serves three unrelated subsystems (EventStore, QueryObjectStore,
+   FileUpload). It must live where none of those subsystems "owns" it, so
+   that depending on it does not couple any one of them to another. This
+   motivates a new `Service.Infra` namespace (below).
 
 ### GitHub Issue
 
@@ -125,39 +130,33 @@ its own `poolSize`). This ADR completes the unification for the
   shares `PostgresEventStore.poolSize` (Option A). This ADR does **not**
   give FileUpload an independent size — that remains a possible future
   split, deliberately not taken here.
+- **A shared concern belongs in shared infrastructure, not in a
+  subsystem.** The connection builder is used by three subsystems and
+  belongs to none. Hanging it off the EventStore module would make two
+  unrelated subsystems depend (directly or by import) on EventStore code
+  just to share five lines of param construction. The right home is a
+  neutral, low-level infrastructure module that the subsystems depend on
+  — never the reverse.
 
 ## Considered options
 
-### Option 1 — Two shared functions in `EventStore.Postgres.Core`, both pools import them (chosen)
+### Option 1 — Two shared functions in `EventStore.Postgres.Core`, both pools import them
 
 Place the two builders in the existing
 `Service.EventStore.Postgres.Core` module (already imported by
-`Internal.hs`):
+`Internal.hs`), and have QueryObjectStore and FileUpload import that
+module too.
 
-- `toConnectionParams :: ConnectionParams -> LinkedList Hasql.Setting` —
-  the single libpq param constructor (host/port/dbname/user/password +
-  the four keepalives, with the `sslmode` seam reserved for WI-5).
-- `toPoolConfig :: Int -> LinkedList Hasql.Setting -> HasqlPoolConfig.Config`
-  — the single pool-config constructor (static settings + `size` +
-  `agingTimeout` + `idlenessTimeout` + `observationHandler`), with
-  `logPoolObservation` defined once here too.
-
-`ConnectionParams` is a small **internal** record (`host`, `databaseName`,
-`user`, `password`, `port`) that both config types project into — it is
-*not* exported from any public module and is not a new public type Jess
-sees. EventStore's `toConnectionSettings` becomes a thin projection of
-`PostgresEventStore` into `ConnectionParams` then a call to
-`toConnectionParams`; QueryObjectStore's `acquirePool` and FileUpload's
-`createPool` do the same projection and call `toConnectionParams` +
-`toPoolConfig`.
-
-- Chosen: `Postgres.Core` is the lowest module all three pools can depend
-  on without a cycle (EventStore already imports it; FileUpload already
-  imports `Service.EventStore.Postgres`; QueryObjectStore can import the
-  `Core` module without pulling in EventStore's `Internal`). Both
-  builders live together; the observation handler is defined once; the
-  `sslmode` seam is a single `Param` line behind one `ConnectionParams`
-  extension.
+- **Rejected / superseded.** It couples a *cross-cutting* concern into
+  the EventStore module: QueryObjectStore and FileUpload would import
+  `Service.EventStore.Postgres.Core` purely to obtain a connection
+  builder that has nothing to do with the event store. That makes the
+  EventStore module the de-facto owner of shared Postgres infrastructure,
+  inverts the dependency direction the codebase wants (subsystems →
+  infra, not subsystem → subsystem), and leaves no clean seam for the
+  #460/#346 config-layer work to lift the builder into later. This was the
+  approach in the first draft of this ADR; the maintainer rejected it in
+  favour of Option 3 (below).
 
 ### Option 2 — Keep the builders in `EventStore.Postgres.Internal`, export them
 
@@ -169,20 +168,30 @@ import them.
   EventStore's `Internal` module — a heavy, churny module that carries
   the whole event-store implementation. It also couples two unrelated
   subsystems to EventStore internals just to share five lines of param
-  construction. A small dedicated home (`Postgres.Core`) is the right
-  altitude.
+  construction. Strictly worse than Option 1, and Option 1 itself was
+  rejected for the same family of reasons.
 
-### Option 3 — A new top-level `Service.Postgres.ConnectionConfig` module
+### Option 3 — A new top-level infrastructure module (chosen)
 
-Create a brand-new module for the shared builder.
+Create a brand-new module, **`Service.Infra.Postgres.ConnectionConfig`**
+(file `core/service/Service/Infra/Postgres/ConnectionConfig.hs`),
+introducing the **`Service.Infra`** namespace as the home for
+cross-cutting infrastructure that belongs to no single subsystem. The
+shared record + the two builders + the single observation handler live
+here. All three pools import this module and route through it.
 
-- Rejected for now: a new module is more ceremony than this 2-function
-  refactor needs, and #460 / #346 (the layered-package / `ServiceConfig`
-  refactors) are the issue's named long-term home for cross-subsystem
-  config. Introducing a competing module here would pre-empt that
-  decision. `Postgres.Core` already exists and is the natural seam;
-  when #460/#346 land, lifting these two functions into the
-  `ServiceConfig` layer is a move, not a redesign.
+- **Chosen.** The connection builder is shared by three subsystems and
+  owned by none, so it belongs in neutral infrastructure rather than in
+  any subsystem's module. `Service.Infra.Postgres.ConnectionConfig` is a
+  **low-level** module: the pool modules (EventStore `Internal.hs`,
+  QueryObjectStore `Postgres.hs`, FileUpload `FileStateStore/Postgres.hs`)
+  import *it*; it imports none of them, so there is **no import cycle**.
+  The new `Service.Infra` namespace gives later cross-cutting
+  infrastructure (e.g. the #460/#346 `ServiceConfig` layer) an obvious,
+  already-established home, so lifting more shared config there is a move,
+  not a redesign. The cost is one new module + one `exposed-modules`
+  registration in `core/nhcore.cabal`; the maintainer accepted that
+  ceremony as worth a correct dependency shape.
 
 ### Option 4 — One shared pool for all three subsystems
 
@@ -195,24 +204,31 @@ Collapse the three pools onto one `hasql-pool`.
 
 | Option | Verdict | Reason |
 |--------|---------|--------|
-| 1. Two functions in `Postgres.Core` | **Chosen** | Lowest no-cycle home; both builders + handler in one place; trivial `sslmode` seam; Jess-invisible. |
-| 2. Export from `Internal` | Rejected | Couples two subsystems to EventStore's heavy internal module. |
-| 3. New top-level module | Rejected | More ceremony than needed; pre-empts the #460/#346 config layer. |
+| 1. Two functions in `EventStore.Postgres.Core` | Rejected / superseded | Couples a cross-cutting concern into the EventStore module; subsystems import EventStore just for a connection builder. |
+| 2. Export from `Internal` | Rejected | Couples two subsystems to EventStore's heavy internal module; strictly worse than Option 1. |
+| 3. New top-level `Service.Infra.Postgres.ConnectionConfig` | **Chosen** | Neutral, low-level home for a cross-cutting concern; subsystems → infra dependency direction; no cycle; establishes the `Service.Infra` namespace for future shared config. |
 | 4. One shared pool | Rejected | Out of scope; couples unrelated subsystem lifecycles. |
 
 ## Decision outcome
 
-Adopt Option 1. One internal record and two shared functions in
-`Service.EventStore.Postgres.Core`; all three pools route through them.
+Adopt **Option 3**. Introduce the **`Service.Infra`** namespace and place
+one internal record and two shared functions in a new module
+**`Service.Infra.Postgres.ConnectionConfig`** (file
+`core/service/Service/Infra/Postgres/ConnectionConfig.hs`). All three
+pools — EventStore (`Internal.hs`), QueryObjectStore (`Postgres.hs`), and
+FileUpload (`FileStateStore/Postgres.hs`) — import this module and route
+through it. The module must be registered in `core/nhcore.cabal`'s
+`exposed-modules`.
 
 ### 1. Internal `ConnectionParams` record
 
-A small internal record both config types project into. It is **not**
-exported publicly and adds no surface Jess configures.
+A small record both config types project into. It lives in the new
+infra module, is **not** exported from any module Jess imports, and adds
+no surface Jess configures.
 
 ```haskell
 -- | Internal connection inputs shared by all three Postgres pools.
--- Not a public type: each config record (PostgresEventStore,
+-- Not a public type Jess uses: each config record (PostgresEventStore,
 -- PostgresQueryObjectStoreConfig) projects into it. The sslmode hook
 -- for WI-5 (#684) is added here as a single field when that work lands.
 data ConnectionParams = ConnectionParams
@@ -270,18 +286,25 @@ toPoolConfig poolSize settings =
     |> HasqlPoolConfig.settings
 ```
 
+`logPoolObservation` is defined once in this module. The two now-dead
+inline copies (in `Internal.hs` and `FileStateStore/Postgres.hs`) are
+deleted in favour of this single definition.
+
 ### 4. The three pools become thin projections
 
 Each pool projects its config into `ConnectionParams`, then calls the
-shared builders. No pool constructs params or pool config inline.
+shared builders. No pool constructs params or pool config inline; each
+imports `Service.Infra.Postgres.ConnectionConfig`.
 
 ```haskell
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
+
 -- EventStore (Internal.hs): toConnectionSettings keeps its name/signature
 -- (it is re-exported) and delegates.
 toConnectionSettings :: PostgresEventStore -> LinkedList Hasql.Setting
 toConnectionSettings cfg =
-  Core.toConnectionParams
-    Core.ConnectionParams
+  ConnectionConfig.toConnectionParams
+    ConnectionConfig.ConnectionParams
       { host = cfg.host,
         databaseName = cfg.databaseName,
         user = cfg.user,
@@ -289,18 +312,15 @@ toConnectionSettings cfg =
         port = cfg.port
       }
 
--- defaultOps.acquire then pipes that through Core.toPoolConfig cfg.poolSize
--- exactly as toConnectionPoolSettings did before.
+-- defaultOps.acquire then pipes that through ConnectionConfig.toPoolConfig
+-- cfg.poolSize exactly as toConnectionPoolSettings did before.
 ```
 
 QueryObjectStore's `acquirePool` and FileUpload's `createPool` do the
 same projection-then-`toConnectionParams`/`toPoolConfig`, replacing their
 inline `params` / `poolConfig` `let`-blocks. The fail-fast
 `poolSize > 0` checks added in ADR-0060 stay exactly where they are — the
-shared builder is reached only on the `True` branch. The two now-dead
-inline copies of `logPoolObservation` (in `Internal.hs` and
-`FileStateStore/Postgres.hs`) are deleted in favour of the single
-`Core` definition.
+shared builder is reached only on the `True` branch.
 
 ### 5. FileUpload still shares `PostgresEventStore.poolSize`
 
@@ -311,14 +331,22 @@ possible future split, explicitly not taken here.
 
 ### 6. Module placement
 
-No new module. Changes are confined to:
+One new module under a new namespace, plus delegation edits in the three
+pool modules:
 
 ```text
-core/service/Service/EventStore/Postgres/Core.hs            -- new ConnectionParams + toConnectionParams + toPoolConfig + logPoolObservation
-core/service/Service/EventStore/Postgres/Internal.hs        -- toConnectionSettings delegates; inline pool config + handler removed
-core/service/Service/QueryObjectStore/Postgres.hs           -- acquirePool delegates; inline params/poolConfig removed
-core/service/Service/FileUpload/FileStateStore/Postgres.hs  -- createPool delegates; inline params/poolConfig + handler removed
+core/service/Service/Infra/Postgres/ConnectionConfig.hs      -- NEW: ConnectionParams + toConnectionParams + toPoolConfig + logPoolObservation
+core/service/Service/EventStore/Postgres/Internal.hs         -- toConnectionSettings delegates; inline pool config + handler removed
+core/service/Service/QueryObjectStore/Postgres.hs            -- acquirePool delegates; inline params/poolConfig removed
+core/service/Service/FileUpload/FileStateStore/Postgres.hs   -- createPool delegates; inline params/poolConfig + handler removed
+core/nhcore.cabal                                            -- register Service.Infra.Postgres.ConnectionConfig in exposed-modules
 ```
+
+`Service.Infra` is a new top-level namespace introduced by this ADR.
+`ConnectionConfig` imports only `hasql` connection/pool/observation
+modules and core primitives — it imports none of the three pool modules,
+so there is **no import cycle**: the pool modules depend on the infra
+module, never the reverse.
 
 ### Performance & testing
 
@@ -327,10 +355,11 @@ config are constructed **once per pool at startup**, never per request or
 per event. There is no new allocation on any hot path and no benchmark is
 required (tier: `moderate`; the change is plumbing, not a new IO path).
 
-Verification is by a pure unit spec
-(`core/test-service/Service/EventStore/Postgres/ConnectionSettingsSpec.hs`),
-running unconditionally with no Postgres, asserting the shared builder's
-output:
+Verification is by a pure unit spec at
+`core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs`
+(registered manually in `core/test-service/Main.hs` — the
+`nhcore-test-service` suite does not auto-discover), running
+unconditionally with no Postgres, asserting the shared builder's output:
 
 1. **Keepalives present, all four** — assert
    `toConnectionParams` emits `keepalives` / `keepalives_idle` /
@@ -344,8 +373,8 @@ output:
    idleness timeouts, and the observation handler, so the QueryObjectStore
    pool's newly-added handler cannot silently regress.
 4. **Single observation handler** — assert (by construction / module
-   surface) that `logPoolObservation` is defined once in `Core`; the two
-   inline copies are gone.
+   surface) that `logPoolObservation` is defined once in
+   `ConnectionConfig`; the two inline copies are gone.
 5. **No regression** — the existing `PoolBudgetSpec` (ADR-0060) and the
    EventStore / QueryObjectStore / FileUpload specs continue to pass;
    Postgres-gated specs self-skip when `POSTGRES_AVAILABLE` is unset.
@@ -361,11 +390,11 @@ the `hasql` version in the pin (`>= 1.3 && < 1.4`, ADR-0060) exposes.
 ## Public API
 
 **None.** This change introduces no new public type, function, or config
-field. `ConnectionParams`, `toConnectionParams`, and `toPoolConfig` are
-internal to the Postgres event-store package and are not re-exported from
-any module Jess imports. `toConnectionSettings` keeps its existing
-name and signature for the EventStore (it is already exported from
-`Internal`). The application-facing surface —
+field. `ConnectionParams`, `toConnectionParams`, and `toPoolConfig` live
+in the internal `Service.Infra.Postgres.ConnectionConfig` module and are
+not re-exported from any module Jess imports. `toConnectionSettings`
+keeps its existing name and signature for the EventStore (it is already
+exported from `Internal`). The application-facing surface —
 `Application.withEventStore postgresConfig`,
 `def { host = ..., ... }`, and the defaulted `poolSize` fields from
 ADR-0060 — is byte-for-byte unchanged.
@@ -404,6 +433,9 @@ app =
    config are pinned equal pre/post by the spec.
 6. **Jess sees nothing new.** No public type, function, or config knob is
    added; the application wiring is identical.
+7. **Correct dependency shape.** The cross-cutting builder lives in
+   neutral infrastructure that the subsystems depend on, not in any
+   subsystem. No subsystem imports another to share it.
 
 ### Negative
 
@@ -416,10 +448,13 @@ app =
 2. **A small internal record is added.** `ConnectionParams` is new code,
    even if not public. It is the price of one builder that does not
    depend on three different config types.
-3. **`Postgres.Core` gains responsibility.** A module previously holding
-   only event-store core types now also owns the shared connection
-   builder. Mitigated by the #460/#346 plan to lift it into a dedicated
-   config layer later — at which point this is a move, not a redesign.
+3. **A new namespace and module are introduced.** `Service.Infra` and
+   `Service.Infra.Postgres.ConnectionConfig` are new; the module must be
+   registered in `core/nhcore.cabal`'s `exposed-modules` (a missing
+   registration is a build failure). This is more ceremony than appending
+   to an existing module, accepted deliberately to keep the dependency
+   direction correct (subsystems → infra) and to give future
+   cross-cutting config (#460/#346) an established home.
 
 ### Risks
 
@@ -428,7 +463,8 @@ app =
 | Refactor silently changes the EventStore param/pool output. | Spec test 2 pins `toConnectionSettings` output equal to its pre-refactor value; spec test 3 pins the pool-config inputs. |
 | QueryObjectStore's newly-added handler regresses (e.g. dropped in a later edit). | Spec test 3 asserts the pool config carries the observation handler. |
 | `hasql`'s opaque `Setting` value blocks direct equality assertions. | Assertions are written at the observable `ConnectionParams → [Param]` boundary, not the opaque end value; the implementation phase confirms the exact assertable surface for the pinned `hasql` version. |
-| Import cycle if the builder is placed wrong. | Placed in `Postgres.Core`, the lowest module all three pools already depend on (directly or transitively); no new edge from `Core` back up to `Internal`. |
+| Import cycle if the builder is placed wrong. | `Service.Infra.Postgres.ConnectionConfig` is low-level: it imports only `hasql` and core primitives, and the three pool modules import it — never the reverse. No new edge back up to any subsystem, so no cycle is possible. |
+| New module not registered in the cabal file. | `exposed-modules` registration of `Service.Infra.Postgres.ConnectionConfig` is part of the build phase; a missing entry fails the build (`Module not found in the package`) rather than shipping. |
 | WI-5 `sslmode` lands and re-introduces drift. | The seam is a single field on `ConnectionParams` + one `Param` line in `toConnectionParams`; #684 cannot add `sslmode` to one pool and not another because there is only one builder. |
 
 ### Mitigations
@@ -439,7 +475,7 @@ app =
 - The `sslmode` seam is documented in `toConnectionParams` as a comment
   marking exactly where WI-5 extends it, so #684 has an unambiguous
   landing point.
-- The change is confined to the four files listed in §6; the spec's
+- The change is confined to the files listed in §6; the spec's
   no-regression assertion (test 5) plus the existing `PoolBudgetSpec`
   guard the ADR-0060 budget contract across the refactor.
 
@@ -454,4 +490,4 @@ app =
 - [core/service/Service/EventStore/Postgres/Internal.hs](../../core/service/Service/EventStore/Postgres/Internal.hs) (lines 100-146) — EventStore builder (has keepalives + handler).
 - [core/service/Service/QueryObjectStore/Postgres.hs](../../core/service/Service/QueryObjectStore/Postgres.hs) (lines 113-141) — QueryObjectStore builder (no keepalives, no handler).
 - [core/service/Service/FileUpload/FileStateStore/Postgres.hs](../../core/service/Service/FileUpload/FileStateStore/Postgres.hs) (lines 168-213) — FileUpload builder (no keepalives, duplicate handler).
-- [core/service/Service/EventStore/Postgres/Core.hs](../../core/service/Service/EventStore/Postgres/Core.hs) — proposed home for the shared builder.
+- `core/service/Service/Infra/Postgres/ConnectionConfig.hs` — the new home for the shared builder (introduces the `Service.Infra` namespace).

--- a/docs/decisions/0062-shared-connection-settings-builder.md
+++ b/docs/decisions/0062-shared-connection-settings-builder.md
@@ -1,0 +1,457 @@
+# ADR-0062: Single Shared Postgres Connection-Settings Builder
+
+> Issue: [#681 — WI-2: Unify the three Postgres connection-settings builders into one shared builder](https://github.com/neohaskell/NeoHaskell/issues/681)
+
+## Status
+
+Proposed
+
+## Context
+
+### Current State
+
+nhcore opens Postgres connections from **three independent `hasql-pool`
+pools**, and each pool builds its own libpq connection parameters and its
+own `Hasql.Pool.Config` inline. The three builders have **drifted**: they
+do not agree on which connection parameters or pool settings to apply.
+
+| Pool | Builder | Keepalives? | Observation handler? | Pool size (ADR-0060) |
+|------|---------|-------------|----------------------|----------------------|
+| EventStore | `toConnectionSettings` + `toConnectionPoolSettings` (`core/service/Service/EventStore/Postgres/Internal.hs:100-146`) | **yes** (`:140-144`) | **yes** | `PostgresEventStore.poolSize` (default 6) |
+| FileUpload | `createPool` (`core/service/Service/FileUpload/FileStateStore/Postgres.hs:168-193`) | **no** | yes | shares `PostgresEventStore.poolSize` |
+| QueryObjectStore | `acquirePool` (`core/service/Service/QueryObjectStore/Postgres.hs:113-141`) | **no** | **no** | `PostgresQueryObjectStoreConfig.poolSize` (default 4) |
+
+Three concrete drifts:
+
+1. **TCP keepalives only on EventStore.** The EventStore builder passes
+   the four libpq keepalive params from ADR-0037 (`keepalives`,
+   `keepalives_idle`, `keepalives_interval`, `keepalives_count`).
+   FileUpload and QueryObjectStore pass **none** — their pooled
+   connections fall back to the OS default keepalive idle (typically 2
+   hours on Linux), far longer than any cloud NAT or Flexible Server
+   maintenance window.
+2. **Pool observation handler only on EventStore + FileUpload.** The
+   ADR-0027 `observationHandler` (which logs aging / idleness / network
+   terminations) is wired on EventStore and FileUpload but **not** on
+   QueryObjectStore — so QueryObjectStore connection terminations are
+   invisible.
+3. **The handler itself is duplicated verbatim.** `logPoolObservation`
+   is copy-pasted identically into `Internal.hs:114-128` and
+   `FileStateStore/Postgres.hs:199-213` — two copies of the same 14-line
+   function that must be kept in lockstep by hand.
+
+The cost of this drift is operational. Across a Flexible Server
+maintenance restart or an idle network drop, the QueryObjectStore and
+FileUpload pools will **not detect dead sockets quickly** (no
+keepalives), and a QueryObjectStore connection death is **not logged**
+(no observation handler). Worse, the drift is structural: the future
+`sslmode` hook from WI-5 (#684), and any other connection parameter,
+would have to be added in **three places** and is liable to drift again.
+
+ADR-0060 (#680, WI-1) already made the *pool size* explicit and shared
+(FileUpload reuses `PostgresEventStore.poolSize`; QueryObjectStore has
+its own `poolSize`). This ADR completes the unification for the
+*connection parameters* and the *pool settings* themselves.
+
+### Use Cases
+
+- **Flexible Server maintenance restart.** When Azure restarts the
+  Burstable `B1ms` instance for patching, every pooled connection's
+  socket dies. With keepalives on all three pools, each pool detects the
+  dead socket within ≈80 s (ADR-0037 timing) and recycles it, instead of
+  the QueryObjectStore / FileUpload pools handing out a dead connection
+  on the next `use` and surfacing a confusing first-query error.
+- **Idle network drop on a NAT gateway.** A QueryObjectStore pool that
+  has been idle through a cold-start window keeps its NAT mapping alive
+  via keepalive probes, rather than silently losing the mapping and
+  failing the first read-model write after the app warms up.
+- **One place to add `sslmode` (WI-5).** When #684 adds opt-in
+  `sslmode=require`, it threads it through the single builder and all
+  three pools get it for free, gated by one config field — not three
+  edits that can disagree.
+- **One place to read the connection contract.** A deploy reviewer reads
+  one function to know exactly which libpq params and pool settings every
+  nhcore Postgres pool uses.
+
+### Design Goals
+
+1. **Single source of truth for connection params.** Exactly one
+   function constructs the libpq `Param` list (host, port, dbname, user,
+   password, the four keepalives, and the future `sslmode`). The three
+   pools call it; none builds params inline.
+2. **Single source of truth for pool settings.** Exactly one function
+   constructs the `Hasql.Pool.Config` (static settings + size + aging +
+   idleness + observation handler), parameterised by the per-pool size.
+   The observation handler is defined once.
+3. **Uniform keepalives + observation handler.** After this change all
+   three pools carry the ADR-0037 keepalives and the ADR-0027 observation
+   handler. The two drifts disappear by construction.
+4. **No behavioural regression for the EventStore path.** The EventStore
+   already had keepalives + handler + its `poolSize`; its emitted
+   params and pool config must be byte-for-byte equivalent before and
+   after. The change is additive for the other two pools only.
+5. **Reserve the `sslmode` seam for WI-5 without building it now.** The
+   shared builder is shaped so #684 adds `sslmode` by extending one
+   input and one `Param` line, with no further structural change. WI-5
+   is out of scope here; this ADR only makes its landing trivial.
+6. **Invisible to Jess.** This is internal plumbing. No new public type,
+   no new public function, no new config field on any config record. The
+   `Application.withEventStore postgresConfig` surface is unchanged.
+
+### GitHub Issue
+
+- [#681: WI-2 — Unify the three Postgres connection-settings builders into one shared builder](https://github.com/neohaskell/NeoHaskell/issues/681)
+- Parent epic: [#679 — Deploy-readiness on Azure Database for PostgreSQL Flexible Server](https://github.com/neohaskell/NeoHaskell/issues/679)
+
+## Decision drivers
+
+- **The drift is a silent correctness gap, not a style nit.** Two of
+  three pools cannot detect a dead socket promptly and one cannot log a
+  termination. On the epic's deploy target (Flexible Server `B1ms`,
+  behind ACA scale-to-zero) connection deaths are *routine*, so the gap
+  is hit in normal operation, not edge cases.
+- **WI-5 forces the question now.** #684 will add `sslmode`. Adding it to
+  three drifted builders re-creates the exact 3-way duplication this work
+  item exists to remove. Unifying first is the cheaper order.
+- **The EventStore path is the regression risk.** It is the only pool
+  whose params already include keepalives; the refactor must preserve its
+  output exactly. The other two pools are *gaining* params, which is the
+  intended behaviour change, not a regression.
+- **Keep the surface Jess-invisible.** This is deploy-tier plumbing. It
+  must add no public type, function, or config knob. The existing
+  defaulted `poolSize` fields (ADR-0060) remain the only connection-pool
+  surface anyone configures.
+- **Honour the config-sharing decision from ADR-0060.** FileUpload still
+  shares `PostgresEventStore.poolSize` (Option A). This ADR does **not**
+  give FileUpload an independent size — that remains a possible future
+  split, deliberately not taken here.
+
+## Considered options
+
+### Option 1 — Two shared functions in `EventStore.Postgres.Core`, both pools import them (chosen)
+
+Place the two builders in the existing
+`Service.EventStore.Postgres.Core` module (already imported by
+`Internal.hs`):
+
+- `toConnectionParams :: ConnectionParams -> LinkedList Hasql.Setting` —
+  the single libpq param constructor (host/port/dbname/user/password +
+  the four keepalives, with the `sslmode` seam reserved for WI-5).
+- `toPoolConfig :: Int -> LinkedList Hasql.Setting -> HasqlPoolConfig.Config`
+  — the single pool-config constructor (static settings + `size` +
+  `agingTimeout` + `idlenessTimeout` + `observationHandler`), with
+  `logPoolObservation` defined once here too.
+
+`ConnectionParams` is a small **internal** record (`host`, `databaseName`,
+`user`, `password`, `port`) that both config types project into — it is
+*not* exported from any public module and is not a new public type Jess
+sees. EventStore's `toConnectionSettings` becomes a thin projection of
+`PostgresEventStore` into `ConnectionParams` then a call to
+`toConnectionParams`; QueryObjectStore's `acquirePool` and FileUpload's
+`createPool` do the same projection and call `toConnectionParams` +
+`toPoolConfig`.
+
+- Chosen: `Postgres.Core` is the lowest module all three pools can depend
+  on without a cycle (EventStore already imports it; FileUpload already
+  imports `Service.EventStore.Postgres`; QueryObjectStore can import the
+  `Core` module without pulling in EventStore's `Internal`). Both
+  builders live together; the observation handler is defined once; the
+  `sslmode` seam is a single `Param` line behind one `ConnectionParams`
+  extension.
+
+### Option 2 — Keep the builders in `EventStore.Postgres.Internal`, export them
+
+Export `toConnectionSettings` / `toConnectionPoolSettings` /
+`logPoolObservation` from `Internal.hs` and have the other two pools
+import them.
+
+- Rejected: forces QueryObjectStore and FileUpload to depend on
+  EventStore's `Internal` module — a heavy, churny module that carries
+  the whole event-store implementation. It also couples two unrelated
+  subsystems to EventStore internals just to share five lines of param
+  construction. A small dedicated home (`Postgres.Core`) is the right
+  altitude.
+
+### Option 3 — A new top-level `Service.Postgres.ConnectionConfig` module
+
+Create a brand-new module for the shared builder.
+
+- Rejected for now: a new module is more ceremony than this 2-function
+  refactor needs, and #460 / #346 (the layered-package / `ServiceConfig`
+  refactors) are the issue's named long-term home for cross-subsystem
+  config. Introducing a competing module here would pre-empt that
+  decision. `Postgres.Core` already exists and is the natural seam;
+  when #460/#346 land, lifting these two functions into the
+  `ServiceConfig` layer is a move, not a redesign.
+
+### Option 4 — One shared pool for all three subsystems
+
+Collapse the three pools onto one `hasql-pool`.
+
+- Rejected: same reasoning as ADR-0060 Option 5. Out of scope; the three
+  subsystems have different lifecycles, and merging couples FileUpload
+  (often unused) contention onto the EventStore hot path. This ADR
+  unifies the *builders*, not the *pools*.
+
+| Option | Verdict | Reason |
+|--------|---------|--------|
+| 1. Two functions in `Postgres.Core` | **Chosen** | Lowest no-cycle home; both builders + handler in one place; trivial `sslmode` seam; Jess-invisible. |
+| 2. Export from `Internal` | Rejected | Couples two subsystems to EventStore's heavy internal module. |
+| 3. New top-level module | Rejected | More ceremony than needed; pre-empts the #460/#346 config layer. |
+| 4. One shared pool | Rejected | Out of scope; couples unrelated subsystem lifecycles. |
+
+## Decision outcome
+
+Adopt Option 1. One internal record and two shared functions in
+`Service.EventStore.Postgres.Core`; all three pools route through them.
+
+### 1. Internal `ConnectionParams` record
+
+A small internal record both config types project into. It is **not**
+exported publicly and adds no surface Jess configures.
+
+```haskell
+-- | Internal connection inputs shared by all three Postgres pools.
+-- Not a public type: each config record (PostgresEventStore,
+-- PostgresQueryObjectStoreConfig) projects into it. The sslmode hook
+-- for WI-5 (#684) is added here as a single field when that work lands.
+data ConnectionParams = ConnectionParams
+  { host :: Text,
+    databaseName :: Text,
+    user :: Text,
+    password :: Text,
+    port :: Int
+  }
+  deriving (Eq, Ord, Show)
+```
+
+### 2. `toConnectionParams` — the single libpq param builder
+
+The one place connection params are constructed. Carries the ADR-0037
+keepalives for every pool. The `sslmode` line for WI-5 is the only
+addition #684 makes here.
+
+```haskell
+toConnectionParams :: ConnectionParams -> LinkedList Hasql.Setting
+toConnectionParams cfg = do
+  let params =
+        ConnectionSettingConnection.params
+          [ Param.host cfg.host,
+            Param.port (fromIntegral cfg.port),
+            Param.dbname cfg.databaseName,
+            Param.user cfg.user,
+            Param.password cfg.password,
+            -- TCP keepalive: detect dead connections in cloud
+            -- environments (ADR-0037, #397) — now on ALL three pools.
+            Param.other "keepalives" "1",
+            Param.other "keepalives_idle" "30",
+            Param.other "keepalives_interval" "10",
+            Param.other "keepalives_count" "5"
+            -- WI-5 (#684) adds: Param.other "sslmode" "<mode>" here.
+          ]
+  [params |> ConnectionSetting.connection]
+```
+
+### 3. `toPoolConfig` — the single pool-config builder
+
+The one place `Hasql.Pool.Config` is constructed, parameterised by the
+per-pool size so EventStore/FileUpload (6) and QueryObjectStore (4) keep
+their ADR-0060 sizes. The observation handler is defined once, here.
+
+```haskell
+toPoolConfig :: Int -> LinkedList Hasql.Setting -> HasqlPoolConfig.Config
+toPoolConfig poolSize settings =
+  [ HasqlPoolConfig.staticConnectionSettings settings,
+    HasqlPoolConfig.size poolSize,
+    HasqlPoolConfig.agingTimeout 300,
+    HasqlPoolConfig.idlenessTimeout 60,
+    HasqlPoolConfig.observationHandler logPoolObservation
+  ]
+    |> HasqlPoolConfig.settings
+```
+
+### 4. The three pools become thin projections
+
+Each pool projects its config into `ConnectionParams`, then calls the
+shared builders. No pool constructs params or pool config inline.
+
+```haskell
+-- EventStore (Internal.hs): toConnectionSettings keeps its name/signature
+-- (it is re-exported) and delegates.
+toConnectionSettings :: PostgresEventStore -> LinkedList Hasql.Setting
+toConnectionSettings cfg =
+  Core.toConnectionParams
+    Core.ConnectionParams
+      { host = cfg.host,
+        databaseName = cfg.databaseName,
+        user = cfg.user,
+        password = cfg.password,
+        port = cfg.port
+      }
+
+-- defaultOps.acquire then pipes that through Core.toPoolConfig cfg.poolSize
+-- exactly as toConnectionPoolSettings did before.
+```
+
+QueryObjectStore's `acquirePool` and FileUpload's `createPool` do the
+same projection-then-`toConnectionParams`/`toPoolConfig`, replacing their
+inline `params` / `poolConfig` `let`-blocks. The fail-fast
+`poolSize > 0` checks added in ADR-0060 stay exactly where they are — the
+shared builder is reached only on the `True` branch. The two now-dead
+inline copies of `logPoolObservation` (in `Internal.hs` and
+`FileStateStore/Postgres.hs`) are deleted in favour of the single
+`Core` definition.
+
+### 5. FileUpload still shares `PostgresEventStore.poolSize`
+
+Unchanged from ADR-0060 (Option A). FileUpload's `createPool` continues
+to take a `PostgresEventStore` and read `cfg.poolSize`; this ADR does
+**not** add an independent FileUpload size. An independent size remains a
+possible future split, explicitly not taken here.
+
+### 6. Module placement
+
+No new module. Changes are confined to:
+
+```text
+core/service/Service/EventStore/Postgres/Core.hs            -- new ConnectionParams + toConnectionParams + toPoolConfig + logPoolObservation
+core/service/Service/EventStore/Postgres/Internal.hs        -- toConnectionSettings delegates; inline pool config + handler removed
+core/service/Service/QueryObjectStore/Postgres.hs           -- acquirePool delegates; inline params/poolConfig removed
+core/service/Service/FileUpload/FileStateStore/Postgres.hs  -- createPool delegates; inline params/poolConfig + handler removed
+```
+
+### Performance & testing
+
+This is a structural refactor on a cold path — connection params and pool
+config are constructed **once per pool at startup**, never per request or
+per event. There is no new allocation on any hot path and no benchmark is
+required (tier: `moderate`; the change is plumbing, not a new IO path).
+
+Verification is by a pure unit spec
+(`core/test-service/Service/EventStore/Postgres/ConnectionSettingsSpec.hs`),
+running unconditionally with no Postgres, asserting the shared builder's
+output:
+
+1. **Keepalives present, all four** — assert
+   `toConnectionParams` emits `keepalives` / `keepalives_idle` /
+   `keepalives_interval` / `keepalives_count` (the ADR-0037 set), so the
+   keepalive contract is pinned for every pool that calls it.
+2. **EventStore params unchanged (no regression)** — assert that
+   `toConnectionSettings cfg` (EventStore's projection) yields the same
+   `Setting` list it produced before the refactor, pinning Design Goal 4.
+3. **Pool config carries size + handler + timeouts** — assert
+   `toPoolConfig n settings` sets `size = n`, the ADR-0027 aging /
+   idleness timeouts, and the observation handler, so the QueryObjectStore
+   pool's newly-added handler cannot silently regress.
+4. **Single observation handler** — assert (by construction / module
+   surface) that `logPoolObservation` is defined once in `Core`; the two
+   inline copies are gone.
+5. **No regression** — the existing `PoolBudgetSpec` (ADR-0060) and the
+   EventStore / QueryObjectStore / FileUpload specs continue to pass;
+   Postgres-gated specs self-skip when `POSTGRES_AVAILABLE` is unset.
+
+`hasql`'s `Setting` / `Param` values are opaque (no `Eq`/`Show` on the
+final `ConnectionSetting`), so assertions are written against the
+`ConnectionParams → Setting` boundary the spec can observe — the param
+*inputs* and the pool-config *inputs* — rather than the opaque end value;
+this is sufficient to pin keepalive presence, the size, and handler
+wiring. The implementation phase confirms the exact assertable surface
+the `hasql` version in the pin (`>= 1.3 && < 1.4`, ADR-0060) exposes.
+
+## Public API
+
+**None.** This change introduces no new public type, function, or config
+field. `ConnectionParams`, `toConnectionParams`, and `toPoolConfig` are
+internal to the Postgres event-store package and are not re-exported from
+any module Jess imports. `toConnectionSettings` keeps its existing
+name and signature for the EventStore (it is already exported from
+`Internal`). The application-facing surface —
+`Application.withEventStore postgresConfig`,
+`def { host = ..., ... }`, and the defaulted `poolSize` fields from
+ADR-0060 — is byte-for-byte unchanged.
+
+```haskell
+-- Unchanged for callers — the same construction works exactly as before.
+postgresEventStoreConfig :: PostgresEventStore
+postgresEventStoreConfig =
+  def { host = "...", databaseName = "...", user = "...", password = "..." }
+
+app :: Application
+app =
+  Application.new
+    |> Application.withEventStore postgresEventStoreConfig
+    |> Application.useQueryObjectStore postgresQueryObjectStoreConfig
+    |> Application.withService userService
+```
+
+## Consequences
+
+### Positive
+
+1. **Keepalives now cover all three pools.** QueryObjectStore and
+   FileUpload detect dead sockets in ≈80 s across a Flexible Server
+   restart or NAT drop, instead of falling back to the 2-hour OS default.
+2. **Observation handler now covers all three pools.** QueryObjectStore
+   connection terminations are logged, closing the last observability
+   gap among the pools.
+3. **One place to change connection behaviour.** Adding `sslmode` (WI-5)
+   or any future param is a single edit to `toConnectionParams`; it
+   cannot drift across pools again.
+4. **The observation handler is defined once.** The two verbatim copies
+   of `logPoolObservation` collapse into one; they can no longer fall out
+   of lockstep.
+5. **No regression risk for EventStore.** Its emitted params and pool
+   config are pinned equal pre/post by the spec.
+6. **Jess sees nothing new.** No public type, function, or config knob is
+   added; the application wiring is identical.
+
+### Negative
+
+1. **QueryObjectStore and FileUpload change behaviour.** They gain
+   keepalives (and QueryObjectStore gains the handler). This is the
+   *intended* fix, but it is a behaviour change: their connections now
+   carry keepalive probes they did not before. The risk is negligible
+   (keepalives are passive TCP probes) but it is not a pure no-op for
+   those two pools.
+2. **A small internal record is added.** `ConnectionParams` is new code,
+   even if not public. It is the price of one builder that does not
+   depend on three different config types.
+3. **`Postgres.Core` gains responsibility.** A module previously holding
+   only event-store core types now also owns the shared connection
+   builder. Mitigated by the #460/#346 plan to lift it into a dedicated
+   config layer later — at which point this is a move, not a redesign.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Refactor silently changes the EventStore param/pool output. | Spec test 2 pins `toConnectionSettings` output equal to its pre-refactor value; spec test 3 pins the pool-config inputs. |
+| QueryObjectStore's newly-added handler regresses (e.g. dropped in a later edit). | Spec test 3 asserts the pool config carries the observation handler. |
+| `hasql`'s opaque `Setting` value blocks direct equality assertions. | Assertions are written at the observable `ConnectionParams → [Param]` boundary, not the opaque end value; the implementation phase confirms the exact assertable surface for the pinned `hasql` version. |
+| Import cycle if the builder is placed wrong. | Placed in `Postgres.Core`, the lowest module all three pools already depend on (directly or transitively); no new edge from `Core` back up to `Internal`. |
+| WI-5 `sslmode` lands and re-introduces drift. | The seam is a single field on `ConnectionParams` + one `Param` line in `toConnectionParams`; #684 cannot add `sslmode` to one pool and not another because there is only one builder. |
+
+### Mitigations
+
+- The keepalive and pool-config contracts are encoded in the unit spec,
+  so a future edit that drops a param or the handler fails CI rather than
+  shipping a silent regression.
+- The `sslmode` seam is documented in `toConnectionParams` as a comment
+  marking exactly where WI-5 extends it, so #684 has an unambiguous
+  landing point.
+- The change is confined to the four files listed in §6; the spec's
+  no-regression assertion (test 5) plus the existing `PoolBudgetSpec`
+  guard the ADR-0060 budget contract across the refactor.
+
+## References
+
+- [#681: WI-2 — Unify the three connection-settings builders](https://github.com/neohaskell/NeoHaskell/issues/681)
+- [#679: Epic — Deploy-readiness on Azure Flexible Server](https://github.com/neohaskell/NeoHaskell/issues/679)
+- [#684: WI-5 — Optional `sslmode` TLS hardening](https://github.com/neohaskell/NeoHaskell/issues/684) — lands in the shared builder defined here.
+- [ADR-0060: Explicit Postgres Connection-Pool Budget for Flexible Server B1ms](0060-postgres-pool-budget.md) — added the `poolSize` fields this builder reads; FileUpload shares `PostgresEventStore.poolSize` (Option A), unchanged here.
+- [ADR-0037: PostgreSQL LISTEN Connection Keepalive and Reconnection](0037-postgres-listen-keepalive-reconnect.md) — the keepalive params now applied to all three pools.
+- [ADR-0027: PostgreSQL Connection Pool Health for Serverless Databases](0027-postgres-pool-health.md) — the `agingTimeout` / `idlenessTimeout` / `observationHandler` now applied to all three pools.
+- [core/service/Service/EventStore/Postgres/Internal.hs](../../core/service/Service/EventStore/Postgres/Internal.hs) (lines 100-146) — EventStore builder (has keepalives + handler).
+- [core/service/Service/QueryObjectStore/Postgres.hs](../../core/service/Service/QueryObjectStore/Postgres.hs) (lines 113-141) — QueryObjectStore builder (no keepalives, no handler).
+- [core/service/Service/FileUpload/FileStateStore/Postgres.hs](../../core/service/Service/FileUpload/FileStateStore/Postgres.hs) (lines 168-213) — FileUpload builder (no keepalives, duplicate handler).
+- [core/service/Service/EventStore/Postgres/Core.hs](../../core/service/Service/EventStore/Postgres/Core.hs) — proposed home for the shared builder.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -71,6 +71,7 @@ ADRs document significant architectural decisions made during the development of
 | [0055](0055-declarative-integrations-with-fakes.md) | Declarative Integrations with Real/Fake Parity | Proposed |
 | [0056](0056-request-context-timestamp-as-datetime.md) | Retype `RequestContext.timestamp` as `DateTime` | Proposed |
 | [0061](0061-listener-reconnect-catchup.md) | Replay from Last globalPosition on LISTEN/NOTIFY Listener Reconnect | Proposed |
+| [0062](0062-shared-connection-settings-builder.md) | Single Shared Postgres Connection-Settings Builder | Proposed |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## WI-2: Unify the three Postgres connection-settings builders

Before this change, NeoHaskell opened Postgres connections from **three separate pools** — EventStore, QueryObjectStore, and FileUpload — and each one built its own libpq connection parameters and pool config inline. Over time they drifted apart:

- Only **EventStore** sent the four ADR-0037 TCP **keepalives**. The other two pools fell back to the OS default (often 2 hours idle), far too long for a cloud NAT or an Azure Flexible Server maintenance restart.
- The ADR-0027 pool **observation handler** (which logs aging / idleness / network terminations) was wired on EventStore and FileUpload but **not** on QueryObjectStore, so its connection deaths were invisible.
- That handler (`logPoolObservation`) was **copy-pasted verbatim** into two modules and had to be kept in lockstep by hand.

This PR removes the drift by extracting one shared builder that all three pools route through.

### What changed

A new low-level module **`Service.Infra.Postgres.ConnectionConfig`** (under a new `Service.Infra` namespace for cross-cutting infrastructure) now owns:

- `ConnectionParams` — a small internal record each pool's config projects into.
- `toConnectionParams` — the single place libpq params are built, carrying the four keepalives for **every** pool.
- `toPoolConfig` — the single place the pool config is built (size + aging/idleness timeouts + the observation handler), parameterised by each pool's `poolSize`.
- `logPoolObservation` — defined **once** here; the two duplicate copies are deleted.

The three pools became thin projections that import this module and delegate. The dependency direction is **subsystems → infra** (the pool modules import `ConnectionConfig`; it imports none of them), so there is no import cycle.

After this change, all three pools carry the keepalives and the observation handler uniformly. **QueryObjectStore and FileUpload gain keepalives; QueryObjectStore also gains the observation handler** — the intended fix. The EventStore path is unchanged (its params and pool config are pinned byte-for-byte by the tests). The future `sslmode` hook (WI-5 / #684) now has a single seam to land in instead of three. FileUpload keeps sharing `PostgresEventStore.poolSize` (ADR-0060 Option A) — no independent size knob.

### Does this change anything for you?

**No.** This is internal plumbing. There is **no new public type, function, or config field**. Your application wiring — `Application.withEventStore postgresConfig`, `def { host = ..., ... }`, and the defaulted `poolSize` fields — works exactly as before.

### ADR

This implements **[ADR-0062: Single Shared Postgres Connection-Settings Builder](docs/decisions/0062-shared-connection-settings-builder.md)** (Status: Proposed). The maintainer chose **Option 3** — a new top-level infrastructure module — over hanging the shared builders off the existing EventStore module, so a cross-cutting concern lives in neutral infrastructure that no subsystem owns.

### Files

- **NEW** `core/service/Service/Infra/Postgres/ConnectionConfig.hs` — the shared `ConnectionParams` + `toConnectionParams` + `toPoolConfig` + the single `logPoolObservation`.
- `core/nhcore.cabal` — registers the new module in `exposed-modules`.
- `core/service/Service/EventStore/Postgres/Internal.hs` — `toConnectionSettings` delegates; local pool-config builder + duplicate handler deleted.
- `core/service/Service/QueryObjectStore/Postgres.hs` — `acquirePool` delegates; gains keepalives + the observation handler.
- `core/service/Service/FileUpload/FileStateStore/Postgres.hs` — `createPool` delegates; gains keepalives; duplicate handler deleted.
- **NEW** `core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs` (+ `core/test-service/Main.hs` registration) — pure unit spec, 22 cases.

### Security

Classification: **moderate** (internal IO-path refactor, no new dependency, no secret-gating boundary). ADR review ([findings-04]) and implementation review ([findings-12]) each landed **0 blockers**. One hardening item was applied directly: the internal `ConnectionParams` record holds `password`, so it derives `(Eq, Ord)` only — **`Show` is deliberately dropped** so a password can never be rendered by an accidental `show`/trace/exception. The observation handler logs only hasql termination-reason values (the cause), never the connection string.

### Performance

ADR review ([findings-05]) and implementation review ([findings-13]) each landed **0 blockers**. Connection params and pool config are built **once per pool at startup** — a cold path, never on the 50k req/s request/event path — so no `INLINE`/`UNPACK`/caching was warranted, and the EventStore path has no new allocation.

### Tests

A pure unit spec (`ConnectionConfigSpec`, 22 cases) runs unconditionally with no Postgres. It pins: the keepalive contract on `toConnectionParams`, the EventStore no-regression equivalence on `toConnectionSettings` (ADR Design Goal 4), and the totality of `toPoolConfig` across pool-size boundaries. Because hasql's `Setting`/`Config` values are opaque (no `Eq`/`Show`), assertions are written at the observable boundary (list length, totality, projection-equivalence). All suites green: **4375 examples, 0 failures**. The existing `PoolBudgetSpec` (ADR-0060) continues to pass.

### Hlint

Hlint clean.

### Checklist

- [x] ADR approved (phase 3)
- [x] Security findings grounded — 0 blockers (ADR + impl)
- [x] Performance findings grounded — 0 blockers (ADR + impl)
- [x] Tests passing — `cabal build all` + `cabal test` green (4375 examples, 0 failures)
- Hlint: clean ✓

Part of the deploy-readiness epic #679 (Phase 2).

Closes #681


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared Postgres connection/pool configuration component used by Event Store, Query Object Store, and File Upload.
  * Added a dedicated test suite for the new Postgres configuration logic.
* **Refactor**
  * Consolidated Postgres connection setup and pool configuration into the shared implementation.
  * Updated services to derive connection parameters and pool settings through the common flow.
* **Bug Fixes**
  * Improved handling of invalid Postgres ports by validating input earlier and surfacing failures more reliably.
* **Documentation**
  * Added an ADR documenting the shared Postgres configuration approach and updated the ADR index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->