### PR TITLE
feat(service): optional sslmode TLS hardening for Postgres (#684)

### DIFF
--- a/core/nhcore.cabal
+++ b/core/nhcore.cabal
@@ -244,6 +244,7 @@ library
     Service.EventStore.Postgres.Internal
     Service.EventStore.Postgres.Core
     Service.Infra.Postgres.ConnectionConfig
+    Service.Infra.Postgres.SslMode
     Service.EventStore.Postgres.Notifications
     Service.EventStore.Postgres.PostgresEventRecord
     Service.EventStore.Postgres.Sessions

--- a/core/service/Service/Application.hs
+++ b/core/service/Service/Application.hs
@@ -120,6 +120,7 @@ import Record qualified
 import Schema qualified
 import LinkedList (LinkedList)
 import Maybe (Maybe (..))
+import Maybe qualified
 import Result (Result (..))
 import Service.Command.Core (NameOf)
 import Service.Entity.Core (Entity (..), EntityOf, EventOf)
@@ -142,7 +143,7 @@ import Service.Integration.Types (OutboundRunner, OutboundLifecycleRunner)
 import Service.Transport (Transport (..), QueryEndpointHandler)
 import Service.Transport.Web qualified as Web
 import Path qualified
-import Service.EventStore.Postgres.Internal (PostgresEventStore (..))
+import Service.EventStore.Postgres.Internal ()  -- instance-only: Default PostgresEventStore for the FileUpload pool fallback
 import Service.FileUpload.BlobStore.Local qualified as LocalBlobStore
 import Service.FileUpload.BlobStore.Local (LocalBlobStoreConfig (..))
 import Service.FileUpload.Core (FileUploadConfig (..), FileStateStoreBackend (..), InternalFileUploadConfig (..))
@@ -2045,14 +2046,15 @@ initializeFileUpload fileConfig = do
       -- No cleanup needed for in-memory store
       Task.yield (FileUpload.inMemoryFileStateStore inMemoryStore, Task.yield ())
 
-    PostgresStateStore {pgHost, pgPort, pgDatabase, pgUser, pgPassword} -> do
-      let postgresConfig = def
-            { host = pgHost
-            , port = pgPort
-            , databaseName = pgDatabase
-            , user = pgUser
-            , password = pgPassword
-            }
+    backend@(PostgresStateStore {}) -> do
+      -- WI-5 (#684): reuse the shared PostgresStateStore -> PostgresEventStore
+      -- mapping so the FileUpload state-store pool inherits the operator's
+      -- pgSslMode/pgSslRootCert exactly like the EventStore pool -- no silent
+      -- TLS downgrade on file operations (ADR-0064). 'withDefault def' is
+      -- unreachable here (we matched PostgresStateStore) but keeps it total.
+      let postgresConfig =
+            PostgresFileStore.toEventStoreConfig backend
+              |> Maybe.withDefault def
       (store, pool) <- PostgresFileStore.newWithCleanup postgresConfig
         |> Task.mapError (\err -> [fmt|Failed to initialize PostgreSQL file state store: #{err}|])
       -- Cleanup action releases the connection pool

--- a/core/service/Service/Application.hs
+++ b/core/service/Service/Application.hs
@@ -120,7 +120,6 @@ import Record qualified
 import Schema qualified
 import LinkedList (LinkedList)
 import Maybe (Maybe (..))
-import Maybe qualified
 import Result (Result (..))
 import Service.Command.Core (NameOf)
 import Service.Entity.Core (Entity (..), EntityOf, EventOf)
@@ -2050,11 +2049,12 @@ initializeFileUpload fileConfig = do
       -- WI-5 (#684): reuse the shared PostgresStateStore -> PostgresEventStore
       -- mapping so the FileUpload state-store pool inherits the operator's
       -- pgSslMode/pgSslRootCert exactly like the EventStore pool -- no silent
-      -- TLS downgrade on file operations (ADR-0064). 'withDefault def' is
-      -- unreachable here (we matched PostgresStateStore) but keeps it total.
-      let postgresConfig =
-            PostgresFileStore.toEventStoreConfig backend
-              |> Maybe.withDefault def
+      -- TLS downgrade on file operations (ADR-0064). The Nothing branch is
+      -- unreachable (we matched PostgresStateStore), so fail loudly rather
+      -- than let a future refactor silently produce an empty DB connection.
+      postgresConfig <- case PostgresFileStore.toEventStoreConfig backend of
+        Just cfg -> Task.yield cfg
+        Nothing -> Task.throw "unreachable: non-Postgres FileStateStoreBackend in Postgres path"
       (store, pool) <- PostgresFileStore.newWithCleanup postgresConfig
         |> Task.mapError (\err -> [fmt|Failed to initialize PostgreSQL file state store: #{err}|])
       -- Cleanup action releases the connection pool

--- a/core/service/Service/EventStore/Postgres/Internal.hs
+++ b/core/service/Service/EventStore/Postgres/Internal.hs
@@ -68,9 +68,12 @@ data PostgresEventStore = PostgresEventStore
     -- FileUpload state-store pool). Defaults to 6, sized for Azure Flexible
     -- Server B1ms (~35 usable connections); see ADR-0060 for the aggregate
     -- budget. Raise per deployment tier via this field.
-    poolSize :: Int
+    poolSize :: Int,
+    -- WI-5 (#684): optional TLS hardening. Both default to off.
+    sslMode :: ConnectionConfig.SslMode,
+    sslRootCert :: Maybe Text
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord)
 
 
 -- | Default config: connection-field placeholders plus the ADR-0060 B1ms
@@ -84,7 +87,9 @@ instance Default PostgresEventStore where
         user = "",
         password = "",
         port = 5432,
-        poolSize = 6
+        poolSize = 6,
+        sslMode = ConnectionConfig.SslModeUnset,
+        sslRootCert = Nothing
       }
 
 
@@ -100,7 +105,9 @@ toConnectionSettings cfg =
         databaseName = cfg.databaseName,
         user = cfg.user,
         password = cfg.password,
-        port = cfg.port
+        port = cfg.port,
+        sslMode = cfg.sslMode,
+        sslRootCert = cfg.sslRootCert
       }
 
 

--- a/core/service/Service/FileUpload/Core.hs
+++ b/core/service/Service/FileUpload/Core.hs
@@ -36,6 +36,7 @@ import Maybe (Maybe)
 import Prelude qualified
 import Schema (ToSchema (..))
 import Schema qualified
+import Service.Infra.Postgres.SslMode (SslMode)
 import Text (Text)
 
 
@@ -296,6 +297,13 @@ data FileStateStoreBackend
       -- ^ Database user
       , pgPassword :: Text
       -- ^ Database password
+      , pgSslMode :: SslMode
+      -- ^ libpq TLS negotiation mode (WI-5 #684 / ADR-0064). 'SslModeUnset'
+      -- (the dev/CI default) emits no sslmode param; 'SslModeRequire' and the
+      -- verifying modes forbid a silent TLS downgrade on the FileUpload pool.
+      , pgSslRootCert :: Maybe Text
+      -- ^ Optional CA-bundle path for the verifying modes (WI-5 #684). Server
+      -- auth only -- never a client cert.
       }
   -- ^ PostgreSQL storage (persistent, recommended for production)
   deriving (Generic, Eq)
@@ -318,13 +326,15 @@ instance Json.ToJSON FileStateStoreBackend where
     InMemoryStateStore -> GhcAeson.object
       [ ("tag", GhcAeson.toJSON @Text "InMemoryStateStore")
       ]
-    PostgresStateStore {pgHost, pgPort, pgDatabase, pgUser} -> GhcAeson.object
+    PostgresStateStore {pgHost, pgPort, pgDatabase, pgUser, pgSslMode, pgSslRootCert} -> GhcAeson.object
       [ ("tag", GhcAeson.toJSON @Text "PostgresStateStore")
       , ("pgHost", GhcAeson.toJSON pgHost)
       , ("pgPort", GhcAeson.toJSON pgPort)
       , ("pgDatabase", GhcAeson.toJSON pgDatabase)
       , ("pgUser", GhcAeson.toJSON pgUser)
       , ("pgPassword", GhcAeson.toJSON @Text "<REDACTED>")
+      , ("pgSslMode", GhcAeson.toJSON pgSslMode)
+      , ("pgSslRootCert", GhcAeson.toJSON pgSslRootCert)
       ]
 
 

--- a/core/service/Service/FileUpload/FileStateStore/Postgres.hs
+++ b/core/service/Service/FileUpload/FileStateStore/Postgres.hs
@@ -69,10 +69,11 @@ import Service.FileUpload.Core (
   BlobKey (..),
   ContentHash (..),
   FileRef (..),
-  FileStateStoreBackend (..),
+  FileStateStoreBackend,
   FileUploadEvent (..),
   OwnerHash (..),
  )
+import Service.FileUpload.Core qualified as FileUploadCore
 import Service.FileUpload.Lifecycle (FileUploadState (..))
 import Service.FileUpload.Lifecycle qualified as Lifecycle
 import Service.FileUpload.Web (FileStateStore (..))
@@ -167,8 +168,8 @@ newWithCleanup config = do
 toEventStoreConfig :: FileStateStoreBackend -> Maybe PostgresEventStore
 toEventStoreConfig backend =
   case backend of
-    InMemoryStateStore -> Nothing
-    PostgresStateStore {pgHost, pgPort, pgDatabase, pgUser, pgPassword, pgSslMode, pgSslRootCert} ->
+    FileUploadCore.InMemoryStateStore -> Nothing
+    FileUploadCore.PostgresStateStore {pgHost, pgPort, pgDatabase, pgUser, pgPassword, pgSslMode, pgSslRootCert} ->
       Just
         ( def
             { host = pgHost,

--- a/core/service/Service/FileUpload/FileStateStore/Postgres.hs
+++ b/core/service/Service/FileUpload/FileStateStore/Postgres.hs
@@ -36,6 +36,7 @@ module Service.FileUpload.FileStateStore.Postgres (
   -- * Initialization
   new,
   newWithCleanup,
+  toEventStoreConfig,
 
   -- * Types
   Pool,
@@ -68,6 +69,7 @@ import Service.FileUpload.Core (
   BlobKey (..),
   ContentHash (..),
   FileRef (..),
+  FileStateStoreBackend (..),
   FileUploadEvent (..),
   OwnerHash (..),
  )
@@ -156,6 +158,30 @@ newWithCleanup config = do
   Task.yield (store, pool)
 
 
+-- | Build the shared 'PostgresEventStore' connection config that the FileUpload
+-- state-store pool runs on, from the declarative 'PostgresStateStore' backend.
+-- WI-5 (#684): threads the operator's @pgSslMode@/@pgSslRootCert@ through so the
+-- FileUpload pool honours DB_SSL_MODE exactly like the EventStore pool, closing
+-- the silent-TLS-downgrade gap (ADR-0064). 'InMemoryStateStore' has no Postgres
+-- connection config, so it maps to 'Nothing'.
+toEventStoreConfig :: FileStateStoreBackend -> Maybe PostgresEventStore
+toEventStoreConfig backend =
+  case backend of
+    InMemoryStateStore -> Nothing
+    PostgresStateStore {pgHost, pgPort, pgDatabase, pgUser, pgPassword, pgSslMode, pgSslRootCert} ->
+      Just
+        ( def
+            { host = pgHost,
+              port = pgPort,
+              databaseName = pgDatabase,
+              user = pgUser,
+              password = pgPassword,
+              sslMode = pgSslMode,
+              sslRootCert = pgSslRootCert
+            }
+        )
+
+
 -- | Create a connection pool from PostgresEventStore config.
 --
 -- The FileUpload state-store pool shares the EventStore config's 'poolSize'
@@ -175,6 +201,8 @@ createPool cfg = do
                , user = cfg.user
                , password = cfg.password
                , port = cfg.port
+               , sslMode = cfg.sslMode
+               , sslRootCert = cfg.sslRootCert
                } of
         Err portErr -> Task.throw (InvalidPort portErr)
         Ok settings -> do

--- a/core/service/Service/Infra/Postgres/ConnectionConfig.hs
+++ b/core/service/Service/Infra/Postgres/ConnectionConfig.hs
@@ -128,20 +128,24 @@ sslParams resolved =
       paramSetting (Param.other "sslmode" token) : rootCertParams resolved.sslMode resolved.sslRootCert
 
 
--- | The 'verify-full' companion Settings: the sslrootcert path and, for
--- verify-full, channel_binding=require — each as an individual Setting.
--- Emits [] when no root cert path is supplied, so 'require' alone adds nothing.
--- Forwards a PATH only — pins no cert (ADR-0064 §"Root-only trust"). NEVER emits
--- sslcert/sslkey.
+-- | The verifying-mode companion Settings. 'sslrootcert' is emitted ONLY for
+-- the verifying modes ('SslModeVerifyCa' / 'SslModeVerifyFull') and only when a
+-- root cert path is supplied — a root cert is meaningless for the non-verifying
+-- modes ('disable'/'allow'/'prefer'/'require'), so it is NEVER sent for them
+-- even if the environment provides a path (ADR-0064 §3). 'verify-full'
+-- additionally emits channel_binding=require. Forwards a PATH only — pins no
+-- cert (ADR-0064 §"Root-only trust"). NEVER emits sslcert/sslkey.
 rootCertParams :: SslMode -> Maybe Text -> LinkedList Setting
 rootCertParams mode maybeRootCert =
-  case maybeRootCert of
-    Nothing -> []
-    Just path -> do
-      let channelBinding = case mode of
-            SslModeVerifyFull -> [paramSetting (Param.other "channel_binding" "require")]
-            _ -> []
-      paramSetting (Param.other "sslrootcert" path) : channelBinding
+  case (mode, maybeRootCert) of
+    (SslModeVerifyCa, Just path) ->
+      [paramSetting (Param.other "sslrootcert" path)]
+    (SslModeVerifyFull, Just path) ->
+      [ paramSetting (Param.other "sslrootcert" path),
+        paramSetting (Param.other "channel_binding" "require")
+      ]
+    _ ->
+      []
 
 
 -- | Wrap a single 'Param.Param' into a 'Setting' so ssl params are individual

--- a/core/service/Service/Infra/Postgres/ConnectionConfig.hs
+++ b/core/service/Service/Infra/Postgres/ConnectionConfig.hs
@@ -1,7 +1,10 @@
 module Service.Infra.Postgres.ConnectionConfig (
+  SslMode (..),
   ConnectionParams (..),
   ResolvedParams (..),
   validatePort,
+  sslModeToText,
+  textToSslMode,
   resolveParams,
   toConnectionParams,
   toPoolConfig,
@@ -22,6 +25,7 @@ import Hasql.Pool.Observation (ConnectionStatus (..), ConnectionTerminationReaso
 import Log qualified
 import Result qualified
 import Task qualified
+import Service.Infra.Postgres.SslMode (SslMode (..), sslModeToText, textToSslMode)
 import Prelude qualified
 
 
@@ -33,7 +37,14 @@ data ConnectionParams = ConnectionParams
     databaseName :: Text,
     user :: Text,
     password :: Text,
-    port :: Int
+    port :: Int,
+    -- WI-5 (#684): optional TLS hardening. 'SslModeUnset' (the default the
+    -- pool configs pass) emits no sslmode param, so libpq keeps its 'prefer'
+    -- default and localhost/dev is unchanged.
+    sslMode :: SslMode,
+    -- Optional CA-bundle path for 'verify-full' (root CAs only; never an
+    -- intermediate or server cert).
+    sslRootCert :: Maybe Text
   }
   deriving (Eq, Ord)
 
@@ -55,7 +66,12 @@ data ResolvedParams = ResolvedParams
     keepalives :: Text,
     keepalivesIdle :: Text,
     keepalivesInterval :: Text,
-    keepalivesCount :: Text
+    keepalivesCount :: Text,
+    -- WI-5 (#684): carried through unchanged so the spec can assert exactly
+    -- which TLS params each mode emits. 'SslModeUnset' here means
+    -- 'toConnectionParams' appends no sslmode param.
+    sslMode :: SslMode,
+    sslRootCert :: Maybe Text
   }
   deriving (Eq)
 
@@ -91,8 +107,50 @@ resolveParams cfg =
           keepalives = "1",
           keepalivesIdle = "30",
           keepalivesInterval = "10",
-          keepalivesCount = "5"
+          keepalivesCount = "5",
+          -- WI-5 (#684): copy both TLS fields through unchanged.
+          sslMode = cfg.sslMode,
+          sslRootCert = cfg.sslRootCert
         }
+
+
+-- | Conditional TLS 'Setting' list appended after the keepalive Setting.
+-- Returns [] for 'SslModeUnset' (byte-identical to pre-WI-5 — the dev/CI
+-- no-regression guarantee, ADR-0064 §2). For any set mode it emits the
+-- sslmode param as its own Setting; for a verifying mode WITH a root cert it
+-- additionally emits sslrootcert (and for verify-full: channel_binding=require)
+-- each as their own Setting. NEVER emits sslcert/sslkey (ADR-0064 §3).
+sslParams :: ResolvedParams -> LinkedList Setting
+sslParams resolved =
+  case sslModeToText resolved.sslMode of
+    Nothing -> []
+    Just token ->
+      paramSetting (Param.other "sslmode" token) : rootCertParams resolved.sslMode resolved.sslRootCert
+
+
+-- | The 'verify-full' companion Settings: the sslrootcert path and, for
+-- verify-full, channel_binding=require — each as an individual Setting.
+-- Emits [] when no root cert path is supplied, so 'require' alone adds nothing.
+-- Forwards a PATH only — pins no cert (ADR-0064 §"Root-only trust"). NEVER emits
+-- sslcert/sslkey.
+rootCertParams :: SslMode -> Maybe Text -> LinkedList Setting
+rootCertParams mode maybeRootCert =
+  case maybeRootCert of
+    Nothing -> []
+    Just path -> do
+      let channelBinding = case mode of
+            SslModeVerifyFull -> [paramSetting (Param.other "channel_binding" "require")]
+            _ -> []
+      paramSetting (Param.other "sslrootcert" path) : channelBinding
+
+
+-- | Wrap a single 'Param.Param' into a 'Setting' so ssl params are individual
+-- list entries (each adds 1 to 'LinkedList.length', making the length assertions
+-- in the spec numerically meaningful).
+paramSetting :: Param.Param -> Setting
+paramSetting p =
+  ConnectionSettingConnection.params [p]
+    |> ConnectionSetting.connection
 
 
 -- | The single place libpq connection params are constructed (ADR-0062
@@ -104,20 +162,21 @@ toConnectionParams cfg =
   cfg
     |> resolveParams
     |> Result.map \resolved -> do
-      let params =
-            ConnectionSettingConnection.params
-              [ Param.host resolved.host,
-                Param.port resolved.port,
-                Param.dbname resolved.databaseName,
-                Param.user resolved.user,
-                Param.password resolved.password,
-                Param.other "keepalives" resolved.keepalives,
-                Param.other "keepalives_idle" resolved.keepalivesIdle,
-                Param.other "keepalives_interval" resolved.keepalivesInterval,
-                Param.other "keepalives_count" resolved.keepalivesCount
-                -- WI-5 (#684) adds: Param.other "sslmode" "<mode>" here.
-              ]
-      [params |> ConnectionSetting.connection]
+      let baseParams =
+            [ Param.host resolved.host,
+              Param.port resolved.port,
+              Param.dbname resolved.databaseName,
+              Param.user resolved.user,
+              Param.password resolved.password,
+              Param.other "keepalives" resolved.keepalives,
+              Param.other "keepalives_idle" resolved.keepalivesIdle,
+              Param.other "keepalives_interval" resolved.keepalivesInterval,
+              Param.other "keepalives_count" resolved.keepalivesCount
+            ]
+      let baseSetting =
+            ConnectionSettingConnection.params baseParams
+              |> ConnectionSetting.connection
+      baseSetting : sslParams resolved
 
 
 -- | The single place 'Hasql.Pool.Config' is constructed (ADR-0062 section 3).

--- a/core/service/Service/Infra/Postgres/SslMode.hs
+++ b/core/service/Service/Infra/Postgres/SslMode.hs
@@ -1,0 +1,106 @@
+module Service.Infra.Postgres.SslMode (
+  SslMode (..),
+  sslModeToText,
+  textToSslMode,
+) where
+
+-- | Core-free home for the WI-5 (#684 / ADR-0064) libpq TLS-mode enum and its
+-- token mappings. It imports only granular primitives (never 'Core'), so the
+-- low-level 'Service.FileUpload.Core' can carry an 'SslMode' field without
+-- forming a Core <-> FileUpload import cycle. The richer
+-- 'Service.Infra.Postgres.ConnectionConfig' re-exports all three names, so
+-- existing call sites are unaffected.
+
+import Basics
+import Json qualified
+import Maybe (Maybe (..))
+import Maybe qualified
+import Result (Result (..))
+import Text (Text)
+import Text qualified
+
+
+-- | Optional libpq TLS negotiation mode (WI-5 / ADR-0064). 'SslModeUnset'
+-- (the 'Default' the pool configs pass) emits no sslmode param, so libpq
+-- keeps its compiled-in 'prefer' default and localhost/dev is unchanged.
+-- Server-auth only: there is deliberately no client-cert (sslcert/sslkey)
+-- field, because Azure Flexible Server has no mTLS and supplying them breaks
+-- the connection (ADR-0064 §3).
+data SslMode
+  = SslModeUnset      -- ^ no sslmode param; libpq default 'prefer' (the default)
+  | SslModeDisable    -- ^ sslmode=disable
+  | SslModeAllow      -- ^ sslmode=allow
+  | SslModePrefer     -- ^ sslmode=prefer (explicit)
+  | SslModeRequire    -- ^ sslmode=require — forbids silent downgrade
+  | SslModeVerifyCa   -- ^ sslmode=verify-ca
+  | SslModeVerifyFull -- ^ sslmode=verify-full — forbids downgrade + MITM
+  deriving (Eq, Ord, Show)
+
+
+-- | Map an 'SslMode' to its libpq sslmode token (WI-5 / ADR-0064).
+-- Total over the closed enum. 'SslModeUnset' has NO token — returns
+-- 'Nothing', because the unset mode emits no sslmode param at all
+-- (ADR-0064 §2). Every other constructor maps to its exact libpq token.
+--
+-- >>> sslModeToText SslModeRequire
+-- Just "require"
+-- >>> sslModeToText SslModeVerifyFull
+-- Just "verify-full"
+-- >>> sslModeToText SslModeUnset
+-- Nothing
+sslModeToText :: SslMode -> Maybe Text
+sslModeToText mode =
+  case mode of
+    SslModeUnset -> Nothing
+    SslModeDisable -> Just "disable"
+    SslModeAllow -> Just "allow"
+    SslModePrefer -> Just "prefer"
+    SslModeRequire -> Just "require"
+    SslModeVerifyCa -> Just "verify-ca"
+    SslModeVerifyFull -> Just "verify-full"
+
+
+-- | Parse an operator-supplied env token into an 'SslMode' (WI-5 / ADR-0064).
+-- The empty string and "unset" both map to 'SslModeUnset' (default-off).
+-- Every libpq token maps to its constructor; anything else is one clean
+-- 'Result' error naming the bad value.
+--
+-- >>> textToSslMode "require"
+-- Ok SslModeRequire
+-- >>> textToSslMode "unset"
+-- Ok SslModeUnset
+-- >>> textToSslMode ""
+-- Ok SslModeUnset
+-- >>> textToSslMode "requre"
+-- Err "unknown DB_SSL_MODE \"requre\"; expected one of: unset, disable, allow, prefer, require, verify-ca, verify-full"
+textToSslMode :: Text -> Result Text SslMode
+textToSslMode input = do
+  let trimmedLower = input |> Text.trim |> Text.toLower
+  case trimmedLower of
+    "" -> Ok SslModeUnset
+    "unset" -> Ok SslModeUnset
+    "disable" -> Ok SslModeDisable
+    "allow" -> Ok SslModeAllow
+    "prefer" -> Ok SslModePrefer
+    "require" -> Ok SslModeRequire
+    "verify-ca" -> Ok SslModeVerifyCa
+    "verify-full" -> Ok SslModeVerifyFull
+    other -> Err [fmt|unknown DB_SSL_MODE "#{other}"; expected one of: unset, disable, allow, prefer, require, verify-ca, verify-full|]
+
+
+-- | JSON token form so 'SslMode' config fields round-trip through the
+-- declarative config layer (e.g. 'Service.FileUpload.Core.FileStateStoreBackend').
+-- 'SslModeUnset' serialises as the literal "unset".
+instance Json.ToJSON SslMode where
+  toJSON mode =
+    sslModeToText mode
+      |> Maybe.withDefault "unset"
+      |> Json.toJSON
+
+
+instance Json.FromJSON SslMode where
+  parseJSON =
+    Json.withText "SslMode" \token ->
+      case textToSslMode token of
+        Ok mode -> Json.yield mode
+        Err err -> Json.fail err

--- a/core/service/Service/Infra/Postgres/SslMode.hs
+++ b/core/service/Service/Infra/Postgres/SslMode.hs
@@ -11,7 +11,7 @@ module Service.Infra.Postgres.SslMode (
 -- 'Service.Infra.Postgres.ConnectionConfig' re-exports all three names, so
 -- existing call sites are unaffected.
 
-import Basics
+import Basics (Eq, Ord, Show, fmt, (|>))
 import Json qualified
 import Maybe (Maybe (..))
 import Maybe qualified

--- a/core/service/Service/QueryObjectStore/Postgres.hs
+++ b/core/service/Service/QueryObjectStore/Postgres.hs
@@ -61,8 +61,11 @@ data PostgresQueryObjectStoreConfig = PostgresQueryObjectStoreConfig
     -- ADR-0060 for the aggregate budget. Raise per deployment tier via this
     -- field.
   , poolSize :: Int
+    -- WI-5 (#684): optional TLS hardening. Both default to off.
+  , sslMode :: ConnectionConfig.SslMode
+  , sslRootCert :: Maybe Text
   }
-  deriving (Eq, Show)
+  deriving (Eq)
 
 
 -- | Default config: connection-field placeholders plus the ADR-0060 B1ms
@@ -77,6 +80,8 @@ instance Default PostgresQueryObjectStoreConfig where
       , password = ""
       , port = 5432
       , poolSize = 4
+      , sslMode = ConnectionConfig.SslModeUnset
+      , sslRootCert = Nothing
       }
 
 
@@ -121,6 +126,8 @@ acquirePool cfg = do
                , user = cfg.user
                , password = cfg.password
                , port = cfg.port
+               , sslMode = cfg.sslMode
+               , sslRootCert = cfg.sslRootCert
                } of
         Err portErr -> Task.throw (ConnectionFailed portErr)
         Ok settings -> do

--- a/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
+++ b/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
@@ -352,11 +352,42 @@ spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
       let vfLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull Nothing))
       vfLen |> Hspec.shouldBe reqLen
 
-    Hspec.it "never emits a client-cert param for any mode (no-mTLS, by construction)" do
-      case ConnectionConfig.resolveParams (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")) of
-        Err _ -> Prelude.error "expected Ok but got Err"
-        Ok r ->
-          r.sslRootCert |> Hspec.shouldBe (Just "/etc/ca.pem")
+    Hspec.it "emits exactly base + sslmode + sslrootcert + channel_binding for verify-full + cert (observes the EMITTED settings: no sslcert/sslkey leaks in)" do
+      -- The opaque hasql Setting list has no Eq/Show, so observe the emitted
+      -- OUTPUT by count rather than just the resolved params: the unset
+      -- baseline is 1 (the single base Setting), and verify-full WITH a root
+      -- cert must add exactly 3 -- sslmode, sslrootcert, channel_binding. A
+      -- leaked sslcert/sslkey client-cert param would push the count past
+      -- baseLen + 3, so this pins the no-mTLS guarantee on the emitted Setting
+      -- list, not merely on the inspectable ResolvedParams.
+      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
+      let vfLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")))
+      vfLen |> Hspec.shouldBe (baseLen + 3)
+
+    Hspec.it "emits sslrootcert but NOT channel_binding for verify-ca + cert (channel_binding is verify-full only)" do
+      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
+      let verifyCaLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyCa (Just "/etc/ca.pem")))
+      verifyCaLen |> Hspec.shouldBe (baseLen + 2)
+
+    Hspec.it "does NOT emit sslrootcert for a non-verifying mode even when a cert path is supplied (verify-only gating)" do
+      -- 'require' is non-verifying: a root cert is meaningless, so the emitted
+      -- settings for require+cert must equal require+no-cert (sslmode only).
+      let reqNoCert = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
+      let reqWithCert = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire (Just "/etc/ca.pem")))
+      reqWithCert |> Hspec.shouldBe reqNoCert
+
+    Hspec.it "ignores a root cert for every non-verifying mode (disable/allow/prefer/require) -- table sweep of the verify-only gate" do
+      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
+      let nonVerifying :: [SslMode]
+          nonVerifying = [SslModeDisable, SslModeAllow, SslModePrefer, SslModeRequire]
+      let allIgnoreCert =
+            nonVerifying
+              |> Prelude.all
+                ( \mode ->
+                    lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl mode (Just "/etc/ca.pem")))
+                      Prelude.== (baseLen + 1)
+                )
+      allIgnoreCert |> Hspec.shouldBe True
 
   Hspec.describe "textToSslMode / sslModeToText round-trip" do
     Hspec.it "round-trips every token-bearing SslMode: parse (toText m) back to Ok m" do

--- a/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
+++ b/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
@@ -14,7 +14,7 @@ module Service.Infra.Postgres.ConnectionConfigSpec (spec) where
 import Core
 import LinkedList qualified
 import Result qualified
-import Service.Infra.Postgres.ConnectionConfig (ConnectionParams (..), ResolvedParams (..))
+import Service.Infra.Postgres.ConnectionConfig (ConnectionParams (..), ResolvedParams (..), SslMode (..))
 import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Prelude qualified
 import Test.Hspec qualified as Hspec
@@ -28,7 +28,9 @@ typicalParams =
       databaseName = "app",
       user = "postgres",
       password = "secret",
-      port = 5432
+      port = 5432,
+      sslMode = ConnectionConfig.SslModeUnset,
+      sslRootCert = Nothing
     }
 
 
@@ -43,7 +45,9 @@ paramsWithPort p =
       databaseName = "app",
       user = "postgres",
       password = "secret",
-      port = p
+      port = p,
+      sslMode = ConnectionConfig.SslModeUnset,
+      sslRootCert = Nothing
     }
 
 
@@ -56,7 +60,9 @@ paramsWithPassword pw =
       databaseName = "app",
       user = "postgres",
       password = pw,
-      port = 5432
+      port = 5432,
+      sslMode = ConnectionConfig.SslModeUnset,
+      sslRootCert = Nothing
     }
 
 
@@ -68,6 +74,30 @@ expectedKeepalives resolved =
     && resolved.keepalivesInterval Prelude.== "10"
     && resolved.keepalivesCount Prelude.== "5"
 
+
+-- | The typical config with explicit TLS fields, full record construction
+-- (the constructor names the type) so the field set is unambiguous.
+paramsWithSsl :: ConnectionConfig.SslMode -> Maybe Text -> ConnectionParams
+paramsWithSsl mode rootCert =
+  ConnectionConfig.ConnectionParams
+    { host = "localhost",
+      databaseName = "app",
+      user = "postgres",
+      password = "secret",
+      port = 5432,
+      sslMode = mode,
+      sslRootCert = rootCert
+    }
+
+
+-- | Extract the length of an Ok payload, failing hard on Err (mirrors existing
+-- idiom at spec lines 99/113/156). The Ok payload LinkedList Setting has no
+-- Show, so we cannot shouldBe on the whole Result.
+lengthOfOk :: Result Text (LinkedList a) -> Int
+lengthOfOk result =
+  case result of
+    Ok xs -> LinkedList.length xs
+    Err e -> Prelude.error (Prelude.show e)
 
 spec :: Hspec.Spec
 spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
@@ -125,7 +155,9 @@ spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
                 databaseName = "",
                 user = "",
                 password = "",
-                port = 5432
+                port = 5432,
+                sslMode = ConnectionConfig.SslModeUnset,
+                sslRootCert = Nothing
               }
       case ConnectionConfig.resolveParams emptyParams of
         Err err -> Prelude.error (Prelude.show err)
@@ -190,3 +222,152 @@ spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
 
     Hspec.it "is total regardless of settings list length (empty vs typical)" do
       (ConnectionConfig.toPoolConfig 6 [] `Prelude.seq` True) |> Hspec.shouldBe True
+
+  Hspec.describe "sslModeToText" do
+    Hspec.it "maps SslModeRequire to Just \"require\" (the canonical opt-in token)" do
+      ConnectionConfig.sslModeToText ConnectionConfig.SslModeRequire
+        |> Hspec.shouldBe (Just "require")
+
+    Hspec.it "maps SslModeUnset to Nothing (no token — the default emits no sslmode param)" do
+      ConnectionConfig.sslModeToText ConnectionConfig.SslModeUnset
+        |> Hspec.shouldBe Nothing
+
+    Hspec.it "maps SslModeDisable to Just \"disable\"" do
+      ConnectionConfig.sslModeToText ConnectionConfig.SslModeDisable
+        |> Hspec.shouldBe (Just "disable")
+
+    Hspec.it "maps SslModeAllow to Just \"allow\"" do
+      ConnectionConfig.sslModeToText ConnectionConfig.SslModeAllow
+        |> Hspec.shouldBe (Just "allow")
+
+    Hspec.it "maps SslModePrefer to Just \"prefer\"" do
+      ConnectionConfig.sslModeToText ConnectionConfig.SslModePrefer
+        |> Hspec.shouldBe (Just "prefer")
+
+    Hspec.it "maps SslModeVerifyCa to Just \"verify-ca\"" do
+      ConnectionConfig.sslModeToText ConnectionConfig.SslModeVerifyCa
+        |> Hspec.shouldBe (Just "verify-ca")
+
+    Hspec.it "maps SslModeVerifyFull to Just \"verify-full\" (the high-assurance token)" do
+      ConnectionConfig.sslModeToText ConnectionConfig.SslModeVerifyFull
+        |> Hspec.shouldBe (Just "verify-full")
+
+    Hspec.it "is total over the 7-constructor enum (table sweep guards a future dropped/typo'd token)" do
+      let table :: [(ConnectionConfig.SslMode, Maybe Text)]
+          table =
+            [ (ConnectionConfig.SslModeUnset, Nothing),
+              (ConnectionConfig.SslModeDisable, Just "disable"),
+              (ConnectionConfig.SslModeAllow, Just "allow"),
+              (ConnectionConfig.SslModePrefer, Just "prefer"),
+              (ConnectionConfig.SslModeRequire, Just "require"),
+              (ConnectionConfig.SslModeVerifyCa, Just "verify-ca"),
+              (ConnectionConfig.SslModeVerifyFull, Just "verify-full")
+            ]
+      (table |> Prelude.all (\(m, t) -> ConnectionConfig.sslModeToText m Prelude.== t))
+        |> Hspec.shouldBe True
+
+  Hspec.describe "textToSslMode" do
+    Hspec.it "parses \"require\" to Ok SslModeRequire (the canonical operator token)" do
+      ConnectionConfig.textToSslMode "require"
+        |> Hspec.shouldBe (Ok SslModeRequire)
+
+    Hspec.it "parses the empty string to Ok SslModeUnset (default-off: operator sets nothing)" do
+      ConnectionConfig.textToSslMode ""
+        |> Hspec.shouldBe (Ok SslModeUnset)
+
+    Hspec.it "parses the literal \"unset\" to Ok SslModeUnset (the explicit default token)" do
+      ConnectionConfig.textToSslMode "unset"
+        |> Hspec.shouldBe (Ok SslModeUnset)
+
+    Hspec.it "parses an unknown token \"requre\" to Err naming the bad value and the valid set" do
+      ConnectionConfig.textToSslMode "requre"
+        |> Hspec.shouldBe (Err "unknown DB_SSL_MODE \"requre\"; expected one of: unset, disable, allow, prefer, require, verify-ca, verify-full")
+
+    Hspec.it "rejects a unicode-multibyte unknown token to Err (multibyte boundary on the Err branch)" do
+      ConnectionConfig.textToSslMode "requëre"
+        |> Hspec.shouldBe (Err "unknown DB_SSL_MODE \"requëre\"; expected one of: unset, disable, allow, prefer, require, verify-ca, verify-full")
+
+    Hspec.it "parses \"disable\" to Ok SslModeDisable" do
+      ConnectionConfig.textToSslMode "disable"
+        |> Hspec.shouldBe (Ok SslModeDisable)
+
+    Hspec.it "parses \"verify-full\" to Ok SslModeVerifyFull (hyphenated high-assurance token)" do
+      ConnectionConfig.textToSslMode "verify-full"
+        |> Hspec.shouldBe (Ok SslModeVerifyFull)
+
+    Hspec.it "case-folds an uppercase token \"REQUIRE\" to Ok SslModeRequire" do
+      ConnectionConfig.textToSslMode "REQUIRE"
+        |> Hspec.shouldBe (Ok SslModeRequire)
+
+    Hspec.it "trims surrounding whitespace \"  require  \" to Ok SslModeRequire" do
+      ConnectionConfig.textToSslMode "  require  "
+        |> Hspec.shouldBe (Ok SslModeRequire)
+
+  Hspec.describe "resolveParams (additive sslMode/sslRootCert)" do
+    Hspec.it "carries SslModeRequire and Just rootCert path through unchanged" do
+      case ConnectionConfig.resolveParams (paramsWithSsl SslModeRequire (Just "/etc/ca.pem")) of
+        Err _ -> Prelude.error "expected Ok but got Err"
+        Ok r -> do
+          r.sslMode |> Hspec.shouldBe SslModeRequire
+          r.sslRootCert |> Hspec.shouldBe (Just "/etc/ca.pem")
+
+    Hspec.it "carries SslModeUnset and Nothing through as the default-off mirror (no-regression)" do
+      case ConnectionConfig.resolveParams (paramsWithSsl SslModeUnset Nothing) of
+        Err _ -> Prelude.error "expected Ok but got Err"
+        Ok r -> do
+          r.sslMode |> Hspec.shouldBe SslModeUnset
+          r.sslRootCert |> Hspec.shouldBe Nothing
+
+    Hspec.it "carries SslModeVerifyFull with Just rootCert through (high-assurance copy-through)" do
+      case ConnectionConfig.resolveParams (paramsWithSsl SslModeVerifyFull (Just "/etc/postgresql/azure-roots.pem")) of
+        Err _ -> Prelude.error "expected Ok but got Err"
+        Ok r -> do
+          r.sslMode |> Hspec.shouldBe SslModeVerifyFull
+          r.sslRootCert |> Hspec.shouldBe (Just "/etc/postgresql/azure-roots.pem")
+
+    Hspec.it "carries Nothing rootCert distinctly from a path (boundary: no cert supplied)" do
+      case ConnectionConfig.resolveParams (paramsWithSsl SslModeVerifyFull Nothing) of
+        Err _ -> Prelude.error "expected Ok but got Err"
+        Ok r ->
+          r.sslRootCert |> Hspec.shouldBe Nothing
+
+  Hspec.describe "toConnectionParams (additive sslMode/sslRootCert)" do
+    Hspec.it "with SslModeRequire produces an Ok settings list one entry longer than the unset baseline" do
+      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
+      let reqLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
+      reqLen |> Hspec.shouldBe (baseLen + 1)
+
+    Hspec.it "with SslModeUnset emits the same settings-list length as the pre-WI-5 baseline (no regression)" do
+      case ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing) of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok settings -> (settings |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "with SslModeVerifyFull + Just rootCert produces a list longer than require alone (sslmode + sslrootcert + channel_binding)" do
+      let reqLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
+      let vfLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")))
+      (vfLen Prelude.> reqLen) |> Hspec.shouldBe True
+
+    Hspec.it "with SslModeVerifyFull but Nothing rootCert emits no sslrootcert (boundary: empty cert path)" do
+      let reqLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
+      let vfLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull Nothing))
+      vfLen |> Hspec.shouldBe reqLen
+
+    Hspec.it "never emits a client-cert param for any mode (no-mTLS, by construction)" do
+      case ConnectionConfig.resolveParams (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")) of
+        Err _ -> Prelude.error "expected Ok but got Err"
+        Ok r ->
+          r.sslRootCert |> Hspec.shouldBe (Just "/etc/ca.pem")
+
+  Hspec.describe "textToSslMode / sslModeToText round-trip" do
+    Hspec.it "round-trips every token-bearing SslMode: parse (toText m) back to Ok m" do
+      let modes :: [SslMode]
+          modes = [SslModeDisable, SslModeAllow, SslModePrefer, SslModeRequire, SslModeVerifyCa, SslModeVerifyFull]
+      let roundTrips =
+            modes
+              |> Prelude.all
+                ( \m ->
+                    case ConnectionConfig.sslModeToText m of
+                      Just token -> ConnectionConfig.textToSslMode token Prelude.== Ok m
+                      Nothing -> False
+                )
+      roundTrips |> Hspec.shouldBe True

--- a/core/test/Service/EventStore/PostgresSpec.hs
+++ b/core/test/Service/EventStore/PostgresSpec.hs
@@ -18,6 +18,7 @@ import Var qualified
 import Service.Event (EntityName (..), Event)
 import Service.Event.StreamId qualified as StreamId
 import Service.EventStore.Postgres.Internal (toConnectionSettings)
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Result qualified
 import Text qualified
 import Bytes qualified
@@ -39,7 +40,9 @@ spec = do
               Internal.user = "neohaskell",
               Internal.password = "neohaskell",
               Internal.port = 5432,
-              Internal.poolSize = 6
+              Internal.poolSize = 6,
+              Internal.sslMode = ConnectionConfig.SslModeUnset,
+              Internal.sslRootCert = Nothing
             }
     describe "new method" do
       it "acquires the connection" \_ -> do

--- a/core/test/Service/FileUpload/CoreSpec.hs
+++ b/core/test/Service/FileUpload/CoreSpec.hs
@@ -19,7 +19,7 @@ import Service.FileUpload.Core (
   OwnerHash (..),
   ResolvedFile (..),
  )
-import Service.Infra.Postgres.ConnectionConfig (SslMode (..))
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Test
 import Text qualified
 
@@ -303,7 +303,7 @@ spec = do
                   , pgDatabase = "testdb"
                   , pgUser = "testuser"
                   , pgPassword = "testpass"
-                  , pgSslMode = SslModeUnset
+                  , pgSslMode = ConnectionConfig.SslModeUnset
                   , pgSslRootCert = Nothing
                   }
               , maxFileSizeBytes = 10485760

--- a/core/test/Service/FileUpload/CoreSpec.hs
+++ b/core/test/Service/FileUpload/CoreSpec.hs
@@ -19,6 +19,7 @@ import Service.FileUpload.Core (
   OwnerHash (..),
   ResolvedFile (..),
  )
+import Service.Infra.Postgres.ConnectionConfig (SslMode (..))
 import Test
 import Text qualified
 
@@ -302,6 +303,8 @@ spec = do
                   , pgDatabase = "testdb"
                   , pgUser = "testuser"
                   , pgPassword = "testpass"
+                  , pgSslMode = SslModeUnset
+                  , pgSslRootCert = Nothing
                   }
               , maxFileSizeBytes = 10485760
               , pendingTtlSeconds = 21600

--- a/core/test/Service/FileUpload/FileStateStore/PostgresSpec.hs
+++ b/core/test/Service/FileUpload/FileStateStore/PostgresSpec.hs
@@ -4,29 +4,108 @@ import Core
 import Hasql.Pool (Pool)
 import Hasql.Pool qualified as HasqlPool
 import Hasql.Session qualified as Session
+import LinkedList qualified
+import Maybe qualified
 import Result qualified
 import Service.EventStore.Postgres (PostgresEventStore (..))
+import Service.FileUpload.Core (FileStateStoreBackend (..))
 import Service.FileUpload.FileStateStore.Postgres qualified as PostgresFileStore
 import Service.FileUpload.Web (FileStateStore (..))
+import Service.Infra.Postgres.ConnectionConfig (ConnectionParams (..), SslMode (..))
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Task qualified
 import Test
 import Test.Service.FileUpload.FileStateStore qualified as FileStateStoreSpec
 
 
 -- | Test configuration - same as other Postgres tests in the codebase
+-- | Full record construction (not a @def { .. }@ update): this module imports
+-- both PostgresEventStore and ConnectionParams field sets, so a bare-field
+-- record UPDATE would be ambiguous under -XDuplicateRecordFields. Constructing
+-- via the named constructor disambiguates. Values mirror the old def-based
+-- fixture (poolSize/sslMode/sslRootCert at their PostgresEventStore defaults).
 testConfig :: PostgresEventStore
 testConfig =
-  def
+  PostgresEventStore
     { host = "localhost"
     , databaseName = "neohaskell"
     , user = "neohaskell"
     , password = "neohaskell"
     , port = 5432
+    , poolSize = 6
+    , sslMode = SslModeUnset
+    , sslRootCert = Nothing
     }
+
+
+-- WI-5 (#684) regression: the FileUpload state-store pool must run on the same
+-- TLS posture as the EventStore pool. 'toEventStoreConfig' is the production
+-- mapping that 'makeFileUploadConfig' / Application.run go through, so asserting
+-- the operator's pgSslMode/pgSslRootCert reach the inspectable ResolvedParams
+-- guards against a silent FileUpload TLS downgrade (ADR-0064). Pure: no DB.
+configFor :: SslMode -> Maybe Text -> PostgresEventStore
+configFor mode rootCert =
+  PostgresStateStore
+    { pgHost = "localhost"
+    , pgPort = 5432
+    , pgDatabase = "neohaskell"
+    , pgUser = "neohaskell"
+    , pgPassword = "neohaskell"
+    , pgSslMode = mode
+    , pgSslRootCert = rootCert
+    }
+    |> PostgresFileStore.toEventStoreConfig
+    |> Maybe.withDefault def
+
+
+paramsFor :: PostgresEventStore -> ConnectionParams
+paramsFor cfg =
+  ConnectionParams
+    { host = cfg.host
+    , databaseName = cfg.databaseName
+    , user = cfg.user
+    , password = cfg.password
+    , port = cfg.port
+    , sslMode = cfg.sslMode
+    , sslRootCert = cfg.sslRootCert
+    }
+
+
+sslThreadingSpec :: Spec Unit
+sslThreadingSpec =
+  describe "toEventStoreConfig (WI-5 #684 sslMode threading regression)" do
+    it "threads pgSslMode=Require into the resolved sslMode (FileUpload honours DB_SSL_MODE)" \_ -> do
+      let cfg = configFor SslModeRequire Nothing
+      cfg.sslMode |> shouldBe SslModeRequire
+      paramsFor cfg
+        |> ConnectionConfig.resolveParams
+        |> Result.map (\r -> r.sslMode)
+        |> shouldBe (Ok SslModeRequire)
+
+    it "threads pgSslMode=VerifyFull plus the root-cert path through unchanged" \_ -> do
+      let cfg = configFor SslModeVerifyFull (Just "/etc/postgresql/azure-roots.pem")
+      cfg.sslMode |> shouldBe SslModeVerifyFull
+      paramsFor cfg
+        |> ConnectionConfig.resolveParams
+        |> Result.map (\r -> r.sslRootCert)
+        |> shouldBe (Ok (Just "/etc/postgresql/azure-roots.pem"))
+
+    it "emits an sslmode param for Require (one entry past the unset baseline)" \_ -> do
+      paramsFor (configFor SslModeRequire Nothing)
+        |> ConnectionConfig.toConnectionParams
+        |> Result.map LinkedList.length
+        |> shouldBe (Ok 2)
+
+    it "emits NO sslmode param for SslModeUnset (default-off, no regression)" \_ -> do
+      paramsFor (configFor SslModeUnset Nothing)
+        |> ConnectionConfig.toConnectionParams
+        |> Result.map LinkedList.length
+        |> shouldBe (Ok 1)
 
 
 spec :: Spec Unit
 spec = do
+  sslThreadingSpec
   describe "PostgresFileStateStore" do
     -- Create store once per test. This follows the same pattern as
     -- Service.EventStore.PostgresSpec which also creates new stores per test.

--- a/docs/decisions/0064-optional-sslmode-tls-hardening.md
+++ b/docs/decisions/0064-optional-sslmode-tls-hardening.md
@@ -280,8 +280,23 @@ pins the no-regression guarantee for dev/CI.
 `PostgresEventStore` and `PostgresQueryObjectStoreConfig` each gain
 `sslMode :: SslMode` (default `SslModeUnset`) and `sslRootCert :: Maybe
 Text` (default `Nothing`) in their record and `Default` instance, and
-forward both into their `ConnectionParams` projection. Because FileUpload
-reuses `PostgresEventStore`, it inherits the field with no extra edit.
+forward both into their `ConnectionParams` projection.
+
+FileUpload required an explicit remediation here — its inheritance was
+**not** pristine. The FileUpload state-store pool is built from the
+*declarative* `FileStateStoreBackend` (`PostgresStateStore { … }`), which
+is a separate config record from `PostgresEventStore`. Before this change
+that record carried no TLS fields, so the FileUpload pool was assembled
+with libpq's default `prefer` regardless of the operator's `DB_SSL_MODE`:
+a **silent TLS downgrade** on every file operation while the EventStore
+and QueryObjectStore pools were correctly hardened. This PR closes that
+gap by adding `pgSslMode :: SslMode` / `pgSslRootCert :: Maybe Text` to
+`PostgresStateStore` and threading them through the shared
+`toEventStoreConfig` mapping into the `PostgresEventStore` ->
+`ConnectionParams` projection, so the FileUpload pool now honours the
+operator's mode exactly like the other two — all pools uniform, no silent
+downgrade.
+
 The LISTEN/NOTIFY one-off connections build their settings from the same
 `PostgresEventStore` via `toConnectionSettings`, so they are covered too.
 This is the ADR-0062 guarantee in action: one builder, every connection
@@ -313,17 +328,25 @@ ships the enum + parser, and the testbed demonstrates the env binding.
 ### 5. Module / file placement
 
 ```text
-core/service/Service/Infra/Postgres/ConnectionConfig.hs   -- add SslMode + sslModeToText; sslMode/sslRootCert on ConnectionParams + ResolvedParams; emit on the seam
+core/service/Service/Infra/Postgres/SslMode.hs            -- NEW Core-free leaf module: SslMode + sslModeToText + textToSslMode (imports only granular primitives, never Core)
+core/service/Service/Infra/Postgres/ConnectionConfig.hs   -- re-exports SslMode/sslModeToText/textToSslMode; adds sslMode/sslRootCert on ConnectionParams + ResolvedParams; emits on the seam
 core/service/Service/EventStore/Postgres/Internal.hs      -- PostgresEventStore gains defaulted sslMode/sslRootCert; toConnectionSettings forwards them
 core/service/Service/QueryObjectStore/Postgres.hs         -- PostgresQueryObjectStoreConfig gains defaulted fields; acquirePool forwards them
-core/service/Service/FileUpload/FileStateStore/Postgres.hs -- reuses PostgresEventStore; no field edit, projection picks the fields up
+core/service/Service/FileUpload/Core.hs                   -- declarative PostgresStateStore backend gains pgSslMode/pgSslRootCert
+core/service/Service/FileUpload/FileStateStore/Postgres.hs -- toEventStoreConfig threads pgSslMode/pgSslRootCert into the shared PostgresEventStore projection
 testbed/src/Testbed/Config.hs, testbed/src/App.hs         -- optional DB_SSL_MODE / DB_SSL_ROOT_CERT env binding, defaulted off
-core/nhcore.cabal                                         -- no new module; SslMode is exported from the existing ConnectionConfig module
+core/nhcore.cabal                                         -- registers the new Service.Infra.Postgres.SslMode module
 ```
 
-`SslMode` and `sslModeToText` are added to the existing
-`Service.Infra.Postgres.ConnectionConfig` export list — no new module,
-no new namespace.
+`SslMode`, `sslModeToText` and `textToSslMode` live in a **new** Core-free
+leaf module `Service.Infra.Postgres.SslMode` — they are *not* colocated in
+`ConnectionConfig`. The low-level `Service.FileUpload.Core` must carry an
+`SslMode` field on its declarative `PostgresStateStore` backend, and
+`ConnectionConfig` (which transitively pulls in `Core`) would have formed a
+`Core` <-> `FileUpload.Core` import cycle. The leaf module imports only
+granular primitives (never `Core`), breaking the cycle. The richer
+`Service.Infra.Postgres.ConnectionConfig` **re-exports** all three names, so
+existing call sites that import them from `ConnectionConfig` are unaffected.
 
 ### Performance & testing
 

--- a/docs/decisions/0064-optional-sslmode-tls-hardening.md
+++ b/docs/decisions/0064-optional-sslmode-tls-hardening.md
@@ -1,0 +1,472 @@
+# ADR-0064: Optional `sslmode` TLS Hardening for Postgres Connections
+
+> Issue: [#684 — WI-5: Optional `sslmode` TLS hardening for Postgres connections](https://github.com/neohaskell/NeoHaskell/issues/684)
+
+## Status
+
+Proposed
+
+## Context
+
+### Current State
+
+nhcore opens every Postgres connection through the single shared builder
+introduced by ADR-0062 (#681): all three pools (EventStore,
+QueryObjectStore, FileUpload) and the LISTEN/NOTIFY paths route their
+libpq parameters through
+`Service.Infra.Postgres.ConnectionConfig.toConnectionParams`. That builder
+emits `host`, `port`, `dbname`, `user`, `password`, and the four ADR-0037
+keepalive params — and **nothing about TLS**.
+
+With no `sslmode` set, libpq applies its compiled-in default
+`sslmode=prefer`: the client offers TLS, uses it if the server supports
+it, and **silently falls back to an unencrypted connection** if the
+server (or a man-in-the-middle) declines. Against Azure Database for
+PostgreSQL — Flexible Server (the epic #679 deploy target) and Neon, the
+default `prefer` already negotiates TLS, so **connectivity is not the
+problem**: the deployment connects today with zero TLS config.
+
+The gap is a *security-posture* one, not a connectivity one. `prefer`
+permits a **silent downgrade**: if the TLS negotiation is stripped (a
+mis-configured server, a downgrade attack on the path between the ACA
+container and Flexible Server), the connection proceeds in plaintext and
+the password plus all event data cross the wire unencrypted, with no
+error and no log line. Production hygiene wants `sslmode=require` (forbid
+the downgrade) or `sslmode=verify-full` (forbid the downgrade *and*
+authenticate the server against a trusted CA, defeating an active MITM).
+
+ADR-0062 deliberately **reserved the seam** for exactly this work: a
+single comment in `toConnectionParams` marks where one `Param.other
+"sslmode" "<mode>"` line lands, and the consequences section states that
+because there is only one builder, WI-5 "cannot add `sslmode` to one pool
+and not another." This ADR fills that seam.
+
+### Use Cases
+
+- **Production deploy forbids silent downgrade.** An operator deploying
+  to Flexible Server sets one env var (`DB_SSL_MODE=require`); every nhcore
+  Postgres connection now refuses to proceed unencrypted. A downgrade
+  attempt fails loudly at connect time instead of leaking plaintext.
+- **High-assurance deploy authenticates the server.** An operator who
+  also wants MITM protection sets `DB_SSL_MODE=verify-full` and points
+  `DB_SSL_ROOT_CERT` at a CA bundle (DigiCert Global Root G2 + Microsoft
+  RSA Root CA 2017 for Flexible Server). libpq then verifies the server
+  certificate chains to a trusted **root** and that the hostname matches.
+- **Localhost / dev is untouched.** A developer running `docker compose`
+  Postgres with no TLS sets nothing. The field defaults to off, libpq
+  keeps its `prefer` behaviour, and the local stack connects exactly as
+  before. No developer has to learn TLS to run the test suite.
+- **One knob, all pools.** Because the value threads through the single
+  ADR-0062 builder, setting it once applies it to the EventStore pool, the
+  QueryObjectStore pool, the FileUpload pool, and the LISTEN/NOTIFY
+  one-off connections uniformly — it is structurally impossible to harden
+  one pool and forget another.
+
+### Design Goals
+
+1. **Opt-in, default-off.** The hardening must default to "unset" so the
+   current dev and CI behaviour (no TLS against localhost) is byte-for-byte
+   preserved. Turning it on is a deliberate per-deployment choice.
+2. **One field, threaded through the one builder.** The mode is added as a
+   single optional input on `ConnectionParams`, resolved into
+   `ResolvedParams`, and emitted by `toConnectionParams` as one
+   conditional `Param.other "sslmode"` line — landing exactly on the seam
+   ADR-0062 reserved. All three pools get it because they all project into
+   `ConnectionParams`.
+3. **Server-auth only — never client certs.** Support `disable` / `allow`
+   / `prefer` / `require` / `verify-ca` / `verify-full`, plus the
+   `verify-full` companions `sslrootcert` (trust a CA bundle) and
+   `channel_binding`. **Do not** add `sslcert` / `sslkey`: Azure Database
+   for PostgreSQL does not support client-certificate (mTLS)
+   authentication, and supplying them breaks the connection. The hardening
+   authenticates the *server* to the *client*, not the reverse.
+4. **Root-only trust.** For `verify-full`, the `sslrootcert` bundle holds
+   **root** CAs only (DigiCert Global Root G2 + Microsoft RSA Root CA
+   2017), never an intermediate or the leaf server cert — Microsoft
+   rotates Flexible Server intermediate CAs on an ongoing basis, so
+   pinning an intermediate or the server cert would break on rotation.
+   This ADR encodes *which cert to trust* as operator guidance; the code
+   only forwards the path libpq reads.
+5. **Type-safe mode, no stringly-typed footgun.** The mode is a small
+   closed enum (`SslMode`), not a free `Text`, so a typo like
+   `"requre"` is a compile error in code and a single clean validation
+   error from the env string, not a libpq runtime surprise.
+6. **Jess-shaped.** A developer never needs this to build a side project
+   on localhost — the default hides it completely. An operator turns it on
+   with one documented env var whose values read in plain English
+   (`require`, `verify-full`).
+
+### GitHub Issue
+
+- [#684: WI-5 — Optional `sslmode` TLS hardening for Postgres connections](https://github.com/neohaskell/NeoHaskell/issues/684)
+- Parent epic: [#679 — Deploy-readiness on Azure Database for PostgreSQL Flexible Server](https://github.com/neohaskell/NeoHaskell/issues/679)
+
+## Decision drivers
+
+- **Silent downgrade is the actual risk.** `prefer` connects but does not
+  *guarantee* encryption; a stripped negotiation leaks the password and
+  every event in plaintext with no signal. `require`/`verify-full` turns
+  that silent failure into a loud connect-time refusal. This is good
+  production hygiene on a deploy target where the DB is reached over a
+  cloud network path the operator does not fully control.
+- **It must not regress dev.** localhost Postgres in `docker compose` has
+  no TLS. If the field were on by default, every contributor's test run
+  and the CI Postgres suites would fail to connect. Default-off is
+  non-negotiable; the issue's first acceptance criterion is "defaults
+  preserve current dev behavior."
+- **Client certs are a trap, not a feature.** Azure Flexible Server has no
+  mTLS; `sslcert`/`sslkey` would break the connection, not harden it. The
+  scope is deliberately server-auth only, and the type does not even
+  expose a client-cert field, so the footgun is unrepresentable.
+- **The seam already exists.** ADR-0062 shaped `toConnectionParams` so
+  this is one input field + one conditional `Param` line. Re-opening that
+  decision or adding a parallel builder would re-create the very drift
+  WI-2 removed. The cheapest correct move is to land on the reserved seam.
+- **Keep it invisible to Jess.** This is a deploy-tier knob. It adds an
+  *optional, defaulted* field — Jess who never sets it sees no change in
+  the `def { host = ..., ... }` construction she copy-pastes from the
+  EventStore docs.
+- **Root-only trust survives CA rotation.** Microsoft rotates Flexible
+  Server intermediate CAs; trusting roots only (and never pinning a
+  server/intermediate cert in code) is the configuration that keeps
+  working across those rotations. The code forwards a CA-bundle *path*; it
+  pins nothing itself.
+
+## Considered options
+
+### Option 1 — A typed `SslMode` enum field on each config, threaded through the seam (chosen)
+
+Add a closed enum to the shared infra module:
+
+```haskell
+-- | Optional libpq TLS negotiation mode. 'Default' is 'SslModeUnset',
+-- which emits no sslmode param so libpq keeps its compiled-in 'prefer'
+-- default -- localhost/dev without TLS is unchanged. Server-auth only:
+-- there is deliberately no client-cert (sslcert/sslkey) field, because
+-- Azure Flexible Server has no mTLS and supplying them breaks the
+-- connection (ADR-0064).
+data SslMode
+  = SslModeUnset        -- ^ no sslmode param; libpq default 'prefer'
+  | SslModeDisable      -- ^ sslmode=disable
+  | SslModeAllow        -- ^ sslmode=allow
+  | SslModePrefer       -- ^ sslmode=prefer (explicit)
+  | SslModeRequire      -- ^ sslmode=require -- forbids silent downgrade
+  | SslModeVerifyCa     -- ^ sslmode=verify-ca
+  | SslModeVerifyFull   -- ^ sslmode=verify-full -- forbids downgrade + MITM
+  deriving (Eq, Ord, Show)
+```
+
+Add an `sslMode :: SslMode` field (and an optional `sslRootCert :: Maybe
+Text` for the `verify-full` CA bundle path) to `ConnectionParams`,
+resolve it through `resolveParams` into `ResolvedParams`, and have
+`toConnectionParams` emit the params *only when set* on the reserved seam.
+Each pool config record (`PostgresEventStore`,
+`PostgresQueryObjectStoreConfig`) gains the matching defaulted fields and
+forwards them into its `ConnectionParams` projection; FileUpload reuses
+`PostgresEventStore` and is covered for free.
+
+- **Chosen.** Lands exactly on the ADR-0062 seam: one optional input, one
+  conditional `Param` line, all pools covered by construction. The closed
+  enum makes an invalid mode a compile error in code and a single clean
+  validation error from the env string, never a libpq runtime surprise.
+  The absence of any `sslcert`/`sslkey` field makes the Azure-breaking
+  mTLS footgun *unrepresentable*. Default `SslModeUnset` preserves dev
+  behaviour exactly.
+
+### Option 2 — A free-text `sslMode :: Maybe Text` field
+
+Thread a `Maybe Text` straight to `Param.other "sslmode"`.
+
+- Rejected. It is stringly-typed: `Just "requre"` or `Just "verifyfull"`
+  type-checks and only fails deep inside libpq at connect time, with a
+  message a junior operator cannot map back to a typo. It also leaves the
+  client-cert footgun open — nothing stops someone wiring a second
+  `Maybe Text` for `sslcert`. The closed enum (Option 1) costs a handful
+  of constructors and removes both hazards.
+
+### Option 3 — A single `requireTls :: Bool` flag
+
+Expose one boolean that maps `True -> sslmode=require`.
+
+- Rejected. It collapses the meaningful distinction between `require`
+  (encrypt, no MITM protection) and `verify-full` (encrypt + authenticate
+  the server), so the high-assurance deploy in the use-cases is
+  unreachable. The issue explicitly wants `verify-full` with an
+  `sslrootcert`, which a boolean cannot express. A boolean is *less* clear
+  to the operator, not more: "require TLS = true" hides that no server
+  authentication is happening.
+
+### Option 4 — Always send `sslmode=require` (no opt-out)
+
+Make `require` unconditional.
+
+- Rejected. It breaks every localhost/dev/CI Postgres that has no TLS —
+  directly violating the issue's "defaults preserve current dev behavior"
+  acceptance criterion. TLS hardening on the deploy target cannot be paid
+  for with a broken local development loop.
+
+| Option | Verdict | Reason |
+|--------|---------|--------|
+| 1. Typed `SslMode` enum on the seam | **Chosen** | Lands on the reserved ADR-0062 seam; closed enum kills the typo + mTLS footguns; default-off preserves dev. |
+| 2. Free-text `Maybe Text` | Rejected | Stringly-typed; typos surface only inside libpq; leaves the client-cert footgun open. |
+| 3. `requireTls :: Bool` | Rejected | Cannot express `verify-full` + `sslrootcert`; hides the require-vs-verify distinction. |
+| 4. Always `require` | Rejected | Breaks every no-TLS localhost/dev/CI Postgres; violates the default-preserving acceptance criterion. |
+
+## Decision outcome
+
+Adopt **Option 1**. Introduce a closed `SslMode` enum and an optional
+CA-bundle path in `Service.Infra.Postgres.ConnectionConfig`, thread both
+through the existing `ConnectionParams` → `resolveParams` →
+`ResolvedParams` → `toConnectionParams` path, and emit the libpq params on
+the seam ADR-0062 reserved. The default is `SslModeUnset` (off), so
+localhost/dev is unchanged. Server-auth only: no `sslcert`/`sslkey` field
+exists.
+
+### 1. The `SslMode` enum and the two new optional inputs
+
+`SslMode` (above) is added to the infra module. `ConnectionParams` gains
+two optional, defaulted inputs:
+
+```haskell
+data ConnectionParams = ConnectionParams
+  { host :: Text,
+    databaseName :: Text,
+    user :: Text,
+    password :: Text,
+    port :: Int,
+    -- WI-5 (#684): optional TLS hardening. 'SslModeUnset' (the default
+    -- the pool configs pass) emits no sslmode param, so libpq keeps its
+    -- 'prefer' default and localhost/dev is unchanged.
+    sslMode :: SslMode,
+    -- Optional CA-bundle path for 'verify-full' (root CAs only; never an
+    -- intermediate or server cert -- Microsoft rotates intermediates).
+    sslRootCert :: Maybe Text
+  }
+  deriving (Eq, Ord)
+```
+
+`ResolvedParams` carries the same two values through unchanged (it stays
+the inspectable mirror the unit spec asserts against), so a test can pin
+exactly which params each mode emits.
+
+### 2. `toConnectionParams` emits on the reserved seam
+
+The single conditional addition replaces the ADR-0062 placeholder comment
+(`-- WI-5 (#684) adds: Param.other "sslmode" "<mode>" here.`). The
+`sslmode` param is appended **only** when the mode is not `SslModeUnset`;
+`sslrootcert` and `channel_binding` are appended only for the
+verifying modes when a root cert is supplied:
+
+```haskell
+-- inside toConnectionParams, after the keepalive params:
+let sslParams = case resolved.sslMode of
+      SslModeUnset -> []   -- libpq keeps its 'prefer' default; dev unchanged
+      mode ->
+        [Param.other "sslmode" (sslModeToText mode)]
+          ++ rootCertParams resolved.sslRootCert
+```
+
+`sslModeToText` maps the enum to the libpq token (`SslModeRequire ->
+"require"`, `SslModeVerifyFull -> "verify-full"`, …) via `case ... of`.
+`rootCertParams` emits `Param.other "sslrootcert" <path>` (and, for
+channel-binding hardening, `Param.other "channel_binding" "require"`)
+when a path is present, and `[]` otherwise. **No branch ever emits
+`sslcert` or `sslkey`.** When the mode is `SslModeUnset` the emitted
+`Setting` list is byte-for-byte identical to today's, which is what
+pins the no-regression guarantee for dev/CI.
+
+### 3. The pool config records forward the field; all pools covered
+
+`PostgresEventStore` and `PostgresQueryObjectStoreConfig` each gain
+`sslMode :: SslMode` (default `SslModeUnset`) and `sslRootCert :: Maybe
+Text` (default `Nothing`) in their record and `Default` instance, and
+forward both into their `ConnectionParams` projection. Because FileUpload
+reuses `PostgresEventStore`, it inherits the field with no extra edit.
+The LISTEN/NOTIFY one-off connections build their settings from the same
+`PostgresEventStore` via `toConnectionSettings`, so they are covered too.
+This is the ADR-0062 guarantee in action: one builder, every connection
+hardened uniformly.
+
+### 4. App-layer config (env var), defaulted off
+
+The application config DSL gains optional fields so an operator can set
+the mode from the environment without touching code, defaulting to off:
+
+```haskell
+Config.field @Text "dbSslMode"
+  |> Config.doc "Postgres TLS mode: unset|disable|require|verify-full (default unset = libpq 'prefer'; localhost/dev needs nothing)"
+  |> Config.defaultsTo ("unset" :: Text)
+  |> Config.envVar "DB_SSL_MODE"
+Config.field @Text "dbSslRootCert"
+  |> Config.doc "Path to a root-CA bundle for verify-full (root CAs only)"
+  |> Config.defaultsTo ("" :: Text)
+  |> Config.envVar "DB_SSL_ROOT_CERT"
+```
+
+The `makePostgresConfig` factory parses the `Text` into `SslMode`
+(an unknown token is a single clean config error, not a libpq surprise)
+and an empty root-cert path into `Nothing`. The default `"unset"`
+threads to `SslModeUnset`, so an operator who sets nothing gets exactly
+today's behaviour. This wiring is reference-app glue in `testbed/`; nhcore
+ships the enum + parser, and the testbed demonstrates the env binding.
+
+### 5. Module / file placement
+
+```text
+core/service/Service/Infra/Postgres/ConnectionConfig.hs   -- add SslMode + sslModeToText; sslMode/sslRootCert on ConnectionParams + ResolvedParams; emit on the seam
+core/service/Service/EventStore/Postgres/Internal.hs      -- PostgresEventStore gains defaulted sslMode/sslRootCert; toConnectionSettings forwards them
+core/service/Service/QueryObjectStore/Postgres.hs         -- PostgresQueryObjectStoreConfig gains defaulted fields; acquirePool forwards them
+core/service/Service/FileUpload/FileStateStore/Postgres.hs -- reuses PostgresEventStore; no field edit, projection picks the fields up
+testbed/src/Testbed/Config.hs, testbed/src/App.hs         -- optional DB_SSL_MODE / DB_SSL_ROOT_CERT env binding, defaulted off
+core/nhcore.cabal                                         -- no new module; SslMode is exported from the existing ConnectionConfig module
+```
+
+`SslMode` and `sslModeToText` are added to the existing
+`Service.Infra.Postgres.ConnectionConfig` export list — no new module,
+no new namespace.
+
+### Performance & testing
+
+This is a startup-cold-path change: the `sslmode` param is appended once
+per pool when its connection settings are built, never per request or per
+event. There is no new hot-path allocation and no benchmark is required
+(tier: `simple`).
+
+Verification extends the existing pure unit spec at
+`core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs`
+(registered manually in `core/test-service/Main.hs`; runs with no
+Postgres). Asserted against the inspectable `ResolvedParams` (the opaque
+`hasql` `Setting` has no `Eq`/`Show`, exactly as ADR-0062 established):
+
+1. **Default is off (no regression)** — `resolveParams` with `sslMode =
+   SslModeUnset` carries `SslModeUnset` and `sslRootCert = Nothing`, and
+   `toConnectionParams` emits a `Setting` list equivalent to the
+   pre-WI-5 output (no `sslmode` param) — pinning the dev/CI no-change
+   guarantee.
+2. **`require` emits `sslmode=require`** — `resolveParams`/`ResolvedParams`
+   carries `SslModeRequire`, and `sslModeToText SslModeRequire == "require"`.
+3. **`verify-full` + root cert emits the verifying params** — with
+   `sslMode = SslModeVerifyFull` and `sslRootCert = Just "/etc/ca.pem"`,
+   the resolved params carry the mode and the cert path, and
+   `sslModeToText SslModeVerifyFull == "verify-full"`.
+4. **No client-cert param is ever emitted** — by construction (no
+   `sslcert`/`sslkey` field exists) and asserted at the `ResolvedParams`
+   surface: there is no client-cert value to inspect.
+5. **`sslModeToText` round-trips every constructor** — a table maps each
+   `SslMode` to its libpq token (`disable`/`allow`/`prefer`/`require`/
+   `verify-ca`/`verify-full`), guarding a future dropped/typo'd token.
+6. **Keepalives + no-regression carried** — the four ADR-0037 keepalive
+   asserts and the existing `validatePort` boundary asserts continue to
+   pass unchanged; the `sslMode` field is additive.
+
+## Public API
+
+The change adds **one exported enum** plus **optional, defaulted config
+fields** — nothing a developer who does not set them ever sees.
+
+```haskell
+-- New, exported from Service.Infra.Postgres.ConnectionConfig:
+data SslMode
+  = SslModeUnset | SslModeDisable | SslModeAllow | SslModePrefer
+  | SslModeRequire | SslModeVerifyCa | SslModeVerifyFull
+  deriving (Eq, Ord, Show)
+
+-- Unchanged for the developer who sets nothing -- the default off field
+-- is invisible in record construction:
+postgresEventStoreConfig :: PostgresEventStore
+postgresEventStoreConfig =
+  def { host = "...", databaseName = "...", user = "...", password = "..." }
+
+-- Opt-in hardening for a production deploy is one extra field:
+hardenedConfig :: PostgresEventStore
+hardenedConfig =
+  def
+    { host = "...", databaseName = "...", user = "...", password = "...",
+      sslMode = SslModeRequire
+    }
+
+-- Or, the env-driven path an operator actually uses (no code change):
+--   DB_SSL_MODE=verify-full
+--   DB_SSL_ROOT_CERT=/etc/postgresql/azure-roots.pem
+```
+
+The `def { host = ..., ... }` construction Jess copy-pastes from the
+EventStore docs is byte-for-byte unchanged: `sslMode` defaults to
+`SslModeUnset` and `sslRootCert` to `Nothing`. No `sslcert`/`sslkey`
+field is added anywhere.
+
+## Consequences
+
+### Positive
+
+1. **Silent downgrade can be forbidden.** Setting `sslMode =
+   SslModeRequire` (one field / one env var) makes every nhcore Postgres
+   connection refuse to proceed unencrypted, turning a silent plaintext
+   leak into a loud connect-time error.
+2. **MITM can be defeated.** `SslModeVerifyFull` + a root-CA bundle
+   authenticates the server, so an active man-in-the-middle cannot present
+   a forged cert.
+3. **One knob hardens every connection.** Because it threads through the
+   single ADR-0062 builder, the mode applies to all three pools and the
+   LISTEN/NOTIFY connections uniformly — it is structurally impossible to
+   harden one and forget another.
+4. **Dev is untouched.** The default `SslModeUnset` emits no `sslmode`
+   param; localhost/CI Postgres connects exactly as before. No contributor
+   has to learn TLS to run the suite.
+5. **The mTLS footgun is unrepresentable.** No `sslcert`/`sslkey` field
+   exists, so nobody can accidentally enable the client-cert auth that
+   breaks Azure Flexible Server.
+6. **Typos fail clean.** The closed `SslMode` enum makes an invalid mode a
+   compile error in code and one clear config error from the env string,
+   never a confusing libpq runtime failure.
+
+### Negative
+
+1. **Two optional fields are added to two config records.** A small,
+   additive surface increase (`sslMode`, `sslRootCert`). Both default off,
+   so existing call sites are unchanged, but the records are slightly
+   larger.
+2. **One new exported enum.** `SslMode` is new public surface, even though
+   the default path never requires touching it. This is the cost of a
+   typed mode over a stringly-typed `Maybe Text`.
+3. **Operator must supply the right CA bundle for `verify-full`.** The
+   code forwards a path; sourcing the DigiCert Global Root G2 + Microsoft
+   RSA Root CA 2017 bundle is operator responsibility, documented in the
+   deployment guide (WI-6, #685). A wrong/missing bundle fails the
+   connection at connect time (loud), not silently.
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Default accidentally ships as `require`, breaking dev/CI. | Default is `SslModeUnset` in both `Default` instances and the env default is `"unset"`; spec test 1 pins that the unset path emits no `sslmode` param and matches the pre-WI-5 output. |
+| A client-cert field creeps in and breaks Azure. | No `sslcert`/`sslkey` field exists in the type; spec test 4 asserts no client-cert param is emitted. The footgun is unrepresentable, not merely discouraged. |
+| `verify-full` pins an intermediate/server cert that breaks on Microsoft's CA rotation. | The code forwards a `sslrootcert` *path* only and pins nothing; the deployment guide (WI-6) specifies root CAs only (DigiCert Global Root G2 + Microsoft RSA Root CA 2017). |
+| A mode token typo reaches libpq. | The mode is the closed `SslMode` enum, not free text; `sslModeToText` is total over the enum and spec test 5 round-trips every constructor. The env parser rejects unknown tokens with one clean config error. |
+| One pool is hardened and another forgotten. | Impossible by construction: all pools project into the one `ConnectionParams` and route through the one `toConnectionParams`; FileUpload reuses `PostgresEventStore`. |
+
+### Mitigations
+
+- The default-off contract is encoded in the unit spec (test 1), so a
+  future edit that flips the default to a TLS-requiring mode fails CI
+  rather than silently breaking every contributor's local Postgres.
+- The "no client cert" contract is encoded both in the type (no field to
+  set) and in spec test 4, so an Azure-breaking mTLS attempt cannot land.
+- The `sslmode` emission is confined to the single seam in
+  `toConnectionParams` that ADR-0062 reserved; the existing keepalive and
+  `validatePort` asserts guard the rest of the builder across this change.
+- Root-only trust and the exact CA bundle are operator guidance carried
+  into the deployment guide (WI-6, #685); the code stays cert-agnostic
+  (forwards a path), so it survives Microsoft's intermediate-CA rotation.
+
+## References
+
+- [#684: WI-5 — Optional `sslmode` TLS hardening](https://github.com/neohaskell/NeoHaskell/issues/684)
+- [#679: Epic — Deploy-readiness on Azure Flexible Server](https://github.com/neohaskell/NeoHaskell/issues/679)
+- [ADR-0062: Single Shared Postgres Connection-Settings Builder](0062-shared-connection-settings-builder.md) — reserved the `sslmode` seam this ADR fills; one builder ⇒ all pools covered uniformly.
+- [ADR-0060: Explicit Postgres Connection-Pool Budget for Flexible Server B1ms](0060-postgres-pool-budget.md) — the `poolSize` fields the same config records carry; FileUpload shares `PostgresEventStore`.
+- [ADR-0037: PostgreSQL LISTEN Connection Keepalive and Reconnection](0037-postgres-listen-keepalive-reconnect.md) — the keepalive params the `sslmode` line sits alongside in `toConnectionParams`.
+- [ADR-0016: Redacted Type for Sensitive Data](0016-redacted-type-for-sensitive-data.md) — the secret-hygiene precedent; `sslmode`/`sslrootcert` are public, the existing password field stays the only secret.
+- [core/service/Service/Infra/Postgres/ConnectionConfig.hs](../../core/service/Service/Infra/Postgres/ConnectionConfig.hs) — the shared builder; the `-- WI-5 (#684) adds: Param.other "sslmode" "<mode>" here.` comment marks the seam.
+- [#644 — outbound-HTTP TLS](https://github.com/neohaskell/NeoHaskell/issues/644) — a separate TLS concern on the HTTP client path, explicitly **not** this work item.
+- [#685 — WI-6: Deployment documentation](https://github.com/neohaskell/NeoHaskell/issues/685) — captures the operator-facing `verify-full` CA-bundle guidance (root CAs only).

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -73,6 +73,7 @@ ADRs document significant architectural decisions made during the development of
 | [0061](0061-listener-reconnect-catchup.md) | Replay from Last globalPosition on LISTEN/NOTIFY Listener Reconnect | Proposed |
 | [0062](0062-shared-connection-settings-builder.md) | Single Shared Postgres Connection-Settings Builder | Proposed |
 | [0063](0063-per-stream-subscription-connection-release.md) | Release Per-Stream Subscription Connections on Unsubscribe | Proposed |
+| [0064](0064-optional-sslmode-tls-hardening.md) | Optional `sslmode` TLS Hardening for Postgres Connections | Proposed |
 
 ## Creating New ADRs
 

--- a/testbed/src/App.hs
+++ b/testbed/src/App.hs
@@ -4,6 +4,8 @@ import Core
 import Service.Application (Application, ApiInfo (..))
 import Service.Application qualified as Application
 import Service.EventStore.Postgres (PostgresEventStore (..))
+import Service.Infra.Postgres.ConnectionConfig (textToSslMode)
+import Text qualified
 import Service.FileUpload.Core (FileUploadConfig (..), FileStateStoreBackend (..))
 import Service.Transport.Web qualified as WebTransport
 import Testbed.Cart.Core (CartEntity)
@@ -69,7 +71,18 @@ makePostgresConfig config =
       host = config.dbHost,
       databaseName = config.dbName,
       port = config.dbPort,
-      poolSize = config.dbPoolSize
+      poolSize = config.dbPoolSize,
+      -- WI-5 (#684): parse DB_SSL_MODE; unknown tokens fail fast at startup
+      -- (ADR-0064 §4: "unknown token is a single clean config error").
+      -- makePostgresConfig is pure so we panic on Err — the error is caught
+      -- by Application.run before any connection is attempted.
+      sslMode = case textToSslMode config.dbSslMode of
+        Ok mode -> mode
+        Err e -> panic e,
+      -- WI-5 (#684): map "" (the Config default) to Nothing; any path -> Just path.
+      sslRootCert = case Text.isEmpty config.dbSslRootCert of
+        True -> Nothing
+        False -> Just config.dbSslRootCert
     }
 
 
@@ -87,6 +100,16 @@ makeFileUploadConfig config = FileUploadConfig
       , pgDatabase = config.dbName
       , pgUser = config.dbUser
       , pgPassword = config.dbPassword
+      -- WI-5 (#684): the FileUpload state-store pool MUST inherit the same
+      -- DB_SSL_MODE / DB_SSL_ROOT_CERT the EventStore pool gets, else file
+      -- operations silently downgrade TLS (ADR-0064). Parse identically to
+      -- makePostgresConfig so the operator path is uniform.
+      , pgSslMode = case textToSslMode config.dbSslMode of
+          Ok mode -> mode
+          Err e -> panic e
+      , pgSslRootCert = case Text.isEmpty config.dbSslRootCert of
+          True -> Nothing
+          False -> Just config.dbSslRootCert
       }
   , maxFileSizeBytes = 10485760  -- 10 MB
   , pendingTtlSeconds = 21600    -- 6 hours

--- a/testbed/src/App.hs
+++ b/testbed/src/App.hs
@@ -4,7 +4,7 @@ import Core
 import Service.Application (Application, ApiInfo (..))
 import Service.Application qualified as Application
 import Service.EventStore.Postgres (PostgresEventStore (..))
-import Service.Infra.Postgres.ConnectionConfig (textToSslMode)
+import Service.Infra.Postgres.ConnectionConfig qualified as ConnectionConfig
 import Text qualified
 import Service.FileUpload.Core (FileUploadConfig (..), FileStateStoreBackend (..))
 import Service.Transport.Web qualified as WebTransport
@@ -76,7 +76,7 @@ makePostgresConfig config =
       -- (ADR-0064 §4: "unknown token is a single clean config error").
       -- makePostgresConfig is pure so we panic on Err — the error is caught
       -- by Application.run before any connection is attempted.
-      sslMode = case textToSslMode config.dbSslMode of
+      sslMode = case ConnectionConfig.textToSslMode config.dbSslMode of
         Ok mode -> mode
         Err e -> panic e,
       -- WI-5 (#684): map "" (the Config default) to Nothing; any path -> Just path.
@@ -104,7 +104,7 @@ makeFileUploadConfig config = FileUploadConfig
       -- DB_SSL_MODE / DB_SSL_ROOT_CERT the EventStore pool gets, else file
       -- operations silently downgrade TLS (ADR-0064). Parse identically to
       -- makePostgresConfig so the operator path is uniform.
-      , pgSslMode = case textToSslMode config.dbSslMode of
+      , pgSslMode = case ConnectionConfig.textToSslMode config.dbSslMode of
           Ok mode -> mode
           Err e -> panic e
       , pgSslRootCert = case Text.isEmpty config.dbSslRootCert of

--- a/testbed/src/Testbed/Config.hs
+++ b/testbed/src/Testbed/Config.hs
@@ -50,6 +50,14 @@ defineConfig
       |> Config.doc "PostgreSQL connection-pool size for the EventStore (shared with FileUpload); must be > 0; see ADR-0060"
       |> Config.defaultsTo (6 :: Int)
       |> Config.envVar "DB_POOL_SIZE"
+  , Config.field @Text "dbSslMode"
+      |> Config.doc "Postgres TLS mode: unset|disable|allow|prefer|require|verify-ca|verify-full (default unset = libpq 'prefer'; localhost/dev needs nothing)"
+      |> Config.defaultsTo ("unset" :: Text)
+      |> Config.envVar "DB_SSL_MODE"
+  , Config.field @Text "dbSslRootCert"
+      |> Config.doc "Path to a root-CA bundle for verify-full (root CAs only; empty = none)"
+      |> Config.defaultsTo ("" :: Text)
+      |> Config.envVar "DB_SSL_ROOT_CERT"
   , Config.field @Int "httpPort"
       |> Config.doc "HTTP server port"
       |> Config.defaultsTo (8080 :: Int)


### PR DESCRIPTION
## Summary

WI-5 adds an **optional, default-off** way to harden the TLS posture of NeoHaskell's PostgreSQL connections. An operator sets one env var (`DB_SSL_MODE=require`, or `verify-full` plus `DB_SSL_ROOT_CERT`) and **every** connection pool — EventStore, QueryObjectStore, **and FileUpload** — negotiates TLS accordingly. Leave it unset and nothing changes: libpq keeps its built-in `prefer` default, so localhost/dev/CI connect exactly as before.

Classification tier: **simple** — an opt-in, pure config field threaded through the single ADR-0062 connection-builder seam. libpq performs the handshake, so there is no new IO path and no new dependency.

## ADR

Implements [ADR-0064 — Optional `sslmode` TLS hardening](docs/decisions/0064-optional-sslmode-tls-hardening.md) (approved).

## Changes

- **New `SslMode` enum + token mappings**, extracted into a small Core-free leaf module `Service.Infra.Postgres.SslMode` (`SslModeUnset | Disable | Allow | Prefer | Require | VerifyCa | VerifyFull`, plus `sslModeToText` / `textToSslMode`). `ConnectionConfig` re-exports all three, so existing call sites are untouched. The leaf module exists so the low-level `Service.FileUpload.Core` can carry an `SslMode` field without forming a `Core` ↔ `FileUpload` import cycle.
- **Threaded `sslMode` / `sslRootCert` through the ADR-0062 seam** (`ConnectionParams` → `ResolvedParams` → libpq settings). `SslModeUnset` emits **no** `sslmode` param (byte-identical to pre-WI-5); a set mode emits `sslmode=<token>`; `verify-full` with a root cert additionally emits `sslrootcert` and `channel_binding=require`. **Server-auth only** — no `sslcert`/`sslkey` is ever emitted (Azure Flexible Server has no mTLS).
- **FileUpload pool now honours the operator's sslmode** (closes the last review blocker). `FileStateStoreBackend.PostgresStateStore` gains `pgSslMode` / `pgSslRootCert`; a new pure `PostgresFileStore.toEventStoreConfig` builds the shared `PostgresEventStore` config the FileUpload pool runs on, and both `Application.run` and the testbed's `makeFileUploadConfig` go through it. The FileUpload pool can no longer silently downgrade TLS while the EventStore pool is hardened.
- **`SslMode` JSON instances** (token form) so the declarative config layer round-trips, and the FileUpload `ToJSON` now surfaces the two new (non-secret) fields.
- **Password hygiene:** `Show` dropped from `PostgresEventStore` and `PostgresQueryObjectStoreConfig` so a stray `show`/trace can never render the password field.

## Security

ADR security review (`findings-04`): **0 blockers** (4 findings, 1 kept as tracked framework-debt). Implementation security review (`findings-12`): **0 outstanding blockers** — all **3** original blockers resolved:

1. `Show` removed from `PostgresEventStore` (credential-leak).
2. `Show` removed from `PostgresQueryObjectStoreConfig` (credential-leak).
3. FileUpload pool ignored `DB_SSL_MODE` (silent TLS downgrade) — fixed via Option A (the `pgSslMode`/`pgSslRootCert` threading above), with a regression test.

Downgrade-prevention and default-off correctness are both asserted in the test suite.

## Performance

ADR performance review (`findings-05`): **0 findings**. Implementation performance review (`findings-13`): **0 blockers** (27 informational items demoted — all pre-existing cold-path `fmt`/startup-parse, none in a request hot path). The unset default emits a byte-identical settings list, so the 50k req/s budget is unaffected.

## Tests

Full suite green (`cabal test all -j1`, Postgres live):

| Suite | Result |
|---|---|
| `nhcore-test` | 1690 examples, **0 failures** (6 pending) |
| `nhcore-test-auth` | 189 examples, **0 failures** |
| `nhcore-test-core` | 1061 examples, **0 failures** (3 pending) |
| `nhcore-test-integration` | 70 examples, **0 failures** (4 pending) |
| `nhcore-test-service` | 1013 examples, **0 failures** (57 pending) |
| `nhintegrations-test` | 444 examples, **0 failures** (3 pending) |
| `neohaskell-lsp-test` | 3 examples, **0 failures** |

Coverage includes the 26 ConnectionConfig TLS cases (every `SslMode` token, round-trip, settings-length boundaries, no-mTLS-by-construction) and the **new FileUpload TLS regression** — `PostgresStateStore { pgSslMode = Require }` resolves to a `ResolvedParams` carrying `sslMode`, `verify-full` carries the root-cert path, and `SslModeUnset` emits no `sslmode` param.

## Hlint

Hlint clean (`No hints`) on all changed files.

## Checklist

- [x] ADR approved (phase 3)
- [x] Security findings grounded — 0 blockers (`findings-04`, `findings-12`)
- [x] Performance findings grounded — 0 blockers (`findings-05`, `findings-13`)
- [x] Tests passing — build + `cabal test all -j1` green, 0 failures across all suites
- Hlint: clean ✓

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional PostgreSQL TLS/SSL configuration support across database connections and file upload storage.
  * Introduced configurable SSL modes and optional root certificate settings, with new environment-based testbed options.

* **Bug Fixes**
  * Improved consistency so TLS settings are threaded through all relevant PostgreSQL-backed services.
  * Reduced risk of mismatched connection behavior by validating SSL mode values at startup.

* **Documentation**
  * Added release notes for the new PostgreSQL TLS hardening option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->