### PR TITLE
fix(service): non-unset sslMode no longer drops the Postgres host param (#694)

### DIFF
--- a/core/service/Service/Infra/Postgres/ConnectionConfig.hs
+++ b/core/service/Service/Infra/Postgres/ConnectionConfig.hs
@@ -6,6 +6,7 @@ module Service.Infra.Postgres.ConnectionConfig (
   sslModeToText,
   textToSslMode,
   resolveParams,
+  toParamPairs,
   toConnectionParams,
   toPoolConfig,
   logPoolObservation,
@@ -22,6 +23,7 @@ import Hasql.Connection.Setting.Connection.Param qualified as Param
 import Hasql.Pool.Config (Config)
 import Hasql.Pool.Config qualified as HasqlPoolConfig
 import Hasql.Pool.Observation (ConnectionStatus (..), ConnectionTerminationReason (..), Observation (..))
+import LinkedList qualified
 import Log qualified
 import Result qualified
 import Task qualified
@@ -114,73 +116,105 @@ resolveParams cfg =
         }
 
 
--- | Conditional TLS 'Setting' list appended after the keepalive Setting.
+-- | The base libpq (key, value) params every pool always sends: the five
+-- connection coordinates plus the four ADR-0037 keepalive entries. Plain
+-- inspectable data (see 'toParamPairs').
+baseParamPairs :: ResolvedParams -> LinkedList (Text, Text)
+baseParamPairs resolved =
+  [ ("host", resolved.host),
+    ("port", portToText resolved.port),
+    ("dbname", resolved.databaseName),
+    ("user", resolved.user),
+    ("password", resolved.password),
+    -- TCP keepalive: detect dead connections in cloud environments
+    -- (ADR-0037, #397) -- on ALL three pools.
+    ("keepalives", resolved.keepalives),
+    ("keepalives_idle", resolved.keepalivesIdle),
+    ("keepalives_interval", resolved.keepalivesInterval),
+    ("keepalives_count", resolved.keepalivesCount)
+  ]
+
+
+-- | Render the validated port to its libpq decimal text form. A standalone
+-- helper so the 'fmt' splice only ever sees a bare variable -- the quasiquoter
+-- does not parse a 'resolved.port' record-dot accessor (OverloadedRecordDot).
+portToText :: Word16 -> Text
+portToText p = [fmt|#{p}|]
+
+
+-- | Conditional TLS (key, value) params appended AFTER the base params.
 -- Returns [] for 'SslModeUnset' (byte-identical to pre-WI-5 — the dev/CI
 -- no-regression guarantee, ADR-0064 §2). For any set mode it emits the
--- sslmode param as its own Setting; for a verifying mode WITH a root cert it
--- additionally emits sslrootcert (and for verify-full: channel_binding=require)
--- each as their own Setting. NEVER emits sslcert/sslkey (ADR-0064 §3).
-sslParams :: ResolvedParams -> LinkedList Setting
-sslParams resolved =
+-- sslmode param; for a verifying mode WITH a root cert it additionally emits
+-- sslrootcert (and for verify-full: channel_binding=require). NEVER emits
+-- sslcert/sslkey (ADR-0064 §3).
+sslParamPairs :: ResolvedParams -> LinkedList (Text, Text)
+sslParamPairs resolved =
   case sslModeToText resolved.sslMode of
     Nothing -> []
     Just token ->
-      paramSetting (Param.other "sslmode" token) : rootCertParams resolved.sslMode resolved.sslRootCert
+      ("sslmode", token) : rootCertParamPairs resolved.sslMode resolved.sslRootCert
 
 
--- | The verifying-mode companion Settings. 'sslrootcert' is emitted ONLY for
--- the verifying modes ('SslModeVerifyCa' / 'SslModeVerifyFull') and only when a
+-- | The verifying-mode companion params. 'sslrootcert' is emitted ONLY for the
+-- verifying modes ('SslModeVerifyCa' / 'SslModeVerifyFull') and only when a
 -- root cert path is supplied — a root cert is meaningless for the non-verifying
 -- modes ('disable'/'allow'/'prefer'/'require'), so it is NEVER sent for them
 -- even if the environment provides a path (ADR-0064 §3). 'verify-full'
 -- additionally emits channel_binding=require. Forwards a PATH only — pins no
 -- cert (ADR-0064 §"Root-only trust"). NEVER emits sslcert/sslkey.
-rootCertParams :: SslMode -> Maybe Text -> LinkedList Setting
-rootCertParams mode maybeRootCert =
+rootCertParamPairs :: SslMode -> Maybe Text -> LinkedList (Text, Text)
+rootCertParamPairs mode maybeRootCert =
   case (mode, maybeRootCert) of
     (SslModeVerifyCa, Just path) ->
-      [paramSetting (Param.other "sslrootcert" path)]
+      [("sslrootcert", path)]
     (SslModeVerifyFull, Just path) ->
-      [ paramSetting (Param.other "sslrootcert" path),
-        paramSetting (Param.other "channel_binding" "require")
+      [ ("sslrootcert", path),
+        ("channel_binding", "require")
       ]
     _ ->
       []
 
 
--- | Wrap a single 'Param.Param' into a 'Setting' so ssl params are individual
--- list entries (each adds 1 to 'LinkedList.length', making the length assertions
--- in the spec numerically meaningful).
-paramSetting :: Param.Param -> Setting
-paramSetting p =
-  ConnectionSettingConnection.params [p]
-    |> ConnectionSetting.connection
+-- | The complete, ORDERED libpq (key, value) parameter set — base params first,
+-- then any conditional TLS params — that the single connection 'Setting' is
+-- built from (ADR-0062 section 2). Carries the four ADR-0037 keepalives for
+-- every pool and fails fast on an out-of-range port (see 'validatePort').
+--
+-- Exposed as plain inspectable data because the hasql 'Param'/'Setting' types
+-- are opaque (no Eq/Show) and the modules that render them to a connection
+-- string are internal to hasql, so this is the ONLY place a test can assert the
+-- exact params — including that 'host' survives a set sslMode (the #694
+-- regression) and that no sslcert/sslkey ever leaks in (ADR-0064 §3).
+toParamPairs :: ConnectionParams -> Result Text (LinkedList (Text, Text))
+toParamPairs cfg =
+  cfg
+    |> resolveParams
+    |> Result.map \resolved -> baseParamPairs resolved ++ sslParamPairs resolved
 
 
 -- | The single place libpq connection params are constructed (ADR-0062
--- section 2). Carries the four ADR-0037 keepalives for every pool and fails
--- fast on an out-of-range port (see 'validatePort'). Returns a 'Result' so
--- the three pools surface the typed error in their own error channel.
+-- section 2). Returns a 'Result' so the three pools surface the typed error in
+-- their own error channel.
+--
+-- Every param — base AND the conditional TLS params — goes into ONE
+-- 'ConnectionSettingConnection.params', i.e. a SINGLE 'ConnectionSetting.connection'
+-- (#694). hasql's 'Hasql.Pool.Config.staticConnectionSettings' applies each
+-- 'ConnectionSetting.connection' by REPLACING the whole connection string
+-- (last-wins, not merge), so emitting the TLS params as a second connection
+-- Setting silently dropped host/port/dbname and libpq fell back to the local
+-- Unix socket. Returning a one-element list keeps the 'LinkedList Setting'
+-- shape every pool already threads through 'toPoolConfig'.
 toConnectionParams :: ConnectionParams -> Result Text (LinkedList Setting)
 toConnectionParams cfg =
   cfg
-    |> resolveParams
-    |> Result.map \resolved -> do
-      let baseParams =
-            [ Param.host resolved.host,
-              Param.port resolved.port,
-              Param.dbname resolved.databaseName,
-              Param.user resolved.user,
-              Param.password resolved.password,
-              Param.other "keepalives" resolved.keepalives,
-              Param.other "keepalives_idle" resolved.keepalivesIdle,
-              Param.other "keepalives_interval" resolved.keepalivesInterval,
-              Param.other "keepalives_count" resolved.keepalivesCount
-            ]
-      let baseSetting =
-            ConnectionSettingConnection.params baseParams
-              |> ConnectionSetting.connection
-      baseSetting : sslParams resolved
+    |> toParamPairs
+    |> Result.map \pairs ->
+      [ pairs
+          |> LinkedList.map (\(key, value) -> Param.other key value)
+          |> ConnectionSettingConnection.params
+          |> ConnectionSetting.connection
+      ]
 
 
 -- | The single place 'Hasql.Pool.Config' is constructed (ADR-0062 section 3).

--- a/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
+++ b/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
@@ -412,27 +412,33 @@ spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
       let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsRemoteHost SslModeVerifyFull))
       (pairs |> Prelude.elem ("host", "db.example.com")) |> Hspec.shouldBe True
 
-    Hspec.it "keeps every base coordinate (host/port/dbname/user/password) for EVERY sslMode -- table sweep" do
-      let modes :: [SslMode]
-          modes =
-            [ SslModeUnset,
-              SslModeDisable,
-              SslModeAllow,
-              SslModePrefer,
-              SslModeRequire,
-              SslModeVerifyCa,
-              SslModeVerifyFull
+    Hspec.it "keeps every base coordinate (host/port/dbname/user/password) for EVERY sslMode -- table sweep over both the no-CA and hardened CA-bundle paths" do
+      -- Covers BOTH the no-CA path (every mode, sslRootCert = Nothing) AND the
+      -- deployed hardened path where verify-ca/verify-full append sslrootcert
+      -- (and verify-full also channel_binding) -- exactly the case that must
+      -- still carry host/port/dbname/user/password and not push them out (#694).
+      let cases :: [(SslMode, Maybe Text)]
+          cases =
+            [ (SslModeUnset, Nothing),
+              (SslModeDisable, Nothing),
+              (SslModeAllow, Nothing),
+              (SslModePrefer, Nothing),
+              (SslModeRequire, Nothing),
+              (SslModeVerifyCa, Nothing),
+              (SslModeVerifyFull, Nothing),
+              (SslModeVerifyCa, Just "/etc/ca.pem"),
+              (SslModeVerifyFull, Just "/etc/ca.pem")
             ]
       let baseKeys :: [Text]
           baseKeys = ["host", "port", "dbname", "user", "password"]
-      let allModesKeepBase =
-            modes
+      let allCasesKeepBase =
+            cases
               |> Prelude.all
-                ( \mode -> do
-                    let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl mode Nothing))
+                ( \(mode, rootCert) -> do
+                    let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl mode rootCert))
                     baseKeys |> Prelude.all (\k -> hasKey k pairs)
                 )
-      allModesKeepBase |> Hspec.shouldBe True
+      allCasesKeepBase |> Hspec.shouldBe True
 
   Hspec.describe "toParamPairs (additive sslMode/sslRootCert)" do
     Hspec.it "with SslModeUnset emits exactly the base params and NO ssl params (byte-identical no-regression baseline)" do

--- a/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
+++ b/core/test-service/Service/Infra/Postgres/ConnectionConfigSpec.hs
@@ -99,6 +99,39 @@ lengthOfOk result =
     Ok xs -> LinkedList.length xs
     Err e -> Prelude.error (Prelude.show e)
 
+
+-- | Extract the Ok (key, value) param-pair list, failing hard on Err. The pairs
+-- have Eq/Show (unlike the opaque hasql Setting), so the contract can be
+-- asserted exactly -- which key/value pairs are present, and which are NOT.
+pairsOfOk :: Result Text (LinkedList (Text, Text)) -> LinkedList (Text, Text)
+pairsOfOk result =
+  case result of
+    Ok pairs -> pairs
+    Err e -> Prelude.error (Prelude.show e)
+
+
+-- | True when the (key, value) pair list contains the given key (value
+-- ignored) -- used to assert presence/absence of a param by name.
+hasKey :: Text -> LinkedList (Text, Text) -> Bool
+hasKey key pairs =
+  pairs |> Prelude.any (\(k, _) -> k Prelude.== key)
+
+
+-- | A remote-host config mirroring the #694 reproduction: a non-localhost host
+-- that the bug silently replaced with the local Unix-socket default. Full
+-- record construction for the same disambiguation reason as 'paramsWithPort'.
+paramsRemoteHost :: ConnectionConfig.SslMode -> ConnectionParams
+paramsRemoteHost mode =
+  ConnectionConfig.ConnectionParams
+    { host = "db.example.com",
+      databaseName = "app",
+      user = "postgres",
+      password = "secret",
+      port = 5432,
+      sslMode = mode,
+      sslRootCert = Nothing
+    }
+
 spec :: Hspec.Spec
 spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
   Hspec.describe "validatePort" do
@@ -181,6 +214,41 @@ spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
       ConnectionConfig.resolveParams (paramsWithPort 65536)
         |> Result.isErr
         |> Hspec.shouldBe True
+
+  Hspec.describe "toConnectionParams (#694 regression: one connection setting)" do
+    -- #694: hasql's 'staticConnectionSettings' applies every
+    -- 'ConnectionSetting.connection' by REPLACING the whole connection string
+    -- (last-wins). Emitting the TLS params as a SEPARATE connection Setting
+    -- therefore silently dropped host/port/dbname and libpq fell back to the
+    -- local Unix socket. The contract is now: ALL params live in exactly ONE
+    -- connection Setting, so the list length is 1 for EVERY sslMode -- never
+    -- 2+, which is the smoking gun of the host-dropping bug.
+    Hspec.it "emits exactly ONE connection setting for SslModeRequire (a 2nd would drop host via last-wins)" do
+      case ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing) of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok settings -> (settings |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "emits exactly ONE connection setting for verify-full + rootCert (sslmode+sslrootcert+channel_binding must not split it)" do
+      case ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")) of
+        Err err -> Prelude.error (Prelude.show err)
+        Ok settings -> (settings |> LinkedList.length) |> Hspec.shouldBe 1
+
+    Hspec.it "emits exactly ONE connection setting for EVERY SslMode (table sweep: none may add a host-dropping 2nd setting)" do
+      let modes :: [SslMode]
+          modes =
+            [ SslModeUnset,
+              SslModeDisable,
+              SslModeAllow,
+              SslModePrefer,
+              SslModeRequire,
+              SslModeVerifyCa,
+              SslModeVerifyFull
+            ]
+      let allSingle =
+            modes
+              |> Prelude.all
+                (\m -> lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl m (Just "/etc/ca.pem"))) Prelude.== 1)
+      allSingle |> Hspec.shouldBe True
 
   Hspec.describe "toConnectionParams" do
     Hspec.it "returns a single connection setting for a typical config" do
@@ -331,63 +399,110 @@ spec = Hspec.describe "Service.Infra.Postgres.ConnectionConfig" do
         Ok r ->
           r.sslRootCert |> Hspec.shouldBe Nothing
 
-  Hspec.describe "toConnectionParams (additive sslMode/sslRootCert)" do
-    Hspec.it "with SslModeRequire produces an Ok settings list one entry longer than the unset baseline" do
-      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
-      let reqLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
-      reqLen |> Hspec.shouldBe (baseLen + 1)
+  Hspec.describe "toParamPairs (#694: base params survive every sslMode)" do
+    -- The smoking gun of #694: with a set sslMode, the host/port/dbname/user/
+    -- password coordinates were dropped and libpq fell back to the local Unix
+    -- socket. The whole base set must now ride in the SAME param list as the
+    -- TLS params, so every base coordinate is present for EVERY mode.
+    Hspec.it "keeps the remote host param under SslModeRequire (the exact param #694 dropped)" do
+      let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsRemoteHost SslModeRequire))
+      (pairs |> Prelude.elem ("host", "db.example.com")) |> Hspec.shouldBe True
 
-    Hspec.it "with SslModeUnset emits the same settings-list length as the pre-WI-5 baseline (no regression)" do
-      case ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing) of
-        Err err -> Prelude.error (Prelude.show err)
-        Ok settings -> (settings |> LinkedList.length) |> Hspec.shouldBe 1
+    Hspec.it "keeps the remote host param under SslModeVerifyFull" do
+      let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsRemoteHost SslModeVerifyFull))
+      (pairs |> Prelude.elem ("host", "db.example.com")) |> Hspec.shouldBe True
 
-    Hspec.it "with SslModeVerifyFull + Just rootCert produces a list longer than require alone (sslmode + sslrootcert + channel_binding)" do
-      let reqLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
-      let vfLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")))
-      (vfLen Prelude.> reqLen) |> Hspec.shouldBe True
+    Hspec.it "keeps every base coordinate (host/port/dbname/user/password) for EVERY sslMode -- table sweep" do
+      let modes :: [SslMode]
+          modes =
+            [ SslModeUnset,
+              SslModeDisable,
+              SslModeAllow,
+              SslModePrefer,
+              SslModeRequire,
+              SslModeVerifyCa,
+              SslModeVerifyFull
+            ]
+      let baseKeys :: [Text]
+          baseKeys = ["host", "port", "dbname", "user", "password"]
+      let allModesKeepBase =
+            modes
+              |> Prelude.all
+                ( \mode -> do
+                    let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl mode Nothing))
+                    baseKeys |> Prelude.all (\k -> hasKey k pairs)
+                )
+      allModesKeepBase |> Hspec.shouldBe True
 
-    Hspec.it "with SslModeVerifyFull but Nothing rootCert emits no sslrootcert (boundary: empty cert path)" do
-      let reqLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
-      let vfLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull Nothing))
-      vfLen |> Hspec.shouldBe reqLen
+  Hspec.describe "toParamPairs (additive sslMode/sslRootCert)" do
+    Hspec.it "with SslModeUnset emits exactly the base params and NO ssl params (byte-identical no-regression baseline)" do
+      let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl SslModeUnset Nothing))
+      pairs
+        |> Hspec.shouldBe
+          [ ("host", "localhost"),
+            ("port", "5432"),
+            ("dbname", "app"),
+            ("user", "postgres"),
+            ("password", "secret"),
+            ("keepalives", "1"),
+            ("keepalives_idle", "30"),
+            ("keepalives_interval", "10"),
+            ("keepalives_count", "5")
+          ]
 
-    Hspec.it "emits exactly base + sslmode + sslrootcert + channel_binding for verify-full + cert (observes the EMITTED settings: no sslcert/sslkey leaks in)" do
-      -- The opaque hasql Setting list has no Eq/Show, so observe the emitted
-      -- OUTPUT by count rather than just the resolved params: the unset
-      -- baseline is 1 (the single base Setting), and verify-full WITH a root
-      -- cert must add exactly 3 -- sslmode, sslrootcert, channel_binding. A
-      -- leaked sslcert/sslkey client-cert param would push the count past
-      -- baseLen + 3, so this pins the no-mTLS guarantee on the emitted Setting
-      -- list, not merely on the inspectable ResolvedParams.
-      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
-      let vfLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")))
-      vfLen |> Hspec.shouldBe (baseLen + 3)
+    Hspec.it "with SslModeRequire appends sslmode=require after the base params (and nothing else)" do
+      let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl SslModeRequire Nothing))
+      pairs
+        |> Hspec.shouldBe
+          [ ("host", "localhost"),
+            ("port", "5432"),
+            ("dbname", "app"),
+            ("user", "postgres"),
+            ("password", "secret"),
+            ("keepalives", "1"),
+            ("keepalives_idle", "30"),
+            ("keepalives_interval", "10"),
+            ("keepalives_count", "5"),
+            ("sslmode", "require")
+          ]
 
-    Hspec.it "emits sslrootcert but NOT channel_binding for verify-ca + cert (channel_binding is verify-full only)" do
-      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
-      let verifyCaLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeVerifyCa (Just "/etc/ca.pem")))
-      verifyCaLen |> Hspec.shouldBe (baseLen + 2)
+    Hspec.it "with SslModeVerifyFull + cert emits exactly sslmode + sslrootcert + channel_binding and NO sslcert/sslkey (no-mTLS guarantee, ADR-0064 §3)" do
+      let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl SslModeVerifyFull (Just "/etc/ca.pem")))
+      (pairs |> Prelude.elem ("sslmode", "verify-full")) |> Hspec.shouldBe True
+      (pairs |> Prelude.elem ("sslrootcert", "/etc/ca.pem")) |> Hspec.shouldBe True
+      (pairs |> Prelude.elem ("channel_binding", "require")) |> Hspec.shouldBe True
+      (pairs |> hasKey "sslcert") |> Hspec.shouldBe False
+      (pairs |> hasKey "sslkey") |> Hspec.shouldBe False
+
+    Hspec.it "with SslModeVerifyFull but Nothing rootCert emits sslmode only -- no sslrootcert, no channel_binding (boundary: empty cert path)" do
+      let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl SslModeVerifyFull Nothing))
+      (pairs |> Prelude.elem ("sslmode", "verify-full")) |> Hspec.shouldBe True
+      (pairs |> hasKey "sslrootcert") |> Hspec.shouldBe False
+      (pairs |> hasKey "channel_binding") |> Hspec.shouldBe False
+
+    Hspec.it "with SslModeVerifyCa + cert emits sslrootcert but NOT channel_binding (channel_binding is verify-full only)" do
+      let pairs = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl SslModeVerifyCa (Just "/etc/ca.pem")))
+      (pairs |> Prelude.elem ("sslrootcert", "/etc/ca.pem")) |> Hspec.shouldBe True
+      (pairs |> hasKey "channel_binding") |> Hspec.shouldBe False
 
     Hspec.it "does NOT emit sslrootcert for a non-verifying mode even when a cert path is supplied (verify-only gating)" do
-      -- 'require' is non-verifying: a root cert is meaningless, so the emitted
-      -- settings for require+cert must equal require+no-cert (sslmode only).
-      let reqNoCert = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire Nothing))
-      let reqWithCert = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeRequire (Just "/etc/ca.pem")))
+      -- 'require' is non-verifying: a root cert is meaningless, so require+cert
+      -- must equal require+no-cert (sslmode only).
+      let reqWithCert = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl SslModeRequire (Just "/etc/ca.pem")))
+      let reqNoCert = pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl SslModeRequire Nothing))
       reqWithCert |> Hspec.shouldBe reqNoCert
+      (reqWithCert |> hasKey "sslrootcert") |> Hspec.shouldBe False
 
     Hspec.it "ignores a root cert for every non-verifying mode (disable/allow/prefer/require) -- table sweep of the verify-only gate" do
-      let baseLen = lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl SslModeUnset Nothing))
       let nonVerifying :: [SslMode]
           nonVerifying = [SslModeDisable, SslModeAllow, SslModePrefer, SslModeRequire]
-      let allIgnoreCert =
+      let noneEmitRootCert =
             nonVerifying
               |> Prelude.all
                 ( \mode ->
-                    lengthOfOk (ConnectionConfig.toConnectionParams (paramsWithSsl mode (Just "/etc/ca.pem")))
-                      Prelude.== (baseLen + 1)
+                    Prelude.not (hasKey "sslrootcert" (pairsOfOk (ConnectionConfig.toParamPairs (paramsWithSsl mode (Just "/etc/ca.pem")))))
                 )
-      allIgnoreCert |> Hspec.shouldBe True
+      noneEmitRootCert |> Hspec.shouldBe True
 
   Hspec.describe "textToSslMode / sslModeToText round-trip" do
     Hspec.it "round-trips every token-bearing SslMode: parse (toText m) back to Ok m" do

--- a/core/test/Service/FileUpload/FileStateStore/PostgresSpec.hs
+++ b/core/test/Service/FileUpload/FileStateStore/PostgresSpec.hs
@@ -90,17 +90,27 @@ sslThreadingSpec =
         |> Result.map (\r -> r.sslRootCert)
         |> shouldBe (Ok (Just "/etc/postgresql/azure-roots.pem"))
 
-    it "emits an sslmode param for Require (one entry past the unset baseline)" \_ -> do
+    it "threads sslmode=require into the single connection setting for Require (#694: ONE setting, never 2)" \_ -> do
+      -- #694: the TLS params must ride INSIDE the one connection setting, not a
+      -- second one (a 2nd 'ConnectionSetting.connection' makes hasql drop the
+      -- host via last-wins). So the setting count is 1 for Require, same as the
+      -- unset baseline -- the sslmode now lives in the shared param list.
       paramsFor (configFor SslModeRequire Nothing)
         |> ConnectionConfig.toConnectionParams
         |> Result.map LinkedList.length
-        |> shouldBe (Ok 2)
+        |> shouldBe (Ok 1)
+
+    it "carries the sslmode=require param through FileUpload's threading (asserted on the inspectable pairs)" \_ -> do
+      paramsFor (configFor SslModeRequire Nothing)
+        |> ConnectionConfig.toParamPairs
+        |> Result.map (LinkedList.any (\(k, v) -> k == "sslmode" && v == "require"))
+        |> shouldBe (Ok True)
 
     it "emits NO sslmode param for SslModeUnset (default-off, no regression)" \_ -> do
       paramsFor (configFor SslModeUnset Nothing)
-        |> ConnectionConfig.toConnectionParams
-        |> Result.map LinkedList.length
-        |> shouldBe (Ok 1)
+        |> ConnectionConfig.toParamPairs
+        |> Result.map (LinkedList.any (\(k, _) -> k == "sslmode"))
+        |> shouldBe (Ok False)
 
 
 spec :: Spec Unit

--- a/core/test/Service/FileUpload/FileStateStore/PostgresSpec.hs
+++ b/core/test/Service/FileUpload/FileStateStore/PostgresSpec.hs
@@ -106,6 +106,20 @@ sslThreadingSpec =
         |> Result.map (LinkedList.any (\(k, v) -> k == "sslmode" && v == "require"))
         |> shouldBe (Ok True)
 
+    it "threads verify-full + sslrootcert + channel_binding through FileUpload's config bridge (hardened path keeps the CA bundle)" \_ -> do
+      -- Guards 'toEventStoreConfig' against silently dropping pgSslRootCert: the
+      -- full hardened posture (sslmode + sslrootcert + channel_binding) must
+      -- survive the FileUpload mapping, not just the sslmode knob.
+      paramsFor (configFor SslModeVerifyFull (Just "/etc/ca.pem"))
+        |> ConnectionConfig.toParamPairs
+        |> Result.map
+          ( \pairs ->
+              LinkedList.any (\(k, v) -> k == "sslmode" && v == "verify-full") pairs
+                && LinkedList.any (\(k, v) -> k == "sslrootcert" && v == "/etc/ca.pem") pairs
+                && LinkedList.any (\(k, v) -> k == "channel_binding" && v == "require") pairs
+          )
+        |> shouldBe (Ok True)
+
     it "emits NO sslmode param for SslModeUnset (default-off, no regression)" \_ -> do
       paramsFor (configFor SslModeUnset Nothing)
         |> ConnectionConfig.toParamPairs


### PR DESCRIPTION
## Summary

Fixes #694. Setting a non-`unset` Postgres TLS mode (`DB_SSL_MODE=require`, or any `SslMode` other than `SslModeUnset`) silently **dropped the `host`/`port`/`dbname` params** and libpq fell back to the local Unix socket, so the app failed to start against a remote host:

```
TableInitializationError "ConnectionUsageError (Just \"connection to server on socket \\\"/run/postgresql/.s.PGSQL.5432\\\" failed: No such file or directory ...\")"
```

This made the documented TLS-hardening path (ADR-0064 / #684) — including the `DB_SSL_MODE=require` golden path from the Azure Database for PostgreSQL Flexible Server guide (#685) — unusable. Only `unset` worked.

## Root cause

`Service.Infra.Postgres.ConnectionConfig.toConnectionParams` emitted the base params and **each** TLS param as *separate* `Hasql.Connection.Setting.connection` values. hasql's `Hasql.Pool.Config.staticConnectionSettings` applies each `connection` Setting by **replacing** the whole connection string rather than merging:

```haskell
-- hasql 1.9.3.2, Hasql.Connection.Config
setConnectionString s config = config {connectionString = s}   -- replace
fromUpdates = foldl' (flip update) nil                          -- last wins
```

So `[baseSetting, sslmodeSetting]` rendered down to just `sslmode='require'` — host/port/dbname gone. `SslModeUnset` emitted no TLS setting, which is exactly why the unset path was the only one that worked.

## Fix

Build every libpq param — base **and** the conditional `sslmode` / `sslrootcert` / `channel_binding` — into **one** `ConnectionSettingConnection.params [...]`, i.e. a single `connection` Setting. All three pools (EventStore, FileUpload, QueryObjectStore) route through this single builder, so all three are fixed at once.

- The `unset` path stays **byte-identical** (the same 9 params in one setting), preserving the ADR-0064 §2 no-regression guarantee.
- `Param.other k v` is byte-identical to the typed `Param.host`/`Param.port`/… constructors (both call `setKeyValue`), so the rendered string is unchanged apart from the now-included TLS params.

## Reproducing the bug in tests

The hasql `Param`/`Setting` types have no `Eq`/`Show` and the modules that render them to a connection string are **internal** to hasql, so a test cannot inspect the final string. The pre-existing tests used `LinkedList.length` of the settings list as a proxy — which is precisely what masked the bug (more TLS params ⇒ more *separate* settings looked "correct").

This PR adds an inspectable `toParamPairs :: ConnectionParams -> Result Text (LinkedList (Text, Text))` — the canonical, ordered `(key, value)` param set the single Setting is built from. Tests now assert the contract **directly**:

- **#694 regression** (`toConnectionParams`): emits exactly **one** connection Setting for *every* `SslMode` (a 2nd `connection` Setting is the host-dropping smoking gun).
- **host survival** (`toParamPairs`): the `host` param is present for `require`, `verify-full`, and every mode (table sweep).
- **exact param sets**: `verify-full + cert` emits exactly `sslmode` + `sslrootcert` + `channel_binding` and **no** `sslcert`/`sslkey` (ADR-0064 §3 no-mTLS guarantee), root-cert is gated to verifying modes only, etc.

**Red verified:** temporarily reintroducing the split-setting structure makes `toConnectionParams` return 2 settings for `require` and 4 for `verify-full`+cert, and the regression tests fail exactly as designed. Restoring the fix → all green (`ConnectionConfigSpec` 55/55; FileUpload sslMode-threading 5/5).

> A true end-to-end TLS connection test needs a remote TLS Postgres (not available in CI). The bug lives entirely in connection-string construction, so these construction-level unit tests catch it deterministically and fast.

## ⚠️ Changed test expectations (needs maintainer sign-off)

Per CONTRIBUTING/CLAUDE rules I'm flagging that two existing expectations changed, because they **encoded the buggy multi-setting shape** introduced by the same #684 PR:

- `ConnectionConfigSpec`: the length-based ssl tests (`baseLen + 1/2/3`) are replaced by direct `toParamPairs` key/value assertions (strictly more precise).
- `FileUpload/FileStateStore/PostgresSpec`: `... |> toConnectionParams |> Result.map LinkedList.length |> shouldBe (Ok 2)` → `(Ok 1)`, plus a `toParamPairs` check that `sslmode=require` is actually threaded through.

## Verification

- `cabal test nhcore-test-service --test-options='--match "Service.Infra.Postgres.ConnectionConfig"'` → 55 examples, 0 failures
- `cabal test nhcore-test --test-options='--match "sslMode threading"'` → 5 examples, 0 failures
- `nhcore-test` full suite compiles (all callers + 99 test modules link)
- `hlint` → No hints on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Postgres connection settings so enabling TLS no longer overrides or drops essential base connection details.
  * Improved TLS/SSL parameter generation for `require`, `verify-ca`, and `verify-full`, including correct inclusion/exclusion of root certificate and channel binding settings depending on the mode.

* **Tests**
  * Expanded regression coverage for Postgres TLS parameter generation and ensured the produced parameters match expected behavior across all `SslMode` variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->