### PR TITLE
fix(service): release per-stream subscription connection on unsubscribe

### DIFF
--- a/core/core/Task.hs
+++ b/core/core/Task.hs
@@ -64,6 +64,13 @@ newtype Task err value = Task
   deriving (Functor, Applicable.Applicative, Monad)
 
 
+-- | A 'Task' wraps a deferred effect, so the value it will produce cannot be
+-- inspected without running it. This placeholder instance lets records that
+-- hold a 'Task' field still derive (or hand-write) 'Show'.
+instance Prelude.Show (Task err value) where
+  show _ = "Task"
+
+
 yield :: value -> Task _ value
 yield value = Task (Applicable.pure value)
 {-# INLINE yield #-}

--- a/core/service/Service/EventStore/Postgres/Internal.hs
+++ b/core/service/Service/EventStore/Postgres/Internal.hs
@@ -809,9 +809,15 @@ subscribeToStreamEventsImpl ops cfg store entityName streamId callback =
       Sessions.selectMaxGlobalPosition
         |> Sessions.run conn
         |> Task.mapError (toText .> StorageFailure)
+
+    -- Release the dedicated per-stream connection when this subscription is
+    -- removed. Owned by the SubscriptionId, run best-effort on unsubscribe
+    -- (ADR-0063 §3).
+    let releaseConnection = Hasql.release connection |> Task.fromIO
+
     subscriptionId <-
       store
-        |> SubscriptionStore.addStreamSubscriptionFromPosition entityName streamId currentMaxPosition callback
+        |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId currentMaxPosition releaseConnection callback
         |> Task.mapError (\err -> SubscriptionError (SubscriptionId "stream") (err |> toText))
     Log.debug [fmt|Subscription created: #{toText subscriptionId}|] |> Task.ignoreError
     Task.yield subscriptionId

--- a/core/service/Service/EventStore/Postgres/SubscriptionStore.hs
+++ b/core/service/Service/EventStore/Postgres/SubscriptionStore.hs
@@ -6,6 +6,7 @@ module Service.EventStore.Postgres.SubscriptionStore (
   addGlobalSubscriptionFromPosition,
   addStreamSubscription,
   addStreamSubscriptionFromPosition,
+  addStreamSubscriptionWithCleanup,
   addEntitySubscription,
   addEntitySubscriptionFromPosition,
   getStreamSubscriptions,
@@ -21,6 +22,7 @@ import Core
 import Json qualified
 import Log qualified
 import Map qualified
+import Prelude qualified
 import Service.Event (EntityName, Event (..), StreamPosition)
 import Service.Event.EventMetadata (EventMetadata (..))
 import Service.EventStore.Core (SubscriptionId (..))
@@ -41,9 +43,23 @@ type SubscriptionCallback =
 data SubscriptionInfo = SubscriptionInfo
   { callback :: SubscriptionCallback,
     startingGlobalPosition :: Maybe StreamPosition,
-    entityNameFilter :: Maybe EntityName
+    entityNameFilter :: Maybe EntityName,
+    -- | Run once when this subscription is removed. Releases any dedicated
+    -- resource the subscription owns (the per-stream LISTEN connection). A
+    -- no-op ('Task.yield unit') for subscriptions that own no dedicated resource.
+    onRemove :: Task Text Unit
   }
-  deriving (Show)
+
+
+-- Hand-written Show: the callback and onRemove are Task/closure fields with no
+-- Show instance, so they are elided. (ADR-0063 §1.)
+instance Show SubscriptionInfo where
+  show info =
+    "SubscriptionInfo {startingGlobalPosition = "
+      ++ Prelude.show info.startingGlobalPosition
+      ++ ", entityNameFilter = "
+      ++ Prelude.show info.entityNameFilter
+      ++ ", callback = <function>, onRemove = <task>}"
 
 
 type Subscriptions =
@@ -68,7 +84,7 @@ new = do
 addGlobalSubscription :: SubscriptionCallback -> SubscriptionStore -> Task Error SubscriptionId
 addGlobalSubscription callback store = do
   subId <- Uuid.generate |> Task.map (\result -> result |> toText |> SubscriptionId)
-  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = Nothing, entityNameFilter = Nothing}
+  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = Nothing, entityNameFilter = Nothing, onRemove = Task.yield unit}
   store.globalSubscriptions
     |> ConcurrentVar.modify (Map.set subId subscriptionInfo)
   Task.yield subId
@@ -78,7 +94,7 @@ addGlobalSubscriptionFromPosition ::
   Maybe StreamPosition -> SubscriptionCallback -> SubscriptionStore -> Task Error SubscriptionId
 addGlobalSubscriptionFromPosition startingPosition callback store = do
   subId <- Uuid.generate |> Task.map (\result -> result |> toText |> SubscriptionId)
-  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = startingPosition, entityNameFilter = Nothing}
+  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = startingPosition, entityNameFilter = Nothing, onRemove = Task.yield unit}
   store.globalSubscriptions
     |> ConcurrentVar.modify (Map.set subId subscriptionInfo)
   Task.yield subId
@@ -88,7 +104,7 @@ addStreamSubscription ::
   EntityName -> StreamId -> SubscriptionCallback -> SubscriptionStore -> Task Error SubscriptionId
 addStreamSubscription entityName streamId callback store = do
   subId <- Uuid.generate |> Task.map (toText .> SubscriptionId)
-  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = Nothing, entityNameFilter = Just entityName}
+  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = Nothing, entityNameFilter = Just entityName, onRemove = Task.yield unit}
   store.streamSubscriptions |> ConcurrentVar.modify \subscriptionsMap -> do
     let currentSubscriptions = subscriptionsMap |> Map.getOrElse streamId Map.empty
     subscriptionsMap |> Map.set streamId (currentSubscriptions |> Map.set subId subscriptionInfo)
@@ -104,7 +120,30 @@ addStreamSubscriptionFromPosition ::
   Task Error SubscriptionId
 addStreamSubscriptionFromPosition entityName streamId startingPosition callback store = do
   subId <- Uuid.generate |> Task.map (toText .> SubscriptionId)
-  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = startingPosition, entityNameFilter = Just entityName}
+  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = startingPosition, entityNameFilter = Just entityName, onRemove = Task.yield unit}
+  store.streamSubscriptions |> ConcurrentVar.modify \subscriptionsMap -> do
+    let currentSubscriptions = subscriptionsMap |> Map.getOrElse streamId Map.empty
+    subscriptionsMap |> Map.set streamId (currentSubscriptions |> Map.set subId subscriptionInfo)
+  Task.yield subId
+
+
+addStreamSubscriptionWithCleanup ::
+  EntityName ->
+  StreamId ->
+  Maybe StreamPosition ->
+  Task Text Unit ->
+  SubscriptionCallback ->
+  SubscriptionStore ->
+  Task Error SubscriptionId
+addStreamSubscriptionWithCleanup entityName streamId startingPosition onRemove callback store = do
+  subId <- Uuid.generate |> Task.map (toText .> SubscriptionId)
+  let subscriptionInfo =
+        SubscriptionInfo
+          { callback,
+            startingGlobalPosition = startingPosition,
+            entityNameFilter = Just entityName,
+            onRemove
+          }
   store.streamSubscriptions |> ConcurrentVar.modify \subscriptionsMap -> do
     let currentSubscriptions = subscriptionsMap |> Map.getOrElse streamId Map.empty
     subscriptionsMap |> Map.set streamId (currentSubscriptions |> Map.set subId subscriptionInfo)
@@ -115,7 +154,7 @@ addEntitySubscription ::
   EntityName -> SubscriptionCallback -> SubscriptionStore -> Task Error SubscriptionId
 addEntitySubscription entityName callback store = do
   subId <- Uuid.generate |> Task.map (toText .> SubscriptionId)
-  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = Nothing, entityNameFilter = Just entityName}
+  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = Nothing, entityNameFilter = Just entityName, onRemove = Task.yield unit}
   store.entitySubscriptions |> ConcurrentVar.modify \subscriptionsMap -> do
     let currentSubscriptions = subscriptionsMap |> Map.getOrElse entityName Map.empty
     subscriptionsMap |> Map.set entityName (currentSubscriptions |> Map.set subId subscriptionInfo)
@@ -130,7 +169,7 @@ addEntitySubscriptionFromPosition ::
   Task Error SubscriptionId
 addEntitySubscriptionFromPosition entityName startingPosition callback store = do
   subId <- Uuid.generate |> Task.map (toText .> SubscriptionId)
-  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = startingPosition, entityNameFilter = Just entityName}
+  let subscriptionInfo = SubscriptionInfo {callback, startingGlobalPosition = startingPosition, entityNameFilter = Just entityName, onRemove = Task.yield unit}
   store.entitySubscriptions |> ConcurrentVar.modify \subscriptionsMap -> do
     let currentSubscriptions = subscriptionsMap |> Map.getOrElse entityName Map.empty
     subscriptionsMap |> Map.set entityName (currentSubscriptions |> Map.set subId subscriptionInfo)
@@ -209,8 +248,39 @@ dispatch streamId message store = do
   allCallbacks |> AsyncTask.runAllIgnoringErrors
 
 
+-- | Find a subscription's 'onRemove' cleanup action across the global, stream,
+-- and entity maps. Returns 'Task.yield unit' when the id is unknown, so removing
+-- an already-removed or never-registered id is a no-op rather than an error.
+findOnRemove :: SubscriptionId -> SubscriptionStore -> Task Error (Task Text Unit)
+findOnRemove subId store = do
+  globalSubs <- store.globalSubscriptions |> ConcurrentVar.peek
+  streamSubsMap <- store.streamSubscriptions |> ConcurrentVar.peek
+  entitySubsMap <- store.entitySubscriptions |> ConcurrentVar.peek
+  -- Search the global map, then every stream's map, then every entity's map for
+  -- the id. SubscriptionIds are unique, so at most one map holds it.
+  let lookupIn subs acc =
+        case acc of
+          Just info -> Just info
+          Nothing -> subs |> Map.get subId
+  let fromStream = streamSubsMap |> Map.values |> Array.reduce lookupIn Nothing
+  let fromEntity = entitySubsMap |> Map.values |> Array.reduce lookupIn Nothing
+  let found =
+        case globalSubs |> Map.get subId of
+          Just info -> Just info
+          Nothing -> case fromStream of
+            Just info -> Just info
+            Nothing -> fromEntity
+  case found of
+    Just info -> Task.yield info.onRemove
+    Nothing -> Task.yield (Task.yield unit)
+
+
 removeSubscription :: SubscriptionId -> SubscriptionStore -> Task Error Unit
 removeSubscription subId store = do
+  -- Read the subscription's cleanup BEFORE deleting, so the cleanup is taken
+  -- (not left in place) and a double-remove cannot run it twice.
+  cleanup <- store |> findOnRemove subId
+
   -- Remove from global subscriptions
   store.globalSubscriptions
     |> ConcurrentVar.modify (Map.remove subId)
@@ -225,4 +295,11 @@ removeSubscription subId store = do
     subscriptionsMap
       |> Map.mapValues (\entitySubs -> entitySubs |> Map.remove subId)
 
-  Task.yield ()
+  -- Run the cleanup best-effort: a failed release is logged and swallowed so
+  -- unsubscribe stays total (ADR-0063 §2, design goal 4).
+  cleanup
+    |> Task.recover \err -> do
+      Log.warn [fmt|Subscription #{toText subId} cleanup failed: #{err}|]
+        |> Task.ignoreError
+      Task.yield unit
+    |> Task.mapError (\_ -> OtherError)

--- a/core/service/Service/EventStore/Postgres/SubscriptionStore.hs
+++ b/core/service/Service/EventStore/Postgres/SubscriptionStore.hs
@@ -22,11 +22,11 @@ import Core
 import Json qualified
 import Log qualified
 import Map qualified
-import Prelude qualified
 import Service.Event (EntityName, Event (..), StreamPosition)
 import Service.Event.EventMetadata (EventMetadata (..))
 import Service.EventStore.Core (SubscriptionId (..))
 import Task qualified
+import Text qualified
 import Uuid qualified
 
 
@@ -51,15 +51,24 @@ data SubscriptionInfo = SubscriptionInfo
   }
 
 
--- Hand-written Show: the callback and onRemove are Task/closure fields with no
--- Show instance, so they are elided. (ADR-0063 §1.)
+-- Hand-written Show: 'callback' is a bare function ('SubscriptionCallback' is a
+-- type synonym for @Event Json.Value -> Task Text Unit@), which has no sensible
+-- 'Show' instance, so full @deriving Show@ is not possible. The function field is
+-- rendered as a @<function>@ placeholder; 'onRemove' is a 'Task', shown via its
+-- placeholder 'Show' instance. (ADR-0063 §1.)
 instance Show SubscriptionInfo where
-  show info =
-    "SubscriptionInfo {startingGlobalPosition = "
-      ++ Prelude.show info.startingGlobalPosition
-      ++ ", entityNameFilter = "
-      ++ Prelude.show info.entityNameFilter
-      ++ ", callback = <function>, onRemove = <task>}"
+  show info = renderSubscriptionInfo info |> Text.toLinkedList
+
+
+-- | Render a 'SubscriptionInfo' as 'Text'. The record-dot field accesses live
+-- here (outside the 'fmt' interpolation) because 'OverloadedRecordDot' is not in
+-- scope inside the quasi-quoter's @#{}@ expressions.
+renderSubscriptionInfo :: SubscriptionInfo -> Text
+renderSubscriptionInfo info = do
+  let startingGlobalPosition = toText info.startingGlobalPosition
+  let entityNameFilter = toText info.entityNameFilter
+  let onRemove = toText info.onRemove
+  [fmt|SubscriptionInfo {startingGlobalPosition = #{startingGlobalPosition}, entityNameFilter = #{entityNameFilter}, callback = <function>, onRemove = #{onRemove}}|]
 
 
 type Subscriptions =

--- a/core/test/Service/EventStore/Postgres/SubscriptionStoreSpec.hs
+++ b/core/test/Service/EventStore/Postgres/SubscriptionStoreSpec.hs
@@ -12,6 +12,7 @@ import Service.Event.EventMetadata qualified as EventMetadata
 import Service.Event.StreamId qualified as StreamId
 import Service.EventStore.Postgres.SubscriptionStore (Error (..), SubscriptionStore (..))
 import Service.EventStore.Postgres.SubscriptionStore qualified as SubscriptionStore
+import Service.EventStore.Core (SubscriptionId (..))
 import Task qualified
 import Test
 import Test.Service.EventStore.Core (CartEvent (..))
@@ -348,6 +349,229 @@ spec = do
             -- Dispatch completed successfully within timeout
             count <- ConcurrentVar.get executionCount
             count |> shouldBe 5
+
+
+    describe "addStreamSubscriptionWithCleanup (ADR-0063)" do
+      it "registers a stream subscription that is dispatched to like any other stream sub" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+
+        executionCount <- ConcurrentVar.containing (0 :: Int)
+        let callback _msg = do
+              executionCount |> ConcurrentVar.modify (\n -> n + 1)
+              Task.yield unit
+        let noopCleanup = Task.yield unit
+
+        store
+          |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing noopCleanup callback
+          |> discard
+          |> Task.mapError toText
+
+        subscriptions <- store |> SubscriptionStore.getStreamSubscriptions streamId |> Task.mapError toText
+        subscriptions |> Map.length |> shouldBe 1
+
+        event <- createTestEvent |> Task.mapError toText
+        store |> SubscriptionStore.dispatch streamId event |> Task.mapError toText
+        count <- ConcurrentVar.get executionCount
+        count |> shouldBe 1
+
+      it "stores the supplied onRemove so it runs on removeSubscription" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+
+        cleanupRuns <- ConcurrentVar.containing (0 :: Int)
+        let callback _msg = Task.yield unit
+        let cleanup = do
+              cleanupRuns |> ConcurrentVar.modify (\n -> n + 1)
+              Task.yield unit
+
+        subId <-
+          store
+            |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing cleanup callback
+            |> Task.mapError toText
+
+        store |> SubscriptionStore.removeSubscription subId |> Task.mapError toText
+
+        runs <- ConcurrentVar.get cleanupRuns
+        runs |> shouldBe 1
+
+      it "does not run onRemove at registration time" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+
+        cleanupRuns <- ConcurrentVar.containing (0 :: Int)
+        let callback _msg = Task.yield unit
+        let cleanup = do
+              cleanupRuns |> ConcurrentVar.modify (\n -> n + 1)
+              Task.yield unit
+
+        store
+          |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing cleanup callback
+          |> discard
+          |> Task.mapError toText
+
+        runs <- ConcurrentVar.get cleanupRuns
+        runs |> shouldBe 0
+
+      it "keeps subscriptions for different streams separate" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId1 <- StreamId.new
+        streamId2 <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+        let callback _msg = Task.yield unit
+        let noopCleanup = Task.yield unit
+
+        store |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId1 Nothing noopCleanup callback |> discard |> Task.mapError toText
+        store |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId1 Nothing noopCleanup callback |> discard |> Task.mapError toText
+        store |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId2 Nothing noopCleanup callback |> discard |> Task.mapError toText
+
+        subs1 <- store |> SubscriptionStore.getStreamSubscriptions streamId1 |> Task.mapError toText
+        subs2 <- store |> SubscriptionStore.getStreamSubscriptions streamId2 |> Task.mapError toText
+        subs1 |> Map.length |> shouldBe 2
+        subs2 |> Map.length |> shouldBe 1
+
+    describe "removeSubscription cleanup (ADR-0063)" do
+      it "runs the stored onRemove exactly once on remove" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+
+        cleanupRuns <- ConcurrentVar.containing (0 :: Int)
+        let callback _msg = Task.yield unit
+        let cleanup = do
+              cleanupRuns |> ConcurrentVar.modify (\n -> n + 1)
+              Task.yield unit
+
+        subId <-
+          store
+            |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing cleanup callback
+            |> Task.mapError toText
+        store |> SubscriptionStore.removeSubscription subId |> Task.mapError toText
+
+        runs <- ConcurrentVar.get cleanupRuns
+        runs |> shouldBe 1
+        subscriptions <- store |> SubscriptionStore.getStreamSubscriptions streamId |> Task.mapError toText
+        subscriptions |> Map.length |> shouldBe 0
+
+      it "stays total when onRemove throws (unsubscribe never fails)" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+
+        let callback _msg = Task.yield unit
+        let failingCleanup = Task.throw "release failed on purpose"
+
+        subId <-
+          store
+            |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing failingCleanup callback
+            |> Task.mapError toText
+
+        result <- store |> SubscriptionStore.removeSubscription subId |> Task.asResult
+        case result of
+          Err err -> Test.fail [fmt|removeSubscription must stay total, but failed: #{toText err}|]
+          Ok _ -> Task.yield unit
+
+        subscriptions <- store |> SubscriptionStore.getStreamSubscriptions streamId |> Task.mapError toText
+        subscriptions |> Map.length |> shouldBe 0
+
+      it "is a no-op for a never-registered id (runs no cleanup)" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+        let unknownId = SubscriptionId "never-registered-id"
+
+        -- Register a real cleanup-bearing subscription, then remove a DIFFERENT
+        -- (unknown) id: the unknown remove must be a no-op AND must not fire the
+        -- registered subscription's cleanup.
+        cleanupRuns <- ConcurrentVar.containing (0 :: Int)
+        let callback _msg = Task.yield unit
+        let cleanup = do
+              cleanupRuns |> ConcurrentVar.modify (\n -> n + 1)
+              Task.yield unit
+        store
+          |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing cleanup callback
+          |> discard
+          |> Task.mapError toText
+
+        result <- store |> SubscriptionStore.removeSubscription unknownId |> Task.asResult
+        case result of
+          Err err -> Test.fail [fmt|removing an unknown id must be a no-op, but failed: #{toText err}|]
+          Ok _ -> Task.yield unit
+
+        runs <- ConcurrentVar.get cleanupRuns
+        runs |> shouldBe 0
+        -- The real subscription is still registered (unknown remove touched nothing).
+        subscriptions <- store |> SubscriptionStore.getStreamSubscriptions streamId |> Task.mapError toText
+        subscriptions |> Map.length |> shouldBe 1
+
+      it "is a no-op (and does not re-run cleanup) on a double remove" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+
+        cleanupRuns <- ConcurrentVar.containing (0 :: Int)
+        let callback _msg = Task.yield unit
+        let cleanup = do
+              cleanupRuns |> ConcurrentVar.modify (\n -> n + 1)
+              Task.yield unit
+
+        subId <-
+          store
+            |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing cleanup callback
+            |> Task.mapError toText
+
+        store |> SubscriptionStore.removeSubscription subId |> Task.mapError toText
+        result <- store |> SubscriptionStore.removeSubscription subId |> Task.asResult
+        case result of
+          Err err -> Test.fail [fmt|second removeSubscription must be a no-op, but failed: #{toText err}|]
+          Ok _ -> Task.yield unit
+
+        runs <- ConcurrentVar.get cleanupRuns
+        runs |> shouldBe 1
+
+      it "leaves global and entity subscriptions no-op cleanup unaffected" \_ -> do
+        store <- SubscriptionStore.new |> Task.mapError toText
+        streamId <- StreamId.new
+        let entityName = Event.EntityName "TestEntity"
+        let callback _msg = Task.yield unit
+
+        -- A stream subscription with a real cleanup coexists with global/entity
+        -- subscriptions; removing the global and entity subs must run NO cleanup
+        -- (their onRemove is a no-op) and must not touch the stream cleanup.
+        cleanupRuns <- ConcurrentVar.containing (0 :: Int)
+        let cleanup = do
+              cleanupRuns |> ConcurrentVar.modify (\n -> n + 1)
+              Task.yield unit
+        store
+          |> SubscriptionStore.addStreamSubscriptionWithCleanup entityName streamId Nothing cleanup callback
+          |> discard
+          |> Task.mapError toText
+
+        globalId <- store |> SubscriptionStore.addGlobalSubscription callback |> Task.mapError toText
+        entityId <- store |> SubscriptionStore.addEntitySubscription entityName callback |> Task.mapError toText
+
+        globalResult <- store |> SubscriptionStore.removeSubscription globalId |> Task.asResult
+        case globalResult of
+          Err err -> Test.fail [fmt|removing a global subscription must be total: #{toText err}|]
+          Ok _ -> Task.yield unit
+
+        entityResult <- store |> SubscriptionStore.removeSubscription entityId |> Task.asResult
+        case entityResult of
+          Err err -> Test.fail [fmt|removing an entity subscription must be total: #{toText err}|]
+          Ok _ -> Task.yield unit
+
+        globalSubs <- store.globalSubscriptions |> ConcurrentVar.peek
+        entitySubs <- store.entitySubscriptions |> ConcurrentVar.peek
+        globalSubs |> Map.length |> shouldBe 0
+        entitySubs |> Map.getOrElse entityName Map.empty |> Map.length |> shouldBe 0
+        -- The stream subscription and its cleanup are untouched by the removals.
+        runs <- ConcurrentVar.get cleanupRuns
+        runs |> shouldBe 0
+        streamSubs <- store |> SubscriptionStore.getStreamSubscriptions streamId |> Task.mapError toText
+        streamSubs |> Map.length |> shouldBe 1
 
 
 -- Helper function to create a test event

--- a/core/test/Service/EventStore/PostgresSpec.hs
+++ b/core/test/Service/EventStore/PostgresSpec.hs
@@ -103,8 +103,15 @@ spec = do
               |> Task.map (EventStore.castEventStore @CartEvent)
               |> Task.mapError toText
 
+          -- WI-2 made 'toConnectionSettings' return a 'Result' (port validation).
+          -- Surface any settings error into this spec's Text error channel before
+          -- acquiring the admin connection.
+          adminSettings <-
+            case toConnectionSettings config of
+              Ok settings -> Task.yield settings
+              Err err -> Task.throw err
           adminConn <-
-            Hasql.acquire (toConnectionSettings config)
+            Hasql.acquire adminSettings
               |> Task.fromIOEither
               |> Task.mapError toText
 

--- a/core/test/Service/EventStore/PostgresSpec.hs
+++ b/core/test/Service/EventStore/PostgresSpec.hs
@@ -108,35 +108,42 @@ spec = do
               |> Task.fromIOEither
               |> Task.mapError toText
 
-          let entityName = EntityName "ConnReleaseRegressionEntity"
-          let callback _event = Task.yield unit
+          -- Guaranteed teardown: release the admin connection and close the store
+          -- whether the body succeeds, throws, or the final assertion fails.
+          -- Otherwise a failure here leaks connections into later Postgres-gated
+          -- specs and contaminates them.
+          let cleanup = do
+                Hasql.release adminConn |> Task.fromIO
+                store.close |> Task.mapError toText |> Task.ignoreError
 
-          -- Warm-up: one subscribe/unsubscribe cycle forces the Hasql pool and
-          -- the store's listener connections to fully establish, so the baseline
-          -- reflects steady state rather than a lazily-growing pool. (The pooled
-          -- connection borrowed by withConnectionAndError is what would otherwise
-          -- inflate the post-loop count and mask the per-stream release.)
-          subscribeUnsubscribeCycles store entityName callback 1
-          AsyncTask.sleep 500 |> Task.mapError (\_ -> "warm-up settle sleep failed")
-          baseline <- countUserBackends adminConn
+          Task.finally cleanup do
+            let entityName = EntityName "ConnReleaseRegressionEntity"
+            let callback _event = Task.yield unit
 
-          -- Now run N more cycles. Each opens ONE dedicated per-stream connection
-          -- that unsubscribe must release; with the leak the count would climb by
-          -- N. With the fix the dedicated connection is gone each cycle, so the
-          -- steady-state count does not grow.
-          let cycleN = 5 :: Int
-          subscribeUnsubscribeCycles store entityName callback cycleN
+            -- Warm-up: one subscribe/unsubscribe cycle forces the Hasql pool and
+            -- the store's listener connections to fully establish, so the baseline
+            -- reflects steady state rather than a lazily-growing pool. (The pooled
+            -- connection borrowed by withConnectionAndError is what would otherwise
+            -- inflate the post-loop count and mask the per-stream release.)
+            subscribeUnsubscribeCycles store entityName callback 1
+            -- Poll until the backend count settles instead of a fixed sleep, so
+            -- the baseline reflects steady state regardless of teardown timing.
+            baseline <- pollSettledBackends adminConn Nothing
 
-          -- Allow libpq teardown to settle so pg_stat_activity reflects the release.
-          AsyncTask.sleep 500 |> Task.mapError (\_ -> "settle sleep failed")
-          afterCycles <- countUserBackends adminConn
+            -- Now run N more cycles. Each opens ONE dedicated per-stream connection
+            -- that unsubscribe must release; with the leak the count would climb by
+            -- N. With the fix the dedicated connection is gone each cycle, so the
+            -- steady-state count does not grow.
+            let cycleN = 5 :: Int
+            subscribeUnsubscribeCycles store entityName callback cycleN
 
-          Hasql.release adminConn |> Task.fromIO
-          store.close |> discard
+            -- Poll until the count settles to at-or-below the baseline (or a bounded
+            -- timeout expires), so pg_stat_activity reflects the per-stream releases.
+            afterCycles <- pollSettledBackends adminConn (Just baseline)
 
-          -- No net growth across the N measured cycles: a leak would leave
-          -- baseline + cycleN dedicated connections; the fix keeps it at baseline.
-          (afterCycles <= baseline) |> shouldBe True
+            -- No net growth across the N measured cycles: a leak would leave
+            -- baseline + cycleN dedicated connections; the fix keeps it at baseline.
+            (afterCycles <= baseline) |> shouldBe True
 
 
 
@@ -213,12 +220,14 @@ subscribeUnsubscribeCycles store entityName callback n =
       subscribeUnsubscribeCycles store entityName callback (n - 1)
 
 
--- | Count the backends currently open for the test database user via
--- pg_stat_activity. The dedicated per-stream connections are opened by the same
--- user, so a leak shows up as a higher count.
+-- | Count the backends currently open for the test database user, scoped to the
+-- current database. The dedicated per-stream connections are opened by the same
+-- user against the same database, so a leak shows up as a higher count. Scoping
+-- to @current_database()@ keeps unrelated sessions for the same user on other
+-- databases from inflating the count.
 countUserBackends :: Hasql.Connection -> Task Text Int64
 countUserBackends conn = do
-  let query :: Text = "SELECT count(*) :: int8 FROM pg_stat_activity WHERE usename = current_user"
+  let query :: Text = "SELECT count(*) :: int8 FROM pg_stat_activity WHERE usename = current_user AND datname = current_database()"
   let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
   let statement :: Statement Unit Int64 =
         HasqlStatement.Statement (query |> Text.toBytes |> Bytes.unwrap) Encoders.noParams decoder True
@@ -226,3 +235,31 @@ countUserBackends conn = do
   case result of
     Err err -> Task.throw [fmt|pg_stat_activity count failed: #{err}|]
     Ok count -> Task.yield count
+
+
+-- | Poll 'countUserBackends' until it settles, replacing a fixed sleep so the
+-- test is deterministic regardless of how long libpq teardown takes.
+--
+-- "Settled" means two consecutive samples (50 ms apart) are equal AND, when a
+-- @target@ baseline is supplied, the count is at or below it. Polling stops as
+-- soon as it settles, or after a bounded number of attempts (≈5 s), returning
+-- the last sample either way so the caller's assertion still runs.
+pollSettledBackends :: Hasql.Connection -> Maybe Int64 -> Task Text Int64
+pollSettledBackends conn target = do
+  let maxAttempts = 100 :: Int
+  let stepMs = 50
+  let atOrBelowTarget count =
+        case target of
+          Nothing -> True
+          Just baseline -> count <= baseline
+  let loop attempts previous = do
+        current <- countUserBackends conn
+        let settled = case previous of
+              Just prev -> current == prev && atOrBelowTarget current
+              Nothing -> False
+        case settled || attempts >= maxAttempts of
+          True -> Task.yield current
+          False -> do
+            AsyncTask.sleep stepMs |> Task.mapError (\_ -> "poll settle sleep failed")
+            loop (attempts + 1) (Just current)
+  loop 0 Nothing

--- a/core/test/Service/EventStore/PostgresSpec.hs
+++ b/core/test/Service/EventStore/PostgresSpec.hs
@@ -2,6 +2,7 @@ module Service.EventStore.PostgresSpec where
 
 import Core
 import Service.EventStore.Core qualified as EventStore
+import AsyncTask qualified
 import Service.EventStore.Postgres qualified as Postgres
 import Service.EventStore.Postgres.Internal qualified as Internal
 import Service.EventStore.Postgres.Core qualified as PostgresCore
@@ -14,6 +15,18 @@ import Test.Service.EntityFetcher.Core qualified as EntityFetcherCore
 import Test.Service.EventStore qualified as EventStoreSpec
 import Test.Service.EventStore.Core (CartEvent)
 import Var qualified
+import Service.Event (EntityName (..), Event)
+import Service.Event.StreamId qualified as StreamId
+import Service.EventStore.Postgres.Internal (toConnectionSettings)
+import Result qualified
+import Text qualified
+import Bytes qualified
+import Hasql.Connection qualified as Hasql
+import Hasql.Session qualified as Session
+import Hasql.Decoders qualified as Decoders
+import Hasql.Encoders qualified as Encoders
+import Hasql.Statement (Statement)
+import Hasql.Statement qualified as HasqlStatement
 
 
 spec :: Spec Unit
@@ -79,6 +92,53 @@ spec = do
             |> Task.mapError toText
     CommandHandler.spec newCartStore
 
+    describe "per-stream connection release (ADR-0063)" do
+      whenEnvVar "POSTGRES_AVAILABLE" do
+        it "releases the dedicated connection across N stream subscribe/unsubscribe cycles (no leak)" \_ -> do
+          -- Regression for issue #683: each subscribeToStreamEvents opens a
+          -- dedicated unpooled connection; unsubscribe must release it. With the
+          -- leak, the backend connection count climbs by N across N cycles.
+          store <-
+            Postgres.new config
+              |> Task.map (EventStore.castEventStore @CartEvent)
+              |> Task.mapError toText
+
+          adminConn <-
+            Hasql.acquire (toConnectionSettings config)
+              |> Task.fromIOEither
+              |> Task.mapError toText
+
+          let entityName = EntityName "ConnReleaseRegressionEntity"
+          let callback _event = Task.yield unit
+
+          -- Warm-up: one subscribe/unsubscribe cycle forces the Hasql pool and
+          -- the store's listener connections to fully establish, so the baseline
+          -- reflects steady state rather than a lazily-growing pool. (The pooled
+          -- connection borrowed by withConnectionAndError is what would otherwise
+          -- inflate the post-loop count and mask the per-stream release.)
+          subscribeUnsubscribeCycles store entityName callback 1
+          AsyncTask.sleep 500 |> Task.mapError (\_ -> "warm-up settle sleep failed")
+          baseline <- countUserBackends adminConn
+
+          -- Now run N more cycles. Each opens ONE dedicated per-stream connection
+          -- that unsubscribe must release; with the leak the count would climb by
+          -- N. With the fix the dedicated connection is gone each cycle, so the
+          -- steady-state count does not grow.
+          let cycleN = 5 :: Int
+          subscribeUnsubscribeCycles store entityName callback cycleN
+
+          -- Allow libpq teardown to settle so pg_stat_activity reflects the release.
+          AsyncTask.sleep 500 |> Task.mapError (\_ -> "settle sleep failed")
+          afterCycles <- countUserBackends adminConn
+
+          Hasql.release adminConn |> Task.fromIO
+          store.close |> discard
+
+          -- No net growth across the N measured cycles: a leak would leave
+          -- baseline + cycleN dedicated connections; the fix keeps it at baseline.
+          (afterCycles <= baseline) |> shouldBe True
+
+
 
 data NewObserve = NewObserve
   { acquireCalls :: Var Int,
@@ -136,3 +196,33 @@ mockNewOps = do
 
   let ops = Internal.Ops {acquire, initializeTable, initializeSubscriptions, release}
   Task.yield (ops, newObserver)
+
+
+-- | Run one subscribe/unsubscribe cycle @n@ times against the same stream id.
+-- Each subscribe opens a dedicated per-stream connection that unsubscribe must
+-- release; after @n@ cycles no dedicated connection should survive.
+subscribeUnsubscribeCycles ::
+  EventStore.EventStore CartEvent -> EntityName -> (Event CartEvent -> Task Text Unit) -> Int -> Task Text Unit
+subscribeUnsubscribeCycles store entityName callback n =
+  case n <= 0 of
+    True -> Task.yield unit
+    False -> do
+      streamId <- StreamId.new
+      subId <- store.subscribeToStreamEvents entityName streamId callback |> Task.mapError toText
+      store.unsubscribe subId |> Task.mapError toText
+      subscribeUnsubscribeCycles store entityName callback (n - 1)
+
+
+-- | Count the backends currently open for the test database user via
+-- pg_stat_activity. The dedicated per-stream connections are opened by the same
+-- user, so a leak shows up as a higher count.
+countUserBackends :: Hasql.Connection -> Task Text Int64
+countUserBackends conn = do
+  let query :: Text = "SELECT count(*) :: int8 FROM pg_stat_activity WHERE usename = current_user"
+  let decoder = Decoders.singleRow (Decoders.column (Decoders.nonNullable Decoders.int8))
+  let statement :: Statement Unit Int64 =
+        HasqlStatement.Statement (query |> Text.toBytes |> Bytes.unwrap) Encoders.noParams decoder True
+  result <- Session.run (Session.statement unit statement) conn |> Task.fromIO |> Task.map Result.fromEither
+  case result of
+    Err err -> Task.throw [fmt|pg_stat_activity count failed: #{err}|]
+    Ok count -> Task.yield count

--- a/docs/decisions/0063-per-stream-subscription-connection-release.md
+++ b/docs/decisions/0063-per-stream-subscription-connection-release.md
@@ -1,0 +1,490 @@
+# ADR-0063: Release Per-Stream Subscription Connections on Unsubscribe
+
+> Issue: [#683 — WI-4: Release per-stream subscription connections on unsubscribe](https://github.com/neohaskell/NeoHaskell/issues/683)
+
+## Status
+
+Proposed
+
+## Context
+
+### Current State
+
+`subscribeToStreamEvents` is the only EventStore subscription that opens
+a **dedicated, unpooled** Postgres connection. Unlike the global and
+entity subscriptions — which dispatch off the shared listener pair —
+each stream subscription issues its own `LISTEN <stream>` on a private
+connection so that stream-scoped `NOTIFY` events reach exactly the
+subscribers for that stream.
+
+`subscribeToStreamEventsImpl`
+(`core/service/Service/EventStore/Postgres/Internal.hs`) acquires that
+connection and never hands ownership of it to anything that can release
+it:
+
+```haskell
+subscribeToStreamEventsImpl ops cfg store entityName streamId callback =
+  ops |> withConnectionAndError cfg \conn -> do
+    -- A dedicated, unpooled connection is acquired here…
+    connection <-
+      Hasql.acquire (toConnectionSettings cfg)
+        |> Task.fromIOEither
+        |> Task.mapError (\err -> SubscriptionError (SubscriptionId "stream") (err |> toText))
+    Notifications.subscribeToStream connection streamId
+      |> Task.mapError StorageFailure
+    -- … then the SubscriptionId is returned, but nothing remembers `connection`.
+    currentMaxPosition <- ...
+    subscriptionId <-
+      store
+        |> SubscriptionStore.addStreamSubscriptionFromPosition entityName streamId currentMaxPosition callback
+        |> Task.mapError (\err -> SubscriptionError (SubscriptionId "stream") (err |> toText))
+    Task.yield subscriptionId
+```
+
+`unsubscribeImpl` only removes the in-memory subscription entry — it has
+no reference to the connection, so the connection is **leaked**:
+
+```haskell
+unsubscribeImpl store id =
+  store
+    |> SubscriptionStore.removeSubscription id
+    |> Task.mapError (\err -> SubscriptionError id (err |> toText))
+```
+
+The `connection` value goes out of scope the moment
+`subscribeToStreamEventsImpl` returns. It is never stored, never paired
+with its `SubscriptionId`, and `removeSubscription` only deletes the
+`SubscriptionInfo` from the `streamSubscriptions` map. The underlying
+libpq connection stays open against Postgres until the whole process
+exits.
+
+### The gap
+
+Under stream-subscription **churn** — clients that subscribe to a
+short-lived stream, consume it, and unsubscribe — every cycle leaks one
+connection. The deploy target for the per-client baseline (epic #679)
+is **Azure Database for PostgreSQL — Flexible Server, Burstable
+`B1ms`**, which allows **50 `max_connections`, ≈35 usable**. ADR-0060
+established the steady-state pooled+fixed budget as **`19 + N`**, where
+`N` is the number of active stream subscriptions; that arithmetic only
+holds if `N` is bounded by *active* subscriptions. A leak makes `N`
+grow monotonically with *cumulative* subscribe calls, so a deployment
+that opens and closes a few dozen stream subscriptions exhausts the
+ceiling and surfaces `FATAL: remaining connection slots are reserved` —
+a production outage, not a degraded mode.
+
+This is the same class of defect ADR-0039 (#439) fixed for the listener
+and init-listen connections: a raw connection acquired without a release
+path. ADR-0039 gave the `EventStore` an explicit `close` lifecycle and
+wired cleanup through every layer that acquires a connection. The
+per-stream subscription connection was not covered by that work because
+it is acquired lazily, per subscribe call, after the store is already
+running — its natural release point is **unsubscribe**, not store
+`close`.
+
+### Use Cases
+
+- **Stream-subscription churn on `B1ms`** — a client subscribes to a
+  per-order or per-session stream, drains it, and unsubscribes. Over a
+  day this is thousands of subscribe/unsubscribe cycles. The connection
+  budget must return to baseline after each cycle, not climb.
+- **Bounded concurrent subscriptions** — an operator needs to know,
+  from the documentation, how many stream subscriptions can be active
+  at once on a given tier before the per-stream connections crowd out
+  the pools and admin headroom from ADR-0060's budget.
+- **Test confidence** — a regression test must be able to assert that
+  N subscribe/unsubscribe cycles leave zero residual per-stream
+  connections, so the leak cannot silently return.
+
+### Design Goals
+
+1. **Release on unsubscribe** — the dedicated connection a stream
+   subscription opens is released exactly when that subscription is
+   removed, with no leak across subscribe/unsubscribe cycles.
+2. **One owner, keyed by `SubscriptionId`** — the connection's lifetime
+   is tied to the same `SubscriptionId` the caller already holds, so
+   there is no second handle for the caller to track and no way to
+   release the wrong connection.
+3. **Mirror the ADR-0039 lifecycle** — reuse the established
+   "acquire returns a cleanup `Task`, run it via `Task.finally`"
+   pattern rather than inventing a new ownership mechanism, so the
+   per-stream path looks like the listener path it sits next to.
+4. **Release is best-effort and never blocks unsubscribe** — a failed
+   connection release (already-dead socket, network drop) must be
+   logged, not thrown back to the caller of `unsubscribe`. Unsubscribe
+   semantics are "this subscription is gone", which must hold even if
+   the connection was already gone.
+5. **Bounded and documented concurrency cap** — the maximum concurrent
+   stream subscriptions per tier is written down against ADR-0060's
+   `19 + N ≤ 35` budget, so `N` is a known, enforced ceiling rather
+   than an accident.
+6. **Invisible to Jess** — no new public surface. Jess calls
+   `subscribeToStreamEvents` and `unsubscribe` exactly as before; the
+   connection lifecycle is internal to the Postgres EventStore.
+
+### GitHub Issue
+
+- [#683: WI-4 — Release per-stream subscription connections on unsubscribe](https://github.com/neohaskell/NeoHaskell/issues/683)
+- Parent epic: [#679 — Deploy-readiness on Azure Database for PostgreSQL Flexible Server](https://github.com/neohaskell/NeoHaskell/issues/679)
+
+## Decision drivers
+
+- **The leak is a hard deploy blocker, not a slow degradation.** On
+  `B1ms` the per-stream connections are the *only* unbounded term in
+  ADR-0060's budget. Left unreleased they are guaranteed to exhaust the
+  35-usable ceiling under any real churn. Fixing the release path is the
+  load-bearing change.
+- **The `SubscriptionId` is already the unit of ownership.** The caller
+  receives a `SubscriptionId` from subscribe and passes it back to
+  `unsubscribe`. Tying the connection's lifetime to that same id means
+  no new handle, no new API, and release-the-right-connection by
+  construction.
+- **ADR-0039 already solved this shape.** The listener and init-listen
+  connections release via a cleanup `Task` run from `Task.finally`. The
+  per-stream connection differs only in *when* it is released
+  (unsubscribe, not store-close). Reusing the pattern keeps the codebase
+  coherent and the reviewer's mental model intact.
+- **Unsubscribe must stay total.** If releasing the connection could
+  throw, an unsubscribe of a subscription whose connection already died
+  would fail — leaving the entry removed but surfacing an error for a
+  no-op cleanup. Release is therefore best-effort + logged.
+- **The cap must be documented, not just possible.** ADR-0060 deferred
+  the per-stream `N` bound to this work item. The budget is only
+  trustworthy if the ceiling on `N` is written into the deploy guidance
+  (WI-6, #685), not left implicit.
+
+## Considered options
+
+### Option 1 — Store a per-subscription cleanup `Task` in the `SubscriptionStore`, run it on remove (chosen)
+
+Extend `SubscriptionInfo` with an `onRemove :: Task Text Unit` cleanup
+action (a no-op for global and entity subscriptions, which open no
+dedicated connection). `subscribeToStreamEventsImpl` builds the cleanup
+that releases its connection and stores it alongside the subscription;
+`removeSubscription` runs the stored cleanup (best-effort, logged) after
+deleting the entry. The connection is owned by the same `SubscriptionId`
+the caller holds.
+
+- The cleanup is colocated with the subscription it belongs to, so the
+  store is the single source of truth for "what does removing this
+  subscription entail".
+- Global/entity subscriptions pass a no-op, so the change is additive
+  and their behaviour is unchanged.
+- Mirrors ADR-0039's `connectTo`-returns-a-cleanup-`Task` pattern
+  exactly, one level down (per subscription instead of per store).
+
+### Option 2 — A separate `ConcurrentVar (Map SubscriptionId Hasql.Connection)` registry in `Internal.hs`
+
+Keep a side table mapping each stream `SubscriptionId` to its raw
+connection; `unsubscribeImpl` looks the id up, releases the connection,
+and deletes the entry.
+
+- Rejected: introduces a *second* structure keyed by `SubscriptionId`
+  that must be kept in lockstep with the `SubscriptionStore`. Any path
+  that removes a subscription without consulting the registry (or vice
+  versa) re-introduces the leak or double-releases. The store already
+  owns subscription lifetime; bolting a parallel map beside it splits
+  the invariant across two modules. Also leaks the `Hasql.Connection`
+  type out of `Notifications`/`Internal` into a new registry type.
+
+### Option 3 — Release-only-at-`EventStore.close` (extend ADR-0039's `close`)
+
+Track all per-stream connections and release them in bulk when the store
+closes, like the listener pair.
+
+- Rejected: does not fix the leak. The whole point of churn is that
+  subscriptions come and go *while the store stays open*. Releasing only
+  at `close` means a long-lived app still accumulates one connection per
+  historical subscribe call until shutdown — exactly the failure #683
+  describes. `close`-time release is necessary as a backstop (Option 1
+  composes with it) but insufficient as the primary mechanism.
+
+### Option 4 — Reuse the shared listener connection instead of a dedicated one
+
+Multiplex stream `LISTEN` channels onto the existing listener pair so no
+per-stream connection is ever opened.
+
+- Rejected: a real architectural change to the notification layer, far
+  beyond a leak fix, and it changes the dispatch semantics ADR-0037 and
+  ADR-0039 established. It also re-opens the `LISTEN`-channel-scaling
+  question (one connection can hold many `LISTEN`s, but channel
+  bookkeeping, reconnect catch-up per channel, and back-pressure become
+  non-trivial). Worth its own ADR if the per-stream model proves too
+  heavy; out of scope for WI-4, whose remit is "release what we acquire".
+
+| Option | Verdict | Reason |
+|--------|---------|--------|
+| 1. Cleanup `Task` in `SubscriptionStore`, run on remove | **Chosen** | Single owner keyed by `SubscriptionId`; additive; mirrors ADR-0039; no new public API. |
+| 2. Side `Map SubscriptionId Connection` registry | Rejected | Splits the lifetime invariant across two structures; easy to desync. |
+| 3. Release only at `close` | Rejected | Does not fix churn; accumulates until shutdown. |
+| 4. Multiplex onto the listener pair | Rejected | Notification-layer redesign; out of scope for a leak fix. |
+
+## Decision outcome
+
+Adopt **Option 1**. The per-stream connection is owned by its
+`SubscriptionId` through a cleanup `Task` carried in the
+`SubscriptionStore`, run best-effort on remove. This mirrors ADR-0039's
+lifecycle one level down: ADR-0039 made *the store* return a cleanup
+`Task` run from `EventStore.close`; WI-4 makes *each stream
+subscription* carry a cleanup `Task` run from `removeSubscription`.
+
+### 1. `SubscriptionInfo` carries an `onRemove` cleanup action
+
+`SubscriptionInfo` (`SubscriptionStore.hs`) gains an `onRemove` field.
+Global, entity, and the existing stream-from-position constructors
+default it to a no-op (`Task.yield unit`); only the dedicated-connection
+stream path supplies a real release action.
+
+```haskell
+data SubscriptionInfo = SubscriptionInfo
+  { callback :: SubscriptionCallback,
+    startingGlobalPosition :: Maybe StreamPosition,
+    entityNameFilter :: Maybe EntityName,
+    -- Run once when this subscription is removed. Releases any dedicated
+    -- resource the subscription owns (the per-stream LISTEN connection).
+    -- No-op for subscriptions that own no dedicated resource.
+    onRemove :: Task Text Unit
+  }
+```
+
+A new constructor lets the stream path register both the subscription
+and its cleanup atomically, so the connection is never tracked without
+its release action:
+
+```haskell
+addStreamSubscriptionWithCleanup ::
+  EntityName ->
+  StreamId ->
+  Maybe StreamPosition ->
+  Task Text Unit ->
+  SubscriptionCallback ->
+  SubscriptionStore ->
+  Task Error SubscriptionId
+```
+
+### 2. `removeSubscription` runs the stored cleanup, best-effort
+
+`removeSubscription` reads the `SubscriptionInfo` (across global, stream,
+and entity maps), deletes the entry, then runs its `onRemove`. A failed
+release is logged and swallowed so unsubscribe stays total:
+
+```haskell
+removeSubscription subId store = do
+  cleanup <- store |> takeOnRemoveFor subId
+  -- delete from global / stream / entity maps (unchanged) …
+  cleanup
+    |> Task.recover \err -> do
+         Log.warn [fmt|Subscription #{toText subId} cleanup failed: #{err}|]
+           |> Task.ignoreError
+         Task.yield unit
+```
+
+`takeOnRemoveFor` finds the subscription's `onRemove` before deletion
+and returns `Task.yield unit` when the id is unknown, so removing an
+already-removed or never-registered id is a no-op rather than an error.
+
+### 3. `subscribeToStreamEventsImpl` registers the connection's release
+
+The stream subscribe path builds the release action for the connection
+it acquired and registers it with the subscription, so the connection
+and its release land in the store together:
+
+```haskell
+subscribeToStreamEventsImpl ops cfg store entityName streamId callback =
+  ops |> withConnectionAndError cfg \conn -> do
+    connection <-
+      Hasql.acquire (toConnectionSettings cfg)
+        |> Task.fromIOEither
+        |> Task.mapError (\err -> SubscriptionError (SubscriptionId "stream") (err |> toText))
+    Notifications.subscribeToStream connection streamId
+      |> Task.mapError StorageFailure
+
+    currentMaxPosition <-
+      Sessions.selectMaxGlobalPosition
+        |> Sessions.run conn
+        |> Task.mapError (toText .> StorageFailure)
+
+    let releaseConnection = Hasql.release connection |> Task.fromIO
+
+    subscriptionId <-
+      store
+        |> SubscriptionStore.addStreamSubscriptionWithCleanup
+             entityName streamId currentMaxPosition releaseConnection callback
+        |> Task.mapError (\err -> SubscriptionError (SubscriptionId "stream") (err |> toText))
+    Log.debug [fmt|Subscription created: #{toText subscriptionId}|] |> Task.ignoreError
+    Task.yield subscriptionId
+```
+
+`unsubscribeImpl` is unchanged — it already routes through
+`SubscriptionStore.removeSubscription`, which now runs the cleanup. The
+release path is therefore a single funnel: every unsubscribe (and every
+`close`-time teardown that removes subscriptions) releases the
+connection through the same code.
+
+### 4. Concurrency cap documented against the ADR-0060 budget
+
+ADR-0060 fixed the steady-state demand at `19 + N` connections of the 35
+usable on `B1ms`, where `N` is the count of **active** stream
+subscriptions. With the leak fixed, `N` is genuinely the active count.
+The recommended ceiling, reserving headroom for an operator `psql`
+session and a maintenance task (ADR-0060's "admin headroom"), is:
+
+```text
+  usable on B1ms              35
+  fixed demand (ADR-0060)   − 19   (16 pooled + 3 unpooled)
+  admin headroom            −  2   (operator psql + maintenance)
+  ---------------------------------
+  max concurrent stream subs  14   (recommended cap for B1ms)
+```
+
+This is **guidance, not a hard runtime limit** — nhcore does not reject
+the 15th stream subscription (that would be a silent feature failure for
+Jess). Instead the cap is documented in the deployment and
+Postgres-event-store guides (WI-6, #685): a `B1ms` deployment should keep
+concurrent stream subscriptions at or below ~14, and a tier upgrade
+raises the budget (ADR-0060's `poolSize` fields plus the larger tier's
+`max_connections`) and therefore the cap. Applications with many
+concurrent streams should prefer entity or global subscriptions (which
+share the listener pair and cost no per-stream connection) where the
+stream-scoped filter is not required.
+
+### 5. Module placement
+
+No new modules. Changes are confined to:
+
+```text
+core/service/Service/EventStore/Postgres/SubscriptionStore.hs  -- onRemove field + addStreamSubscriptionWithCleanup + run cleanup in removeSubscription
+core/service/Service/EventStore/Postgres/Internal.hs           -- register releaseConnection on subscribe
+```
+
+Documentation of the cap lands in WI-6's guide changes (#685), not in
+nhcore source.
+
+### Performance & testing
+
+Tier: `moderate`. There is no new per-event work — `onRemove` is built
+once at subscribe time and run once at unsubscribe time. Dispatch
+(`SubscriptionStore.dispatch`) is unchanged; the new field is not read on
+the hot path. The cleanup is a single `Hasql.release` per unsubscribe,
+which the runtime was already obligated to do (it simply never did).
+
+Verification (`core/test/Service/EventStore/Postgres/SubscriptionStoreSpec.hs`,
+plus a Postgres-gated EventStore spec for the real connection path):
+
+1. **No leak across cycles (regression, primary)** — a Postgres-gated
+   spec subscribes to a stream and unsubscribes N times, asserting the
+   Postgres connection count returns to the pre-subscription baseline
+   (e.g. via `pg_stat_activity`), proving no per-stream connection
+   survives unsubscribe. Self-skips when `POSTGRES_AVAILABLE` is unset.
+2. **Cleanup runs exactly once on remove (unit)** — a pure
+   `SubscriptionStore` spec registers a stream subscription with an
+   `onRemove` that flips a `ConcurrentVar`, calls `removeSubscription`,
+   and asserts the var flipped exactly once.
+3. **Unsubscribe stays total when release fails (boundary)** — register
+   an `onRemove` that throws; assert `removeSubscription` yields `unit`
+   (does not propagate the error) and the entry is gone.
+4. **Removing an unknown id is a no-op (boundary)** — `removeSubscription`
+   on a never-registered or already-removed id yields `unit` and runs no
+   cleanup.
+5. **Global/entity subscriptions are unaffected** — existing
+   `SubscriptionStore` specs continue to pass; their `onRemove` defaults
+   to a no-op and `dispatch` behaviour is unchanged.
+
+## Public API
+
+**None changed.** `subscribeToStreamEvents`, `unsubscribe`, and the
+`EventStore` record are unchanged from the caller's perspective. Jess
+subscribes and unsubscribes exactly as before:
+
+```haskell
+-- Subscribe to a single stream; release happens automatically on unsubscribe.
+subscriptionId <- store.subscribeToStreamEvents entityName streamId handleEvent
+
+-- … later: unsubscribe releases the dedicated connection for us.
+store.unsubscribe subscriptionId
+```
+
+The only new surface is **internal** to the Postgres EventStore:
+`SubscriptionInfo.onRemove` and
+`SubscriptionStore.addStreamSubscriptionWithCleanup`, neither of which is
+re-exported beyond the Postgres backend. The `SubscriptionStore` module
+is an internal implementation detail of the Postgres EventStore, so this
+is not a breaking change for application code.
+
+## Consequences
+
+### Positive
+
+1. **The connection leak is fixed.** Every stream subscribe/unsubscribe
+   cycle returns to the connection baseline, so `N` in ADR-0060's
+   `19 + N` budget is the *active* subscription count, as that ADR
+   assumed.
+2. **`B1ms` churn no longer exhausts connections.** A deployment can run
+   sustained subscribe/unsubscribe churn without climbing toward the
+   35-usable ceiling.
+3. **One owner, one funnel.** The connection's lifetime is tied to its
+   `SubscriptionId`, and all removal (unsubscribe and close-time
+   teardown) routes through `removeSubscription`, so there is a single
+   release path and no second handle to track.
+4. **Consistent with ADR-0039.** The per-stream path now uses the same
+   "cleanup `Task` run from a `finally`/remove" lifecycle as the
+   listener pair, so the notification layer's resource discipline is
+   uniform.
+5. **The concurrency cap is documented and tied to the budget.** WI-6
+   gets a concrete number (~14 on `B1ms`) derived from ADR-0060's math,
+   closing the `N`-bound the budget ADR deferred here.
+6. **Invisible to Jess.** No new public function, no new config knob, no
+   new error to handle at the call site.
+
+### Negative
+
+1. **`SubscriptionInfo` gains a non-`Show`-able field.** A `Task` field
+   cannot derive `Show`, so the existing `deriving (Show)` on
+   `SubscriptionInfo` must change (drop `Show`, or add a hand-written
+   instance that elides the action). This is a mechanical, internal
+   change but it does touch the derived-instance list.
+2. **Cleanup failures are swallowed.** A connection that fails to release
+   is logged at `warn` and the unsubscribe proceeds. In the rare case of
+   a release that fails for a reason *other* than an already-dead socket,
+   the connection could linger until process exit — but this is strictly
+   better than today (no release at all) and matches ADR-0039's
+   best-effort posture for the listener pair.
+3. **The cap is advisory, not enforced.** nhcore does not reject the
+   15th stream subscription; an operator who ignores the documented cap
+   can still over-subscribe. Enforcing it in code is deferred (see
+   Risks) because a hard limit is a silent feature failure for Jess.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| A future subscription path opens a dedicated resource but forgets to register an `onRemove`, re-introducing a leak. | `addStreamSubscriptionWithCleanup` makes registering the connection and its cleanup a single call, so the connection cannot be tracked without its release. The Postgres-gated no-leak regression test (Testing §1) fails the build if any stream path leaks. |
+| `removeSubscription`'s cleanup throws and breaks unsubscribe. | Cleanup is run under `Task.recover` + `Log.warn`; the boundary test (Testing §3) asserts unsubscribe stays total when `onRemove` throws. |
+| Double-remove releases the connection twice. | `takeOnRemoveFor` returns the cleanup and the delete happens once; a second remove of the same id finds no `onRemove` and yields `unit` (Testing §4). `Hasql.release` on an already-released connection is not invoked because the cleanup is taken, not left in place. |
+| Operators exceed the advisory cap and exhaust `B1ms`. | The cap is documented in the deploy guide (WI-6, #685) with the budget math; ADR-0060's `acquisitionTimeout` surfaces pool starvation as a clean retryable error rather than a hang; a tier upgrade raises both the budget and the cap. |
+| `SubscriptionInfo` losing `Show` breaks a debug/log call site. | The field is internal; any `Show`-dependent site is updated in the same change, and a hand-written instance eliding the `Task` is the fallback if a `Show` is genuinely needed. |
+
+### Mitigations
+
+- The no-leak regression test encodes the acceptance criterion in CI, so
+  a future change that re-leaks fails the build rather than production.
+- The single-funnel design (all removal through `removeSubscription`)
+  means the close-time teardown from ADR-0039 also releases any
+  still-active stream connections as a backstop, composing the two
+  lifecycles rather than duplicating them.
+- The concurrency cap and its derivation are mirrored into the
+  deployment and Postgres-event-store guides by WI-6 (#685), so
+  operators have the number without reading this ADR.
+
+## References
+
+- [#683: WI-4 — Release per-stream subscription connections on unsubscribe](https://github.com/neohaskell/NeoHaskell/issues/683)
+- [#679: Epic — Deploy-readiness on Azure Flexible Server](https://github.com/neohaskell/NeoHaskell/issues/679)
+- [#685: WI-6 — Deployment documentation](https://github.com/neohaskell/NeoHaskell/issues/685) — documents the per-tier stream-subscription cap derived here.
+- [ADR-0039: Fix LISTEN/NOTIFY Connection Leak in Test Teardown](0039-fix-listen-notify-connection-leak.md) — the `close`/cleanup lifecycle precedent this ADR mirrors one level down.
+- [ADR-0060: Explicit Postgres Connection-Pool Budget for Flexible Server B1ms](0060-postgres-pool-budget.md) — establishes the `19 + N ≤ 35` budget; this ADR bounds and documents the `N` term.
+- [ADR-0037: PostgreSQL LISTEN Keepalive + Supervised Reconnect](0037-postgres-listen-keepalive-reconnect.md) — the per-stream `LISTEN` mechanism whose connection this ADR releases.
+- [ADR-0061: Replay from Last globalPosition on LISTEN/NOTIFY Listener Reconnect](0061-listener-reconnect-catchup.md) — sibling correctness work item (WI-3) on the same notification layer.
+- [core/service/Service/EventStore/Postgres/Internal.hs](../../core/service/Service/EventStore/Postgres/Internal.hs) — `subscribeToStreamEventsImpl` / `unsubscribeImpl`.
+- [core/service/Service/EventStore/Postgres/SubscriptionStore.hs](../../core/service/Service/EventStore/Postgres/SubscriptionStore.hs) — `SubscriptionInfo` / `removeSubscription`.
+- [core/service/Service/EventStore/Postgres/Notifications.hs](../../core/service/Service/EventStore/Postgres/Notifications.hs) — `subscribeToStream` (the per-stream `LISTEN`).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -71,6 +71,7 @@ ADRs document significant architectural decisions made during the development of
 | [0055](0055-declarative-integrations-with-fakes.md) | Declarative Integrations with Real/Fake Parity | Proposed |
 | [0056](0056-request-context-timestamp-as-datetime.md) | Retype `RequestContext.timestamp` as `DateTime` | Proposed |
 | [0061](0061-listener-reconnect-catchup.md) | Replay from Last globalPosition on LISTEN/NOTIFY Listener Reconnect | Proposed |
+| [0063](0063-per-stream-subscription-connection-release.md) | Release Per-Stream Subscription Connections on Unsubscribe | Proposed |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

When you subscribe to a single stream with `subscribeToStreamEvents`, the Postgres
event store opens a **dedicated database connection** just for that stream's
`LISTEN`/`NOTIFY` channel. Until now, `unsubscribe` removed the in-memory
subscription but **never closed that connection** — so every
subscribe/unsubscribe cycle leaked one Postgres connection that stayed open until
the whole process exited.

On a small deploy target (Azure Database for PostgreSQL Flexible Server `B1ms`,
~35 usable connections) that leak is a hard outage: a few dozen short-lived
stream subscriptions exhaust the connection ceiling and Postgres starts rejecting
new connections.

This PR ties each stream subscription's dedicated connection to the
`SubscriptionId` you already hold, and releases it automatically when you
unsubscribe. **Nothing changes in how you call the API** — you subscribe and
unsubscribe exactly as before; the cleanup happens for you.

Classification: **moderate** — modifies subscription lifecycle in the existing
Postgres event store (external IO, no new dependency, no auth/secret handling, no
schema change).

## ADR

[ADR-0063 — Release per-stream subscription connections on unsubscribe](docs/decisions/0063-per-stream-subscription-connection-release.md)
(approved). Chosen option: store a per-subscription cleanup `Task` in the
`SubscriptionStore` and run it best-effort on remove — mirroring ADR-0039's
connection-cleanup lifecycle one level down.

## Changes

- **`SubscriptionStore.hs`**
  - `SubscriptionInfo` gains an `onRemove :: Task Text Unit` cleanup field
    (a no-op for global/entity/plain-stream subscriptions).
  - Dropped the derived `Show` and added a hand-written `Show` that elides the
    `Task`/closure fields (a `Task` has no `Show`).
  - New `addStreamSubscriptionWithCleanup` registers a stream subscription
    **together with** its connection-release action, so a connection can never be
    tracked without its cleanup.
  - `removeSubscription` now reads the subscription's cleanup before deleting the
    entry, then runs it best-effort under `Task.recover` + `Log.warn`, so
    `unsubscribe` stays total even if the connection was already dead.
- **`Internal.hs`** — `subscribeToStreamEventsImpl` builds
  `Hasql.release connection` and registers it as the subscription's cleanup.
  `unsubscribeImpl` is unchanged — it already routes through `removeSubscription`,
  which is now the single release funnel.

No public API changed. The new surface (`onRemove`,
`addStreamSubscriptionWithCleanup`) is internal to the Postgres backend.

## Security

ADR-grounded (`findings-04`) and implementation-grounded (`findings-12`) reviews:
**0 blockers**. The new hand-written `Show` is security-positive — it never
renders the connection handle or callback. The `findOnRemove`/`removeSubscription`
sequence is internal, keyed by server-minted `SubscriptionId`s (not attacker
input), and the cleanup is *taken* (read-then-delete) so a double-remove can't
release a connection twice.

## Performance

ADR-grounded (`findings-05`) and implementation-grounded (`findings-13`) reviews:
**0 blockers**, target 50k req/s. No new per-event work — the dispatch hot path
never reads `onRemove`. The cleanup is one `Hasql.release` per unsubscribe (work
the runtime was already obligated to do). `findOnRemove`'s lookup runs only at
unsubscribe and is bounded by the documented concurrency budget.

Advisory capacity note (from ADR-0060's `19 + N ≤ 35` budget): keep concurrent
stream subscriptions at or below **~14 on `B1ms`**. This is documented guidance,
**not** a hard runtime limit — nhcore does not reject the 15th subscription; the
number is carried into the deploy guide (WI-6, #685) and a tier upgrade raises it.

## Tests

- **Unit (`SubscriptionStoreSpec.hs`, no Postgres):** cleanup runs exactly once on
  remove; `unsubscribe` stays total when the cleanup throws; removing an unknown
  id is a no-op that runs no cleanup; a double-remove does not re-run the cleanup;
  global/entity subscriptions' no-op cleanup is unaffected; the new constructor
  registers and dispatches like any other stream subscription and does not fire
  cleanup at registration time.
- **Regression (`PostgresSpec.hs`, Postgres-gated on `POSTGRES_AVAILABLE`):** after
  a warm-up, runs N stream subscribe→unsubscribe cycles and asserts the backend
  connection count (`pg_stat_activity`) does not grow — proving the dedicated
  connection is released each cycle and the leak cannot silently return.

All suites green: **4415 examples, 0 failures** (lsp, auth, integrations,
core, service, and the full `nhcore-test`).

## Hlint

Hlint clean.

## Checklist

- [x] ADR approved
- [x] Security findings grounded (0 blockers)
- [x] Performance findings grounded (0 blockers)
- [x] Tests passing (build + full suite green)
- Hlint: clean ✓

Closes #683


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stream subscriptions now support per-subscription cleanup logic tied to unsubscription.
* **Bug Fixes**
  * Fixed a PostgreSQL connection leak during repeated subscribe/unsubscribe cycles.
  * Subscription removal is now safer: cleanup runs exactly once (best-effort), failures don’t break removal, and repeated/unknown removals are no-ops.
* **Tests**
  * Added unit and PostgreSQL-gated regression coverage for cleanup semantics and connection release across churn.
* **Documentation**
  * Added an ADR describing the per-stream connection release fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->