### PR TITLE
feat(acs): Add Azure Communication Services email integration

### DIFF
--- a/docs/decisions/0065-acs-email-integration.md
+++ b/docs/decisions/0065-acs-email-integration.md
@@ -57,10 +57,14 @@ plain `Bearer <token>`, which is what this integration emits.
 
 ### Design drivers
 
-1. **Mirror Brevo exactly.** Jess already learned `Brevo.send (Brevo.sender …)
+1. **Mirror Brevo's *surface*.** Jess already learned `Brevo.send (Brevo.sender …)
    (Brevo.recipient …) subject (Brevo.HtmlBody …) onSuccess onError |>
-   Integration.outbound`. The ACS spelling must be identical apart from the
-   module name and one extra `endpoint` argument, so she reuses one mental model.
+   Integration.outbound`. The ACS spelling is identical apart from the module name
+   and one extra `endpoint` argument, so she reuses one mental model. The
+   *internals* deliberately diverge from Brevo where Brevo is wrong or incomplete:
+   ACS ships the `ToAction` instance Brevo omits (§4), validates the endpoint
+   scheme before unwrapping the token (§4, SEC-001), and always treats a `202` as
+   an accepted send so a retry can never double-send (§6, SEC-002).
 2. **Two-persona split (ADR-0015).** Facade `Integration.Acs` exposes only pure
    records and smart constructors; all HTTP/IO/Task lives in
    `Integration.Acs.Internal`, which is not re-exported.
@@ -139,7 +143,7 @@ Adopt Option A. Concretely:
 | `Integration.Acs` | Jess | Re-exports `Request (..)`, `Body (..)`, `Sender (..)`, `Recipient (..)`, smart constructors `send`/`sender`/`recipient`, and `Response (..)` |
 | `Integration.Acs.Request` | Jess | `Request` record, `Body` sum, `Address`/`Sender`/`Recipient` types, smart constructors |
 | `Integration.Acs.Response` | Jess | `Response { operationId :: Text }` |
-| `Integration.Acs.Internal` | Nick | `toHttpRequest`, `encodeRequest`, `AcsResponseHandler`, status dispatch — **not re-exported** |
+| `Integration.Acs.Internal` | Nick | `ToAction` instance, `validateEndpoint`, `toHttpRequest`, `encodeRequest`, `AcsResponseHandler`, status dispatch — **not re-exported** |
 
 `Integration.Acs.Internal` is the single module that touches `Integration.Http`
 and the single site that calls `Redacted.unwrap`.
@@ -242,12 +246,51 @@ send endpointVal senderVal recipientVal subjectVal bodyVal onSuccess onError =
     }
 ```
 
-### 4. `toHttpRequest` — the single unwrap site
+### 4. `ToAction` instance + endpoint guard + the single unwrap site
+
+`Integration.Acs.Internal` supplies the `ToAction (Request command)` instance —
+the bridge that lets Jess write `Acs.send … |> Integration.outbound`. (Note:
+`Integration.Brevo` is currently missing this instance, so "mirror Brevo exactly"
+is *not* sufficient; this ADR follows the complete integrations — `OpenRouter`,
+`Pdf`, `Ocr`, `Agent` — which delegate to `Integration.Http`'s `ToAction` via
+`toHttpRequest`.)
+
+The `ToAction` instance is also where the **endpoint scheme is validated before
+the token is ever unwrapped** (security finding SEC-001). The Entra Bearer token
+must never be transmitted over cleartext, so an `endpoint` that does not begin
+with `https://` (case-insensitive, after trimming) short-circuits to `onError`
+with a clear message — `toHttpRequest` is never called, `Redacted.unwrap` never
+runs, and no HTTP request leaves the process. Only an `https://` endpoint reaches
+the delegation path.
+
+```haskell
+instance
+  (Json.ToJSON command, KnownSymbol (NameOf command)) =>
+  Integration.ToAction (Request command)
+  where
+  toAction req =
+    case validateEndpoint req.endpoint of
+      Result.Err message ->
+        -- No https → emit the error directly; the token is never unwrapped.
+        Integration.action (\_ctx -> Integration.emitCommand (req.onError message))
+      Result.Ok _ ->
+        req |> toHttpRequest |> Integration.toAction
+
+
+-- | Accept only an https endpoint; anything else would leak the Bearer token.
+validateEndpoint :: Text -> Result Text Text
+validateEndpoint endpoint =
+  do
+    let trimmed = Text.trim endpoint
+    if Text.toLower trimmed |> Text.startsWith "https://"
+      then Result.Ok trimmed
+      else Result.Err "ACS endpoint must use https (refusing to send the Bearer token over cleartext)"
+```
 
 `Internal.toHttpRequest` is the only place that unwraps the token and the only
-place that constructs the HTTP request. It targets the ACS Email send route with
-the pinned API version and attaches `Http.Bearer`, which produces
-`Authorization: Bearer <token>`.
+place that constructs the HTTP request. It is reached only for an already-validated
+`https://` endpoint. It targets the ACS Email send route with the pinned API
+version and attaches `Http.Bearer`, which produces `Authorization: Bearer <token>`.
 
 ```haskell
 toHttpRequest ::
@@ -321,21 +364,24 @@ encodeBodyField body =
 ### 6. Status dispatch — `202` success, sanitized errors
 
 `handleAcsResponse` mirrors `handleBrevoResponse` but treats `202 Accepted` as
-success (ACS sends are asynchronous) and decodes the `operationId` from the
-response body. Auth failures and throttling get explicit messages; every other
-`4xx`/`5xx` collapses to a status-only message so neither the token nor the raw
-body can leak.
+success (ACS sends are asynchronous). Auth failures and throttling get explicit
+messages; every other `4xx`/`5xx` collapses to a status-only message so neither
+the token nor the raw body can leak.
 
-The ACS success body is `EmailSendResult { "id": ..., "status": ... }`. The
-operation id arrives under the wire key **`id`** (the same id also appears in the
-`Operation-Location` response header); the decoder maps `id` → `operationId`,
-mirroring the request-side `email` → `address` mapping (see §7). The body also
-carries a `status` field (`NotStarted` / `Running` / `Succeeded` / `Failed` /
-`Canceled`); for fire-and-forget send we treat any `202` as accepted and do not
-inspect `status` — polling is out of scope. On error, ACS returns a safe,
-non-sensitive `x-ms-error-code` response header; the dispatcher MAY append that
-code to the sanitized message for diagnosability without leaking the token or
-body, but never echoes the response body itself.
+**A `202` always routes to `onSuccess`, never `onError`.** This is a deliberate
+correctness decision (security finding SEC-002): a `202` means ACS has *accepted
+and queued* the email. Routing an accepted-but-unparseable `202` to `onError` —
+as a naive mirror of Brevo's `201` branch would — invites a `onError → retry`
+handler to send a **duplicate transactional email**. The operation id is
+best-effort: the dispatcher reads it from the body wire key **`id`**, falling
+back to the `Operation-Location` response header, and finally to `""` when
+neither is present. The send is reported as succeeded in every `202` case; an
+empty `operationId` simply means "accepted, id not captured" (the id only feeds
+out-of-scope delivery polling). The body also carries a `status` field
+(`NotStarted` / `Running` / `Succeeded` / `Failed` / `Canceled`) which we do not
+inspect. On a `4xx`/`5xx` error, ACS returns a safe, non-sensitive
+`x-ms-error-code` response header; the dispatcher MAY append that code to the
+sanitized message for diagnosability without ever echoing the token or body.
 
 ```haskell
 handleAcsResponse ::
@@ -346,11 +392,8 @@ handleAcsResponse ::
 handleAcsResponse handler response =
   case response.statusCode of
     202 ->
-      case Json.decode response.body of
-        Result.Ok acsResponse ->
-          handler.onSuccess acsResponse
-        Result.Err _ ->
-          handler.onError "Failed to parse ACS response"
+      -- Accepted. Always succeed; never re-send on a 202.
+      handler.onSuccess (Response { operationId = operationIdFrom response })
     401 ->
       handler.onError "Authentication failed (HTTP 401): unauthorized"
     403 ->
@@ -363,6 +406,20 @@ handleAcsResponse handler response =
       handler.onError [fmt|ACS server error (HTTP #{status})|]
     status ->
       handler.onError [fmt|Unexpected HTTP status #{status}|]
+
+
+-- | Best-effort ACS operation id: body @id@, then the @Operation-Location@
+-- header, then empty. A 202 is always an accepted send regardless.
+operationIdFrom :: Http.Response -> Text
+operationIdFrom response =
+  case Json.decode response.body of
+    Result.Ok parsed ->
+      parsed.operationId
+    Result.Err _ ->
+      response.headers
+        |> Array.find (\(name, _) -> Text.toLower name == "operation-location")
+        |> Maybe.map (\(_, value) -> operationIdFromLocation value)
+        |> Maybe.withDefault ""
 ```
 
 ### 7. Response
@@ -402,7 +459,7 @@ Config.field @(Redacted Text) "acsAccessToken"
 | Facade re-exporting Request/Body/Sender/Recipient/constructors/Response | `integrations/Integration/Acs.hs` |
 | Request record, `Body`, `Address`/`Sender`/`Recipient`, smart constructors | `integrations/Integration/Acs/Request.hs` |
 | `Response { operationId }` | `integrations/Integration/Acs/Response.hs` |
-| `toHttpRequest`, `encodeRequest`, `AcsResponseHandler`, status dispatch | `integrations/Integration/Acs/Internal.hs` |
+| `ToAction` instance, `validateEndpoint`, `toHttpRequest`, `encodeRequest`, `AcsResponseHandler`, status dispatch | `integrations/Integration/Acs/Internal.hs` |
 | Expose the four modules under `exposed-modules` | `integrations/nhintegrations.cabal` |
 | Register `Integration.Acs.RequestSpec`, `ResponseSpec`, `InternalSpec` | `integrations/nhintegrations.cabal` (test suite `other-modules`) |
 | Request encoding / smart-constructor tests | `integrations/test/Integration/Acs/RequestSpec.hs` |
@@ -411,25 +468,53 @@ Config.field @(Redacted Text) "acsAccessToken"
 
 ## Public API
 
-```haskell
--- Integration.Acs (Jess's surface)
+`Integration.Acs` re-exports its surface in category groups (the same grouping the
+facade's export list uses, mirroring the `Array` / `Brevo` convention):
 
+```haskell
+module Integration.Acs
+  ( -- * Construction — build the address values
+    sender
+  , recipient
+
+    -- * Email body — mutually-exclusive content variant
+  , Body (..)
+
+    -- * Operation — send one transactional email
+  , send
+  , Request (..)
+
+    -- * Response — the accepted-send payload
+  , Response (..)
+  ) where
+```
+
+### Construction
+
+```haskell
 -- | Build a sender from an email address.
 sender :: Text -> Sender
 
 -- | Build a recipient from an email address.
 recipient :: Text -> Recipient
+```
 
--- | Mutually-exclusive email body.
+### Email body
+
+```haskell
+-- | Mutually-exclusive email body (compile-time exclusive html vs text).
 data Body
   = HtmlBody Text
   | TextBody Text
+```
 
--- | The accepted-send payload; carries the ACS operation id.
-data Response = Response { operationId :: Text }
+### Operation
 
+```haskell
 -- | Send one transactional email through an ACS Email resource.
--- Reads the Entra Bearer token from @?config.acsAccessToken@.
+-- Reads the Entra Bearer token from @?config.acsAccessToken@. The endpoint
+-- must be an @https://@ URL — a non-https endpoint is reported through the
+-- error callback and the token is never transmitted.
 send ::
   forall command config.
   ( ?config :: config
@@ -443,6 +528,14 @@ send ::
   (Response -> command) ->   -- ^ on 202 Accepted
   (Text -> command) ->       -- ^ on sanitized error
   Request command
+```
+
+### Response
+
+```haskell
+-- | The accepted-send payload; carries the ACS operation id (best-effort —
+-- empty when a 202 body carried no id). Decoded from the ACS wire field @id@.
+data Response = Response { operationId :: Text }
 ```
 
 Jess's call site, identical to Brevo apart from the module name and the leading
@@ -474,6 +567,12 @@ Acs.send
   hash, signing string, or HMAC key.
 - **Errors are safe by default.** `onError` receives a short, status-derived
   string; the token and raw response body are never echoed back.
+- **No token leak over cleartext.** A non-`https://` endpoint short-circuits to
+  `onError` before the token is unwrapped, so the Bearer credential can never be
+  put on the wire in the clear (SEC-001).
+- **A retry can never double-send.** Every `202` is reported as a success, so an
+  `onError → retry` handler is never triggered for an email ACS already accepted
+  (SEC-002).
 - **Single-vendor Azure path.** Teams consolidating on Azure drop a second email
   vendor and keep the same outbound-handler ergonomics.
 
@@ -495,8 +594,9 @@ Acs.send
   an integration failure to an operator who does not know Entra tokens are
   short-lived.
 - **Endpoint typo produces an opaque failure.** A malformed `endpoint` argument
-  (wrong region, missing scheme) yields a generic client/connection error rather
-  than a guided message.
+  (wrong region) yields a generic client/connection error rather than a guided
+  message. A missing/incorrect *scheme* is handled explicitly — a non-https
+  endpoint returns the guided `onError` "ACS endpoint must use https".
 - **ACS API-version drift.** The `2023-03-31` (GA) API version is pinned in
   `toHttpRequest`. A newer GA, `2025-09-01`, also exists; its request/response
   contract is identical for the subset this integration uses (`senderAddress`,

--- a/docs/decisions/0065-acs-email-integration.md
+++ b/docs/decisions/0065-acs-email-integration.md
@@ -386,9 +386,11 @@ neither is present. The send is reported as succeeded in every `202` case; an
 empty `operationId` simply means "accepted, id not captured" (the id only feeds
 out-of-scope delivery polling). The body also carries a `status` field
 (`NotStarted` / `Running` / `Succeeded` / `Failed` / `Canceled`) which we do not
-inspect. On a `4xx`/`5xx` error, ACS returns a safe, non-sensitive
-`x-ms-error-code` response header; the dispatcher MAY append that code to the
-sanitized message for diagnosability without ever echoing the token or body.
+inspect. On a `4xx`/`5xx` error, ACS also returns a safe, non-sensitive
+`x-ms-error-code` response header. The current `handleAcsResponse` returns
+**status-only** messages and does not read that header; a future revision could
+append it for extra diagnosability without ever echoing the token or body. It is
+intentionally not appended today.
 
 ```haskell
 handleAcsResponse ::

--- a/docs/decisions/0065-acs-email-integration.md
+++ b/docs/decisions/0065-acs-email-integration.md
@@ -32,6 +32,15 @@ connection-string/HMAC path **out** and supports Bearer-only, with the token
 supplied by the caller as `Redacted Text` (Azure SDKs and the `az` CLI already
 mint these tokens, so Jess never touches crypto).
 
+The Bearer token must be acquired for the ACS data-plane scope
+`https://communication.azure.com/.default`, and the identity (managed identity
+or service principal) needs the `acs.email.write` permission — typically via an
+Azure RBAC role assignment on the ACS resource. Both are the caller's
+responsibility, exactly like minting a Brevo API key; the integration only
+forwards the resulting token. The ACS `Authorization` header itself is marked
+`Required` and accepts either the HMAC-SHA256 scheme (out of scope here) or a
+plain `Bearer <token>`, which is what this integration emits.
+
 ### Use cases
 
 - **Azure-native SaaS sign-up.** Jess runs her app on Azure Container Apps and
@@ -312,9 +321,21 @@ encodeBodyField body =
 ### 6. Status dispatch — `202` success, sanitized errors
 
 `handleAcsResponse` mirrors `handleBrevoResponse` but treats `202 Accepted` as
-success (ACS sends are asynchronous) and decodes the `operationId`. Auth failures
-and throttling get explicit messages; every other `4xx`/`5xx` collapses to a
-status-only message so neither the token nor the raw body can leak.
+success (ACS sends are asynchronous) and decodes the `operationId` from the
+response body. Auth failures and throttling get explicit messages; every other
+`4xx`/`5xx` collapses to a status-only message so neither the token nor the raw
+body can leak.
+
+The ACS success body is `EmailSendResult { "id": ..., "status": ... }`. The
+operation id arrives under the wire key **`id`** (the same id also appears in the
+`Operation-Location` response header); the decoder maps `id` → `operationId`,
+mirroring the request-side `email` → `address` mapping (see §7). The body also
+carries a `status` field (`NotStarted` / `Running` / `Succeeded` / `Failed` /
+`Canceled`); for fire-and-forget send we treat any `202` as accepted and do not
+inspect `status` — polling is out of scope. On error, ACS returns a safe,
+non-sensitive `x-ms-error-code` response header; the dispatcher MAY append that
+code to the sanitized message for diagnosability without leaking the token or
+body, but never echoes the response body itself.
 
 ```haskell
 handleAcsResponse ::
@@ -346,9 +367,16 @@ handleAcsResponse handler response =
 
 ### 7. Response
 
+ACS's success body is `{ "id": "<uuid>", "status": "Running" }`. The wire key is
+`id`, so the decoder cannot rely on Generic field-name matching (which would look
+for `operationId`); like the request encoder, it maps the ACS key explicitly —
+reading `id` into `operationId`. `ResponseSpec` therefore decodes a literal
+`{"id": "..."}` payload, and ignores the `status` field.
+
 ```haskell
 -- | ACS's success payload for an accepted email send. ACS is asynchronous;
--- 'operationId' identifies the send for later delivery-status polling.
+-- 'operationId' identifies the send for later delivery-status polling. Decoded
+-- from the ACS wire field @id@ (not @operationId@).
 data Response = Response
   { operationId :: Text
   }
@@ -361,7 +389,7 @@ Jess adds one config field, exactly like `brevoApiKey`:
 
 ```haskell
 Config.field @(Redacted Text) "acsAccessToken"
-  |> Config.doc "Azure Communication Services Entra ID Bearer token"
+  |> Config.doc "ACS Entra ID Bearer token (scope https://communication.azure.com/.default, permission acs.email.write)"
   |> Config.required
   |> Config.envVar "ACS_ACCESS_TOKEN"
   |> Config.secret
@@ -469,8 +497,12 @@ Acs.send
 - **Endpoint typo produces an opaque failure.** A malformed `endpoint` argument
   (wrong region, missing scheme) yields a generic client/connection error rather
   than a guided message.
-- **ACS API-version drift.** The `2023-03-31` API version is pinned in
-  `toHttpRequest`; a future ACS breaking change would require a code update.
+- **ACS API-version drift.** The `2023-03-31` (GA) API version is pinned in
+  `toHttpRequest`. A newer GA, `2025-09-01`, also exists; its request/response
+  contract is identical for the subset this integration uses (`senderAddress`,
+  `content.subject`/`html`/`plainText`, `recipients.to[].address`, the `202` +
+  body `id` success shape), so the pin is safe today and a future ACS breaking
+  change — or a deliberate version bump — would require only the single URL edit.
 
 ### Mitigations
 
@@ -495,5 +527,7 @@ Acs.send
 - [integrations/Integration/Brevo/Response.hs](../../integrations/Integration/Brevo/Response.hs)
 - [integrations/Integration/Brevo/Internal.hs](../../integrations/Integration/Brevo/Internal.hs)
 - [integrations/Integration/Http/Auth.hs](../../integrations/Integration/Http/Auth.hs)
+- [ACS Email - Send REST API (2023-03-31)](https://learn.microsoft.com/en-us/rest/api/communication/email/email/send?view=rest-communication-email-2023-03-31)
+- [ACS REST authentication (Entra ID scope, acs.email.write)](https://learn.microsoft.com/en-us/rest/api/communication/authentication)
 </content>
 </invoke>

--- a/docs/decisions/0065-acs-email-integration.md
+++ b/docs/decisions/0065-acs-email-integration.md
@@ -181,8 +181,15 @@ data Body
   deriving (Eq, Show, Generic)
 
 
--- | A complete ACS email send. 'accessToken' is 'Redacted Text' so the Entra
--- Bearer token is never logged or serialized by accident.
+-- | A complete ACS email send, produced by 'send' and consumed by
+-- 'Integration.outbound'. 'accessToken' is 'Redacted Text' so the Entra Bearer
+-- token is never logged or serialized by accident. Jess never builds this record
+-- by hand — 'send' is the only constructor:
+--
+-- @
+-- request = Acs.send "https://my-acs.communication.azure.com" sender recipient
+--             "Subject" (Acs.HtmlBody "<h1>Hi</h1>") onSuccess onError
+-- @
 data Request command = Request
   { endpoint :: Text
   , sender :: Sender
@@ -521,6 +528,14 @@ data Body
 -- Reads the Entra Bearer token from @?config.acsAccessToken@. The endpoint
 -- must be an @https://@ URL — a non-https endpoint is reported through the
 -- error callback and the token is never transmitted.
+--
+-- @
+-- Acs.send "https://my-acs.communication.azure.com"
+--   (Acs.sender "noreply@myapp.com") (Acs.recipient info.email)
+--   "Your order is confirmed" (Acs.HtmlBody "<h1>Thanks</h1>")
+--   (\\r -> EmailSent { operationId = r.operationId }) (\\e -> EmailFailed { reason = e })
+--   |> Integration.outbound
+-- @
 send ::
   forall command config.
   ( ?config :: config

--- a/docs/decisions/0065-acs-email-integration.md
+++ b/docs/decisions/0065-acs-email-integration.md
@@ -493,9 +493,13 @@ module Integration.Acs
 
 ```haskell
 -- | Build a sender from an email address.
+--
+-- @Acs.sender "noreply@myapp.com"@
 sender :: Text -> Sender
 
 -- | Build a recipient from an email address.
+--
+-- @Acs.recipient "user@example.com"@
 recipient :: Text -> Recipient
 ```
 
@@ -503,6 +507,8 @@ recipient :: Text -> Recipient
 
 ```haskell
 -- | Mutually-exclusive email body (compile-time exclusive html vs text).
+--
+-- @Acs.HtmlBody "<h1>Hi</h1>"@  —  or  —  @Acs.TextBody "Hi"@
 data Body
   = HtmlBody Text
   | TextBody Text
@@ -535,6 +541,8 @@ send ::
 ```haskell
 -- | The accepted-send payload; carries the ACS operation id (best-effort —
 -- empty when a 202 body carried no id). Decoded from the ACS wire field @id@.
+--
+-- @\\response -> EmailSent { operationId = response.operationId }@
 data Response = Response { operationId :: Text }
 ```
 

--- a/docs/decisions/0065-acs-email-integration.md
+++ b/docs/decisions/0065-acs-email-integration.md
@@ -1,0 +1,499 @@
+# ADR-0065: Azure Communication Services email integration
+
+## Status
+
+Proposed
+
+## Context
+
+### Current state
+
+NeoHaskell ships exactly one transactional email integration: `Integration.Brevo`
+(ADR-0015 two-persona model, `integrations/Integration/Brevo/`). Jess configures a
+pure `Brevo.Request` record with smart constructors (`Brevo.sender`,
+`Brevo.recipient`, `Brevo.HtmlBody`) and calls `Integration.outbound` in an
+outbound handler; Nick's `Integration.Brevo.Internal.toHttpRequest` turns that
+record into an `Http.Request`, unwraps the `Redacted` API key once, and dispatches
+on the HTTP status code.
+
+Teams already standardized on Microsoft Azure have no first-class path to send the
+same transactional emails through Azure Communication Services (ACS). Today they
+either pull in Brevo as a second vendor purely for email, or hand-roll an
+`Integration.Http` request against the ACS REST endpoint — losing the
+two-persona ergonomics, the `Redacted` secret discipline, and the
+status-code sanitization that Brevo gives for free.
+
+ACS authenticates email sends with a Microsoft Entra ID Bearer token
+(`Authorization: Bearer <token>`). ACS also offers an HMAC-signed
+connection-string scheme, but that path requires the caller to compute a
+SHA-256 content hash and an HMAC-SHA256 signature per request — cryptography
+vocabulary that fails the Jess test by construction. This ADR scopes the
+connection-string/HMAC path **out** and supports Bearer-only, with the token
+supplied by the caller as `Redacted Text` (Azure SDKs and the `az` CLI already
+mint these tokens, so Jess never touches crypto).
+
+### Use cases
+
+- **Azure-native SaaS sign-up.** Jess runs her app on Azure Container Apps and
+  already has an Entra-managed identity. She wants `OrderConfirmed` to send a
+  receipt through her existing ACS Email resource instead of onboarding a second
+  email vendor.
+- **Single-vendor billing.** A team consolidating cloud spend under one Azure
+  invoice replaces Brevo with ACS for password-reset and notification emails,
+  changing only the smart-constructor module name in their outbound handler.
+- **Async send with operation tracking.** ACS accepts an email and returns
+  `202 Accepted` with an `operationId`; an operator wants that id surfaced in a
+  domain event so a later phase can poll delivery status (polling itself is out
+  of scope here, but the id must be captured).
+
+### Design drivers
+
+1. **Mirror Brevo exactly.** Jess already learned `Brevo.send (Brevo.sender …)
+   (Brevo.recipient …) subject (Brevo.HtmlBody …) onSuccess onError |>
+   Integration.outbound`. The ACS spelling must be identical apart from the
+   module name and one extra `endpoint` argument, so she reuses one mental model.
+2. **Two-persona split (ADR-0015).** Facade `Integration.Acs` exposes only pure
+   records and smart constructors; all HTTP/IO/Task lives in
+   `Integration.Acs.Internal`, which is not re-exported.
+3. **One secret-unwrap site.** The Entra Bearer token is `Redacted Text`
+   everywhere except a single `Redacted.unwrap` call inside
+   `Internal.toHttpRequest`, matching Brevo's single-unwrap invariant.
+4. **No cryptography.** Bearer-only. No HMAC, no connection-string parsing, no
+   content hashing. Anything that would make Jess read a crypto doc is deferred.
+5. **Sanitized error text.** A failed send never echoes the token or the raw
+   response body back to the caller; `onError` receives a short,
+   status-derived message.
+6. **Pass the Jess 15-minute test.** Sending one ACS email must take ≤ 15 minutes
+   from the moment Jess opens autocomplete, with no flag or pragma.
+
+## Considered options
+
+### Option A — Mirror `Integration.Brevo` module-for-module, Bearer-only (CHOSEN)
+
+Add `Integration.Acs` (facade), `Integration.Acs.Request`,
+`Integration.Acs.Response`, and `Integration.Acs.Internal`, one-for-one with the
+Brevo layout. `Acs.Body` is a two-constructor sum (`HtmlBody Text | TextBody Text`),
+`send` takes the same arguments as `Brevo.send` plus a leading ACS `endpoint`
+`Text`, and reads the Bearer token from `?config.acsAccessToken`. The Internal
+module builds the request to `POST {endpoint}/emails:send?api-version=2023-03-31`,
+attaches `Http.Bearer` auth, and dispatches the `202` success and the
+`401/403/429/other` error cases.
+
+Verdict: **chosen.** Maximum reuse of an already-shipped, already-reviewed
+pattern. Jess transfers her Brevo knowledge verbatim. The single-unwrap and
+sanitized-error invariants come along for free because the code shape is
+identical. The only genuinely new code is the ACS-specific JSON wire shape and
+the `202`-with-`operationId` success branch.
+
+### Option B — Generic "EmailProvider" abstraction over Brevo and ACS (REJECTED)
+
+Introduce a provider-agnostic `Email.send` that dispatches to Brevo or ACS via a
+typeclass or a sum of provider configs, so Jess writes one call and swaps
+providers by config.
+
+Rejected for three reasons:
+
+1. **Premature.** With exactly two providers and no third on the roadmap, the
+   abstraction is speculative. The two wire formats differ in body shape, success
+   status (`201` vs `202`), and success payload (`messageId` vs `operationId`),
+   so the "common" interface would leak provider specifics immediately.
+2. **Worse Jess ergonomics.** A generic facade forces Jess to choose and
+   configure a provider variant — an extra decision the per-provider modules
+   avoid. The autocomplete path `Acs.send …` is shorter and more discoverable
+   than `Email.send (Email.Acs …) …`.
+3. **Out of scope.** ADR-0015 deliberately keeps each integration self-contained
+   so it can later move to its own repo. A cross-provider abstraction couples
+   them. If a real third provider arrives, that is the moment to extract a shared
+   interface — a separate, evidence-driven ADR.
+
+### Option C — Support the ACS connection-string / HMAC auth path (REJECTED)
+
+Accept the ACS connection string and compute the per-request HMAC-SHA256
+signature and SHA-256 content hash that the non-Entra ACS scheme requires.
+
+Rejected because it fails the Jess test on contact: the caller (or the framework)
+must understand content hashing, signing strings, and clock-skew windows. It also
+multiplies the secret surface (connection string + derived signing key) and the
+error modes (signature mismatch vs expired token). Entra Bearer tokens are minted
+by the Azure tooling Jess already runs, so Bearer-only covers the use cases
+without any cryptography. HMAC can be added later behind the same facade if a
+concrete need appears.
+
+## Decision
+
+Adopt Option A. Concretely:
+
+### 1. Module layout (mirrors Brevo)
+
+| Module | Audience | Contents |
+|---|---|---|
+| `Integration.Acs` | Jess | Re-exports `Request (..)`, `Body (..)`, `Sender (..)`, `Recipient (..)`, smart constructors `send`/`sender`/`recipient`, and `Response (..)` |
+| `Integration.Acs.Request` | Jess | `Request` record, `Body` sum, `Address`/`Sender`/`Recipient` types, smart constructors |
+| `Integration.Acs.Response` | Jess | `Response { operationId :: Text }` |
+| `Integration.Acs.Internal` | Nick | `toHttpRequest`, `encodeRequest`, `AcsResponseHandler`, status dispatch — **not re-exported** |
+
+`Integration.Acs.Internal` is the single module that touches `Integration.Http`
+and the single site that calls `Redacted.unwrap`.
+
+### 2. Request types and smart constructors
+
+The address shape mirrors Brevo so a later display-name addition is a
+non-breaking change. ACS's wire contract names the recipient key `address`
+(not `email`), so the hand-written encoder maps the field; the Haskell-facing
+field stays `email` for Brevo parity.
+
+```haskell
+-- | A wire-format email address. The display name is optional and currently
+-- always 'Nothing' from the smart constructors; kept for forward-compat.
+data Address = Address
+  { name :: Maybe Text
+  , email :: Text
+  }
+  deriving (Eq, Show, Generic)
+
+
+-- | The sender address. A newtype to stop accidental swaps with 'Recipient'.
+newtype Sender = Sender Address deriving (Eq, Show)
+
+
+-- | A recipient address. A newtype to stop accidental swaps with 'Sender'.
+newtype Recipient = Recipient Address deriving (Eq, Show)
+
+
+-- | Mutually-exclusive email body. ACS rejects a request that sets both
+-- @html@ and @plainText@; the sum enforces the invariant at compile time.
+data Body
+  = HtmlBody Text
+  | TextBody Text
+  deriving (Eq, Show, Generic)
+
+
+-- | A complete ACS email send. 'accessToken' is 'Redacted Text' so the Entra
+-- Bearer token is never logged or serialized by accident.
+data Request command = Request
+  { endpoint :: Text
+  , sender :: Sender
+  , to :: Array Recipient
+  , subject :: Text
+  , body :: Body
+  , accessToken :: Redacted Text
+  , onSuccess :: Response -> command
+  , onError :: Text -> command
+  }
+```
+
+Smart constructors build the single-recipient happy path, matching
+`Brevo.sender` / `Brevo.recipient`:
+
+```haskell
+-- | Build a sender from just an email address (no display name).
+sender :: Text -> Sender
+sender email =
+  Sender (Address { name = Nothing, email })
+
+
+-- | Build a recipient from just an email address (no display name).
+recipient :: Text -> Recipient
+recipient email =
+  Recipient (Address { name = Nothing, email })
+```
+
+### 3. `send` reads the token from config
+
+`send` takes the ACS resource `endpoint` as its first argument (it varies per
+Azure resource and is not a secret), then the same arguments as `Brevo.send`.
+The Bearer token comes from the project config via the implicit `?config`
+parameter and a `HasField "acsAccessToken"` constraint, mirroring Brevo's
+`brevoApiKey` read.
+
+```haskell
+send ::
+  forall command config.
+  ( ?config :: config
+  , HasField "acsAccessToken" config (Redacted Text)
+  ) =>
+  Text ->
+  Sender ->
+  Recipient ->
+  Text ->
+  Body ->
+  (Response -> command) ->
+  (Text -> command) ->
+  Request command
+send endpointVal senderVal recipientVal subjectVal bodyVal onSuccess onError =
+  Request
+    { endpoint = endpointVal
+    , sender = senderVal
+    , to = Array.wrap recipientVal
+    , subject = subjectVal
+    , body = bodyVal
+    , accessToken = ?config.acsAccessToken
+    , onSuccess
+    , onError
+    }
+```
+
+### 4. `toHttpRequest` — the single unwrap site
+
+`Internal.toHttpRequest` is the only place that unwraps the token and the only
+place that constructs the HTTP request. It targets the ACS Email send route with
+the pinned API version and attaches `Http.Bearer`, which produces
+`Authorization: Bearer <token>`.
+
+```haskell
+toHttpRequest ::
+  forall command.
+  Request command ->
+  Http.Request command
+toHttpRequest req =
+  do
+    let url = [fmt|#{req.endpoint}/emails:send?api-version=2023-03-31|]
+    let tokenValue = Redacted.unwrap req.accessToken
+    let encodedBody = encodeRequest req
+    let handler = AcsResponseHandler { onSuccess = req.onSuccess, onError = req.onError }
+    Http.Request
+      { method = Http.POST
+      , url
+      , headers = Array.empty
+      , body = Http.raw "application/json" encodedBody
+      , onSuccess = handleAcsResponse handler
+      , onError = Just req.onError
+      , auth = Http.Bearer tokenValue
+      , retry = Http.noRetry
+      , timeoutSeconds = 30
+      }
+```
+
+### 5. Hand-built JSON wire shape
+
+The encoder is hand-built (like `Brevo.encodeRequest`) so optional fields are
+omitted entirely rather than serialized as `null`. The body variant chooses the
+`html` or `plainText` key inside `content`; the recipient list is
+`recipients.to` of `{ address }` objects; the sender is a plain
+`senderAddress` string.
+
+```haskell
+-- Target shape:
+-- { "senderAddress": "noreply@myapp.com"
+-- , "content": { "subject": "Welcome", "html": "<h1>Hi</h1>" }
+-- , "recipients": { "to": [ { "address": "user@example.com" } ] }
+-- }
+encodeRequest ::
+  forall command.
+  Request command ->
+  Text
+encodeRequest req =
+  do
+    let contentFields =
+          encodeBodyField req.body
+            |> Array.pushFront ("subject", Json.encode req.subject)
+            |> Array.toLinkedList
+    let toEntries =
+          req.to
+            |> Array.map encodeRecipientAddress
+    let allFields =
+          [ ("senderAddress", Json.encode (senderEmail req.sender))
+          , ("content", Json.object contentFields)
+          , ("recipients", Json.object [("to", Json.encode toEntries)])
+          ]
+    Json.encodeText (Json.object allFields)
+
+
+-- | Pick the ACS body key for the chosen 'Body' variant.
+encodeBodyField :: Body -> Array (Text, Json.Value)
+encodeBodyField body =
+  case body of
+    HtmlBody html ->
+      Array.fromLinkedList [("html", Json.encode html)]
+    TextBody text ->
+      Array.fromLinkedList [("plainText", Json.encode text)]
+```
+
+### 6. Status dispatch — `202` success, sanitized errors
+
+`handleAcsResponse` mirrors `handleBrevoResponse` but treats `202 Accepted` as
+success (ACS sends are asynchronous) and decodes the `operationId`. Auth failures
+and throttling get explicit messages; every other `4xx`/`5xx` collapses to a
+status-only message so neither the token nor the raw body can leak.
+
+```haskell
+handleAcsResponse ::
+  forall command.
+  AcsResponseHandler command ->
+  Http.Response ->
+  command
+handleAcsResponse handler response =
+  case response.statusCode of
+    202 ->
+      case Json.decode response.body of
+        Result.Ok acsResponse ->
+          handler.onSuccess acsResponse
+        Result.Err _ ->
+          handler.onError "Failed to parse ACS response"
+    401 ->
+      handler.onError "Authentication failed (HTTP 401): unauthorized"
+    403 ->
+      handler.onError "Authorization failed (HTTP 403): unauthorized"
+    429 ->
+      handler.onError "Rate limit exceeded (HTTP 429): throttled"
+    status | status >= 400 && status < 500 ->
+      handler.onError [fmt|ACS client error (HTTP #{status})|]
+    status | status >= 500 ->
+      handler.onError [fmt|ACS server error (HTTP #{status})|]
+    status ->
+      handler.onError [fmt|Unexpected HTTP status #{status}|]
+```
+
+### 7. Response
+
+```haskell
+-- | ACS's success payload for an accepted email send. ACS is asynchronous;
+-- 'operationId' identifies the send for later delivery-status polling.
+data Response = Response
+  { operationId :: Text
+  }
+  deriving (Eq, Show, Generic)
+```
+
+### 8. Configuration
+
+Jess adds one config field, exactly like `brevoApiKey`:
+
+```haskell
+Config.field @(Redacted Text) "acsAccessToken"
+  |> Config.doc "Azure Communication Services Entra ID Bearer token"
+  |> Config.required
+  |> Config.envVar "ACS_ACCESS_TOKEN"
+  |> Config.secret
+```
+
+### 9. Module placement
+
+| Change | File |
+|---|---|
+| Facade re-exporting Request/Body/Sender/Recipient/constructors/Response | `integrations/Integration/Acs.hs` |
+| Request record, `Body`, `Address`/`Sender`/`Recipient`, smart constructors | `integrations/Integration/Acs/Request.hs` |
+| `Response { operationId }` | `integrations/Integration/Acs/Response.hs` |
+| `toHttpRequest`, `encodeRequest`, `AcsResponseHandler`, status dispatch | `integrations/Integration/Acs/Internal.hs` |
+| Expose the four modules under `exposed-modules` | `integrations/nhintegrations.cabal` |
+| Register `Integration.Acs.RequestSpec`, `ResponseSpec`, `InternalSpec` | `integrations/nhintegrations.cabal` (test suite `other-modules`) |
+| Request encoding / smart-constructor tests | `integrations/test/Integration/Acs/RequestSpec.hs` |
+| Response decode test | `integrations/test/Integration/Acs/ResponseSpec.hs` |
+| `toHttpRequest` + status-dispatch tests | `integrations/test/Integration/Acs/InternalSpec.hs` |
+
+## Public API
+
+```haskell
+-- Integration.Acs (Jess's surface)
+
+-- | Build a sender from an email address.
+sender :: Text -> Sender
+
+-- | Build a recipient from an email address.
+recipient :: Text -> Recipient
+
+-- | Mutually-exclusive email body.
+data Body
+  = HtmlBody Text
+  | TextBody Text
+
+-- | The accepted-send payload; carries the ACS operation id.
+data Response = Response { operationId :: Text }
+
+-- | Send one transactional email through an ACS Email resource.
+-- Reads the Entra Bearer token from @?config.acsAccessToken@.
+send ::
+  forall command config.
+  ( ?config :: config
+  , HasField "acsAccessToken" config (Redacted Text)
+  ) =>
+  Text ->                    -- ^ ACS resource endpoint, e.g. "https://my-acs.communication.azure.com"
+  Sender ->
+  Recipient ->
+  Text ->                    -- ^ subject
+  Body ->
+  (Response -> command) ->   -- ^ on 202 Accepted
+  (Text -> command) ->       -- ^ on sanitized error
+  Request command
+```
+
+Jess's call site, identical to Brevo apart from the module name and the leading
+endpoint:
+
+```haskell
+Acs.send
+  "https://my-acs.communication.azure.com"
+  (Acs.sender "noreply@myapp.com")
+  (Acs.recipient info.email)
+  "Your order is confirmed"
+  (Acs.HtmlBody "<h1>Thank you</h1>")
+  (\response -> EmailSent { operationId = response.operationId })
+  (\err -> EmailFailed { reason = err })
+  |> Integration.outbound
+```
+
+## Consequences
+
+### Positive
+
+- **Brevo knowledge transfers verbatim.** Jess who has sent a Brevo email can
+  send an ACS email in under 15 minutes; the only new things to learn are the
+  module name and the `endpoint` argument, both visible from autocomplete.
+- **Secret discipline is preserved.** The Entra token is `Redacted Text`
+  end-to-end with one unwrap site, so it cannot be logged or serialized by
+  accident, and a `Show` on the request prints `<redacted>`.
+- **No cryptography reaches the user.** Bearer-only means Jess never sees a
+  hash, signing string, or HMAC key.
+- **Errors are safe by default.** `onError` receives a short, status-derived
+  string; the token and raw response body are never echoed back.
+- **Single-vendor Azure path.** Teams consolidating on Azure drop a second email
+  vendor and keep the same outbound-handler ergonomics.
+
+### Negative
+
+- **A second email integration to maintain.** Brevo and ACS now both exist with
+  duplicated-but-divergent encoders and dispatchers; a future bug fix to one
+  does not automatically apply to the other.
+- **Token lifecycle is the caller's job.** Entra Bearer tokens expire; Jess must
+  refresh `ACS_ACCESS_TOKEN` out of band. An expired token surfaces only as a
+  `401` at send time, not at config load.
+- **No delivery confirmation.** A `202 Accepted` means ACS queued the email, not
+  that it was delivered; the `operationId` is captured but polling is out of
+  scope.
+
+### Risks
+
+- **Token expiry mistaken for a code bug.** A `401` from a stale token looks like
+  an integration failure to an operator who does not know Entra tokens are
+  short-lived.
+- **Endpoint typo produces an opaque failure.** A malformed `endpoint` argument
+  (wrong region, missing scheme) yields a generic client/connection error rather
+  than a guided message.
+- **ACS API-version drift.** The `2023-03-31` API version is pinned in
+  `toHttpRequest`; a future ACS breaking change would require a code update.
+
+### Mitigations
+
+- The `401`/`403` branch returns the explicit text `unauthorized`, and the ADR
+  and module haddock state that the token is caller-managed and short-lived, so
+  the most common operational failure has a documented cause.
+- The `endpoint` is a plain function argument (not buried in config), so a typo
+  is visible at the call site Jess is already editing.
+- The pinned API version lives at the single `toHttpRequest` URL site, so a
+  future bump is a one-line change with a regression test already in place.
+- HMAC/connection-string auth, delivery-status polling, attachments, and
+  cc/bcc/reply-to remain explicitly out of scope; each can be added later behind
+  the same facade as evidence-driven follow-up ADRs.
+
+## References
+
+- [#698: Azure Communication Services email integration](https://github.com/neohaskell/NeoHaskell/issues/698)
+- [ADR-0015: HTTP outbound integration two-persona model](0015-http-outbound-integration.md)
+- [ADR-0008: Integration pattern](0008-integration-pattern.md)
+- [integrations/Integration/Brevo.hs](../../integrations/Integration/Brevo.hs)
+- [integrations/Integration/Brevo/Request.hs](../../integrations/Integration/Brevo/Request.hs)
+- [integrations/Integration/Brevo/Response.hs](../../integrations/Integration/Brevo/Response.hs)
+- [integrations/Integration/Brevo/Internal.hs](../../integrations/Integration/Brevo/Internal.hs)
+- [integrations/Integration/Http/Auth.hs](../../integrations/Integration/Http/Auth.hs)
+</content>
+</invoke>

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -74,6 +74,7 @@ ADRs document significant architectural decisions made during the development of
 | [0062](0062-shared-connection-settings-builder.md) | Single Shared Postgres Connection-Settings Builder | Proposed |
 | [0063](0063-per-stream-subscription-connection-release.md) | Release Per-Stream Subscription Connections on Unsubscribe | Proposed |
 | [0064](0064-optional-sslmode-tls-hardening.md) | Optional `sslmode` TLS Hardening for Postgres Connections | Proposed |
+| [0065](0065-acs-email-integration.md) | Azure Communication Services Email Integration | Proposed |
 
 ## Creating New ADRs
 

--- a/integrations/Integration/Acs.hs
+++ b/integrations/Integration/Acs.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ImplicitParams #-}
-
 -- | Azure Communication Services transactional email integration for NeoHaskell.
 --
 -- Send transactional emails (sign-up confirmations, password resets, receipts,

--- a/integrations/Integration/Acs.hs
+++ b/integrations/Integration/Acs.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE ImplicitParams #-}
+
+-- | Azure Communication Services transactional email integration for NeoHaskell.
+--
+-- Send transactional emails (sign-up confirmations, password resets, receipts,
+-- notifications) via an ACS Email resource.
+--
+-- == Quick Start
+--
+-- @
+-- import Integration qualified
+-- import Integration.Acs qualified as Acs
+--
+-- Acs.send
+--   "https://my-acs.communication.azure.com"
+--   (Acs.sender "noreply@myapp.com")
+--   (Acs.recipient "user@example.com")
+--   "Your order is confirmed"
+--   (Acs.HtmlBody "<h1>Thank you</h1>")
+--   (\\r -> EmailSent { operationId = r.operationId })
+--   (\\e -> EmailFailed { reason = e })
+--   |> Integration.outbound
+-- @
+--
+-- == Configuration
+--
+-- Add to your @Config.hs@:
+--
+-- @
+-- Config.field @(Redacted Text) "acsAccessToken"
+--   |> Config.doc "ACS Entra ID Bearer token (scope https://communication.azure.com/.default)"
+--   |> Config.required
+--   |> Config.envVar "ACS_ACCESS_TOKEN"
+--   |> Config.secret
+-- @
+module Integration.Acs
+  ( -- * Address types
+    Address (..)
+  , Sender (..)
+  , Recipient (..)
+
+    -- * Construction — build the address values
+  , sender
+  , recipient
+
+    -- * Email body — mutually-exclusive content variant
+  , Body (..)
+
+    -- * Operation — send one transactional email
+  , send
+  , Request (..)
+
+    -- * Response — the accepted-send payload
+  , Response (..)
+  ) where
+
+import Integration.Acs.Internal ()  -- ToAction (Request command) instance
+import Integration.Acs.Request (Address (..), Body (..), Recipient (..), Request (..), Sender (..), recipient, send, sender)
+import Integration.Acs.Response (Response (..))

--- a/integrations/Integration/Acs/Internal.hs
+++ b/integrations/Integration/Acs/Internal.hs
@@ -62,8 +62,10 @@ instance
         -- Non-https endpoint: emit the error command directly.
         -- The Bearer token is never unwrapped in this branch.
         Integration.action (\_ctx -> Integration.emitCommand (req.onError message))
-      Result.Ok _ ->
-        req |> toHttpRequest |> Integration.toAction
+      Result.Ok trimmedEndpoint ->
+        -- Use the trimmed endpoint so leading/trailing whitespace never
+        -- reaches the request URL (CodeRabbit: honor validateEndpoint's result).
+        req { endpoint = trimmedEndpoint } |> toHttpRequest |> Integration.toAction
 
 
 -- | Accept only an https endpoint; anything else would leak the Bearer token.
@@ -89,7 +91,7 @@ toHttpRequest ::
   Http.Request command
 toHttpRequest req =
   do
-    let endpointBase = req.endpoint
+    let endpointBase = Text.trim req.endpoint
     let url = [fmt|#{endpointBase}/emails:send?api-version=2023-03-31|]
     let tokenValue = Redacted.unwrap req.accessToken
     let encodedBody = encodeRequest req
@@ -154,14 +156,18 @@ encodeBodyField body =
 
 -- | Encode a Recipient as a JSON object @{ "address": "..." }@.
 encodeRecipientAddress :: Recipient -> Json.Value
-encodeRecipientAddress (Recipient (Address { email = emailVal })) =
-  Json.object [("address", Json.encode emailVal)]
+encodeRecipientAddress recipientVal =
+  case recipientVal of
+    Recipient (Address { email = emailVal }) ->
+      Json.object [("address", Json.encode emailVal)]
 
 
 -- | Extract the email address from a Sender.
 senderEmail :: Sender -> Text
-senderEmail (Sender (Address { email = emailVal })) =
-  emailVal
+senderEmail senderVal =
+  case senderVal of
+    Sender (Address { email = emailVal }) ->
+      emailVal
 
 
 -- | Dispatch the ACS HTTP response on status code.

--- a/integrations/Integration/Acs/Internal.hs
+++ b/integrations/Integration/Acs/Internal.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | Internal implementation for ACS transactional email integration.
+--
+-- Contains the transformation from 'Request' to 'Http.Request', the single
+-- 'Redacted.unwrap' site for the Bearer token, the endpoint guard (SEC-001),
+-- and the 'AcsResponseHandler' HTTP response dispatcher.
+--
+-- __This module is not re-exported from 'Integration.Acs'.__
+module Integration.Acs.Internal
+  ( -- * Transformation (exported for testing)
+    toHttpRequest
+  , encodeRequest
+  , encodeBodyField
+  , encodeRecipientAddress
+  , senderEmail
+  , validateEndpoint
+  , operationIdFrom
+  , operationIdFromLocation
+  , handleAcsResponse
+
+    -- * Internal types (exported for testing)
+  , AcsResponseHandler (..)
+  ) where
+
+import Array (Array)
+import Basics
+import Integration (ToAction (..))
+import Integration.Acs.Request (Body (..), Request (..), Recipient (..), Sender (..))
+import Integration.Acs.Response (Response (..))
+import Integration.Http qualified as Http
+import Json qualified
+import Result (Result)
+import Service.Command.Core (NameOf)
+import Text (Text)
+
+
+-- | Internal record bundling the onSuccess and onError callbacks from the Request.
+data AcsResponseHandler command = AcsResponseHandler
+  { onSuccess :: Response -> command
+  , onError :: Text -> command
+  }
+
+
+-- | ToAction instance: validate endpoint (SEC-001) before unwrapping token.
+--
+-- Stub: throws to make every test that calls 'toAction' red.
+instance
+  (Json.ToJSON command, KnownSymbol (NameOf command)) =>
+  ToAction (Request command)
+  where
+  toAction _req = panic "Acs.Internal.toAction stub: not implemented"
+
+
+-- | Validate that the endpoint uses the https scheme.
+--
+-- Stub: throws to make every test that calls 'validateEndpoint' red.
+validateEndpoint :: Text -> Result Text Text
+validateEndpoint _endpoint = panic "Acs.Internal.validateEndpoint stub: not implemented"
+
+
+-- | Convert a validated Request into an Http.Request.
+-- The single unwrap site for the Entra Bearer token.
+--
+-- Stub: throws to make every test that calls 'toHttpRequest' red.
+toHttpRequest ::
+  forall command.
+  Request command ->
+  Http.Request command
+toHttpRequest _req = panic "Acs.Internal.toHttpRequest stub: not implemented"
+
+
+-- | Encode a Request into ACS-compatible JSON wire format.
+--
+-- Stub: throws to make every test that calls 'encodeRequest' red.
+encodeRequest ::
+  forall command.
+  Request command ->
+  Text
+encodeRequest _req = panic "Acs.Internal.encodeRequest stub: not implemented"
+
+
+-- | Pick the ACS body key for the chosen Body variant.
+--
+-- Stub: throws to make every test that calls 'encodeBodyField' red.
+encodeBodyField :: Body -> Array (Text, Json.Value)
+encodeBodyField _body = panic "Acs.Internal.encodeBodyField stub: not implemented"
+
+
+-- | Encode a Recipient as a JSON object { \"address\": \"...\" }.
+--
+-- Stub: throws to make every test that calls 'encodeRecipientAddress' red.
+encodeRecipientAddress :: Recipient -> Json.Value
+encodeRecipientAddress _recipient = panic "Acs.Internal.encodeRecipientAddress stub: not implemented"
+
+
+-- | Extract the email address from a Sender.
+--
+-- Stub: throws to make every test that calls 'senderEmail' red.
+senderEmail :: Sender -> Text
+senderEmail _sender = panic "Acs.Internal.senderEmail stub: not implemented"
+
+
+-- | Dispatch the ACS HTTP response on status code.
+-- 202 Accepted always succeeds (SEC-002).
+--
+-- Stub: throws to make every test that calls 'handleAcsResponse' red.
+handleAcsResponse ::
+  forall command.
+  AcsResponseHandler command ->
+  Http.Response ->
+  command
+handleAcsResponse _handler _response = panic "Acs.Internal.handleAcsResponse stub: not implemented"
+
+
+-- | Best-effort ACS operation id from the response body or Operation-Location header.
+--
+-- Stub: throws to make every test that calls 'operationIdFrom' red.
+operationIdFrom :: Http.Response -> Text
+operationIdFrom _response = panic "Acs.Internal.operationIdFrom stub: not implemented"
+
+
+-- | Parse the operation id from an Operation-Location header value.
+--
+-- Stub: throws to make every test that calls 'operationIdFromLocation' red.
+operationIdFromLocation :: Text -> Text
+operationIdFromLocation _location = panic "Acs.Internal.operationIdFromLocation stub: not implemented"

--- a/integrations/Integration/Acs/Internal.hs
+++ b/integrations/Integration/Acs/Internal.hs
@@ -24,104 +24,196 @@ module Integration.Acs.Internal
   ) where
 
 import Array (Array)
+import Array qualified
 import Basics
 import Integration (ToAction (..))
-import Integration.Acs.Request (Body (..), Request (..), Recipient (..), Sender (..))
+import Integration qualified
+import Integration.Acs.Request (Address (..), Body (..), Recipient (..), Request (..), Sender (..))
 import Integration.Acs.Response (Response (..))
 import Integration.Http qualified as Http
 import Json qualified
-import Result (Result)
+import Maybe (Maybe (..))
+import Maybe qualified
+import Redacted qualified
+import Result (Result (..))
 import Service.Command.Core (NameOf)
 import Text (Text)
+import Text qualified
 
 
 -- | Internal record bundling the onSuccess and onError callbacks from the Request.
+-- Used to pass callbacks through to 'handleAcsResponse' without exposing them
+-- outside Internal.
 data AcsResponseHandler command = AcsResponseHandler
   { onSuccess :: Response -> command
   , onError :: Text -> command
   }
 
 
--- | ToAction instance: validate endpoint (SEC-001) before unwrapping token.
---
--- Stub: throws to make every test that calls 'toAction' red.
+-- | Bridge from Request to the Integration.Http layer.
+-- Validates the endpoint BEFORE unwrapping the token (ADR §4, SEC-001).
 instance
   (Json.ToJSON command, KnownSymbol (NameOf command)) =>
   ToAction (Request command)
   where
-  toAction _req = panic "Acs.Internal.toAction stub: not implemented"
+  toAction req =
+    case validateEndpoint req.endpoint of
+      Result.Err message ->
+        -- Non-https endpoint: emit the error command directly.
+        -- The Bearer token is never unwrapped in this branch.
+        Integration.action (\_ctx -> Integration.emitCommand (req.onError message))
+      Result.Ok _ ->
+        req |> toHttpRequest |> Integration.toAction
 
 
--- | Validate that the endpoint uses the https scheme.
---
--- Stub: throws to make every test that calls 'validateEndpoint' red.
+-- | Accept only an https endpoint; anything else would leak the Bearer token.
+-- Returns 'Result.Ok' with the trimmed endpoint on success, 'Result.Err'
+-- with a guided message on non-https.
+-- Called from: 'toAction' (before token unwrap).
+-- ADR §4 (SEC-001): ensures the Bearer token is never transmitted over cleartext.
 validateEndpoint :: Text -> Result Text Text
-validateEndpoint _endpoint = panic "Acs.Internal.validateEndpoint stub: not implemented"
+validateEndpoint endpoint =
+  do
+    let trimmed = Text.trim endpoint
+    if Text.toLower trimmed |> Text.startsWith "https://"
+      then Result.Ok trimmed
+      else Result.Err "ACS endpoint must use https (refusing to send the Bearer token over cleartext)"
 
 
--- | Convert a validated Request into an Http.Request.
--- The single unwrap site for the Entra Bearer token.
---
--- Stub: throws to make every test that calls 'toHttpRequest' red.
+-- | Convert a validated Request into an Http.Request, unwrapping the Bearer token.
+-- This is the only site where 'Redacted.unwrap' is called (single-unwrap invariant).
+-- Called from: 'toAction' (after 'validateEndpoint' passes).
 toHttpRequest ::
   forall command.
   Request command ->
   Http.Request command
-toHttpRequest _req = panic "Acs.Internal.toHttpRequest stub: not implemented"
+toHttpRequest req =
+  do
+    let endpointBase = req.endpoint
+    let url = [fmt|#{endpointBase}/emails:send?api-version=2023-03-31|]
+    let tokenValue = Redacted.unwrap req.accessToken
+    let encodedBody = encodeRequest req
+    let handler = AcsResponseHandler { onSuccess = req.onSuccess, onError = req.onError }
+    Http.Request
+      { method = Http.POST
+      , url
+      , headers = Array.empty
+      , body = Http.raw "application/json" encodedBody
+      , onSuccess = handleAcsResponse handler
+      , onError = Just req.onError
+      , auth = Http.Bearer tokenValue
+      , retry = Http.noRetry
+      , timeoutSeconds = 30
+      }
 
 
 -- | Encode a Request into ACS-compatible JSON wire format.
+-- Target shape:
 --
--- Stub: throws to make every test that calls 'encodeRequest' red.
+-- @
+-- { "senderAddress": "noreply\@myapp.com"
+-- , "content": { "subject": "Welcome", "html": "\<h1\>Hi\<\/h1\>" }
+-- , "recipients": { "to": [ { "address": "user\@example.com" } ] }
+-- }
+-- @
+--
+-- Hand-built to omit optional fields entirely (never serialize null).
+-- Called from: 'toHttpRequest'.
 encodeRequest ::
   forall command.
   Request command ->
   Text
-encodeRequest _req = panic "Acs.Internal.encodeRequest stub: not implemented"
+encodeRequest req =
+  do
+    let contentFields =
+          encodeBodyField req.body
+            |> Array.push ("subject", Json.encode req.subject)
+            |> Array.toLinkedList
+    let toEntries =
+          req.to
+            |> Array.map encodeRecipientAddress
+    let allFields =
+          [ ("senderAddress", Json.encode (senderEmail req.sender))
+          , ("content", Json.object contentFields)
+          , ("recipients", Json.object [("to", Json.encode toEntries)])
+          ]
+    Json.encodeText (Json.object allFields)
 
 
 -- | Pick the ACS body key for the chosen Body variant.
---
--- Stub: throws to make every test that calls 'encodeBodyField' red.
+-- Returns an array with a single (key, value) pair: @("html", ...)@ or
+-- @("plainText", ...)@.
 encodeBodyField :: Body -> Array (Text, Json.Value)
-encodeBodyField _body = panic "Acs.Internal.encodeBodyField stub: not implemented"
+encodeBodyField body =
+  case body of
+    HtmlBody html ->
+      Array.fromLinkedList [("html", Json.encode html)]
+    TextBody text ->
+      Array.fromLinkedList [("plainText", Json.encode text)]
 
 
--- | Encode a Recipient as a JSON object { \"address\": \"...\" }.
---
--- Stub: throws to make every test that calls 'encodeRecipientAddress' red.
+-- | Encode a Recipient as a JSON object @{ "address": "..." }@.
 encodeRecipientAddress :: Recipient -> Json.Value
-encodeRecipientAddress _recipient = panic "Acs.Internal.encodeRecipientAddress stub: not implemented"
+encodeRecipientAddress (Recipient (Address { email = emailVal })) =
+  Json.object [("address", Json.encode emailVal)]
 
 
 -- | Extract the email address from a Sender.
---
--- Stub: throws to make every test that calls 'senderEmail' red.
 senderEmail :: Sender -> Text
-senderEmail _sender = panic "Acs.Internal.senderEmail stub: not implemented"
+senderEmail (Sender (Address { email = emailVal })) =
+  emailVal
 
 
 -- | Dispatch the ACS HTTP response on status code.
--- 202 Accepted always succeeds (SEC-002).
---
--- Stub: throws to make every test that calls 'handleAcsResponse' red.
+-- 202 Accepted always succeeds (never retried, ADR §6, SEC-002).
+-- Auth/error cases return sanitized messages (no token or body leak).
+-- Called from: 'toHttpRequest' as the onSuccess handler for 'Http.Request'.
 handleAcsResponse ::
   forall command.
   AcsResponseHandler command ->
   Http.Response ->
   command
-handleAcsResponse _handler _response = panic "Acs.Internal.handleAcsResponse stub: not implemented"
+handleAcsResponse handler response =
+  case response.statusCode of
+    202 ->
+      -- Accepted.  Always succeed; never re-send on a 202 (ADR §6, SEC-002).
+      handler.onSuccess (Response { operationId = operationIdFrom response })
+    401 ->
+      handler.onError "Authentication failed (HTTP 401): unauthorized"
+    403 ->
+      handler.onError "Authorization failed (HTTP 403): unauthorized"
+    429 ->
+      handler.onError "Rate limit exceeded (HTTP 429): throttled"
+    status | status >= 400 && status < 500 ->
+      handler.onError [fmt|ACS client error (HTTP #{status})|]
+    status | status >= 500 ->
+      handler.onError [fmt|ACS server error (HTTP #{status})|]
+    status ->
+      handler.onError [fmt|Unexpected HTTP status #{status}|]
 
 
--- | Best-effort ACS operation id from the response body or Operation-Location header.
---
--- Stub: throws to make every test that calls 'operationIdFrom' red.
+-- | Best-effort ACS operation id: read from body @id@ key, fall back to
+-- @Operation-Location@ header trailing segment, fall back to empty string.
+-- Called from 'handleAcsResponse' on every 202.
 operationIdFrom :: Http.Response -> Text
-operationIdFrom _response = panic "Acs.Internal.operationIdFrom stub: not implemented"
+operationIdFrom response =
+  case (Json.decode response.body :: Result Text Response) of
+    Result.Ok (Response { operationId = opId }) ->
+      opId
+    Result.Err _ ->
+      response.headers
+        |> Array.find (\(headerName, _) -> Text.toLower headerName == "operation-location")
+        |> Maybe.map (\(_, value) -> operationIdFromLocation value)
+        |> Maybe.withDefault ""
 
 
 -- | Parse the operation id from an Operation-Location header value.
---
--- Stub: throws to make every test that calls 'operationIdFromLocation' red.
+-- The header value is typically something like
+-- @https://my-acs.communication.azure.com/operations/abc-123@;
+-- extract the last path segment.
 operationIdFromLocation :: Text -> Text
-operationIdFromLocation _location = panic "Acs.Internal.operationIdFromLocation stub: not implemented"
+operationIdFromLocation location =
+  location
+    |> Text.split "/"
+    |> Array.last
+    |> Maybe.withDefault ""

--- a/integrations/Integration/Acs/Internal.hs
+++ b/integrations/Integration/Acs/Internal.hs
@@ -10,6 +10,7 @@
 module Integration.Acs.Internal
   ( -- * Transformation (exported for testing)
     toHttpRequest
+  , planAction
   , encodeRequest
   , encodeBodyField
   , encodeRecipientAddress
@@ -57,15 +58,30 @@ instance
   ToAction (Request command)
   where
   toAction req =
-    case validateEndpoint req.endpoint of
+    case planAction req of
       Result.Err message ->
         -- Non-https endpoint: emit the error command directly.
         -- The Bearer token is never unwrapped in this branch.
         Integration.action (\_ctx -> Integration.emitCommand (req.onError message))
-      Result.Ok trimmedEndpoint ->
-        -- Use the trimmed endpoint so leading/trailing whitespace never
-        -- reaches the request URL (CodeRabbit: honor validateEndpoint's result).
-        req { endpoint = trimmedEndpoint } |> toHttpRequest |> Integration.toAction
+      Result.Ok httpReq ->
+        Integration.toAction httpReq
+
+
+-- | Pure planning step for the 'ToAction' instance: validate the endpoint
+-- (SEC-001) and, on success, build the 'Http.Request' from the trimmed
+-- endpoint.  Returns 'Result.Err' with the guard message for a non-https
+-- endpoint (the token is never unwrapped), 'Result.Ok' the request otherwise.
+-- Exposed for testing so both branches are assertable without a live HTTP call.
+planAction ::
+  forall command.
+  Request command ->
+  Result Text (Http.Request command)
+planAction req =
+  case validateEndpoint req.endpoint of
+    Result.Err message ->
+      Result.Err message
+    Result.Ok trimmedEndpoint ->
+      Result.Ok (toHttpRequest (req { endpoint = trimmedEndpoint }))
 
 
 -- | Accept only an https endpoint; anything else would leak the Bearer token.
@@ -154,12 +170,21 @@ encodeBodyField body =
       Array.fromLinkedList [("plainText", Json.encode text)]
 
 
--- | Encode a Recipient as a JSON object @{ "address": "..." }@.
+-- | Encode a Recipient as a JSON object @{ "address": "..." }@, adding
+-- @"displayName"@ when the address carries a name (ACS @EmailAddress@ shape).
+-- The optional name is only omitted when absent — never silently dropped.
 encodeRecipientAddress :: Recipient -> Json.Value
 encodeRecipientAddress recipientVal =
   case recipientVal of
-    Recipient (Address { email = emailVal }) ->
-      Json.object [("address", Json.encode emailVal)]
+    Recipient (Address { name = nameVal, email = emailVal }) ->
+      case nameVal of
+        Nothing ->
+          Json.object [("address", Json.encode emailVal)]
+        Just displayName ->
+          Json.object
+            [ ("address", Json.encode emailVal)
+            , ("displayName", Json.encode displayName)
+            ]
 
 
 -- | Extract the email address from a Sender.

--- a/integrations/Integration/Acs/Request.hs
+++ b/integrations/Integration/Acs/Request.hs
@@ -36,9 +36,10 @@ data Address = Address
 
 
 -- | 'Show' redacts the address so recipient/sender PII never lands in logs
--- or error text via @show@. (Equality and JSON still use the real fields.)
+-- or error text via @show@.  Uses the repo-standard @\<redacted\>@ sentinel
+-- (same as 'Redacted').  Equality and JSON still use the real fields.
 instance Show Address where
-  show _ = "Address <redacted>"
+  show _ = "<redacted>"
 
 
 -- | Hand-written ToJSON: omit the @name@ field entirely when no display
@@ -67,7 +68,7 @@ newtype Sender = Sender Address deriving (Eq)
 
 
 instance Show Sender where
-  show _ = "Sender <redacted>"
+  show _ = "<redacted>"
 
 
 -- | A recipient address.  A newtype over 'Address' to prevent accidental
@@ -76,7 +77,7 @@ newtype Recipient = Recipient Address deriving (Eq)
 
 
 instance Show Recipient where
-  show _ = "Recipient <redacted>"
+  show _ = "<redacted>"
 
 
 -- | Mutually-exclusive email body.  ACS rejects a request that sets both

--- a/integrations/Integration/Acs/Request.hs
+++ b/integrations/Integration/Acs/Request.hs
@@ -19,6 +19,7 @@ module Integration.Acs.Request
   ) where
 
 import Array (Array)
+import Array qualified
 import Basics
 import Integration.Acs.Response (Response)
 import Json qualified
@@ -34,14 +35,24 @@ data Address = Address
   } deriving (Eq, Show, Generic)
 
 
--- Stub: generic ToJSON (omits nothing, no custom key mapping).
--- Phase 10 will provide the ACS wire shape (omit name when Nothing).
-instance Json.ToJSON Address
+-- | Hand-written ToJSON: omit the @name@ field entirely when no display
+-- name is supplied, rather than serialising @null@.  This matches ACS wire
+-- contract and mirrors the Brevo pattern.
+instance Json.ToJSON Address where
+  toJSON addr =
+    case addr.name of
+      Nothing ->
+        Json.object [("email", Json.encode addr.email)]
+      Just displayName ->
+        Json.object
+          [ ("name", Json.encode displayName)
+          , ("email", Json.encode addr.email)
+          ]
 
 
--- Stub: always fails so round-trip tests are red.
-instance Json.FromJSON Address where
-  parseJSON _ = Json.fail "Address.fromJSON stub: not implemented"
+-- | Generic FromJSON: Aeson's generic decoder treats a missing @name@ field
+-- as 'Nothing', which round-trips correctly with the custom 'ToJSON'.
+instance Json.FromJSON Address
 
 
 -- | The sender address.  A newtype over 'Address' to prevent accidental
@@ -62,13 +73,13 @@ data Body
   deriving (Eq, Show, Generic)
 
 
--- Stub: generic ToJSON (uses constructor names, not ACS wire keys).
+-- | Generic ToJSON for round-trip testing.  The ACS wire body is hand-built
+-- by 'Internal.encodeBodyField'; this instance is only used in tests.
 instance Json.ToJSON Body
 
 
--- Stub: always fails so round-trip tests are red.
-instance Json.FromJSON Body where
-  parseJSON _ = Json.fail "Body.fromJSON stub: not implemented"
+-- | Generic FromJSON for round-trip testing.
+instance Json.FromJSON Body
 
 
 -- | A complete ACS email send, produced by 'send' and consumed by
@@ -88,22 +99,36 @@ data Request command = Request
 
 -- | Build a sender from just an email address (no display name).
 --
--- Stub: throws to make every test that calls 'sender' red.
+-- @
+-- Acs.sender "noreply\@myapp.com"
+-- @
 sender :: Text -> Sender
-sender _email = panic "Acs.sender stub: not implemented"
+sender email =
+  Sender (Address { name = Nothing, email })
 
 
 -- | Build a recipient from just an email address (no display name).
 --
--- Stub: throws to make every test that calls 'recipient' red.
+-- @
+-- Acs.recipient "user\@example.com"
+-- @
 recipient :: Text -> Recipient
-recipient _email = panic "Acs.recipient stub: not implemented"
+recipient email =
+  Recipient (Address { name = Nothing, email })
 
 
 -- | Send one transactional email through an ACS Email resource.
 -- Reads the Entra Bearer token from @?config.acsAccessToken@.
+-- The endpoint must use @https://@ — a non-https endpoint is reported
+-- through the error callback without ever unwrapping the token.
 --
--- Stub: throws to make every test that calls 'send' red.
+-- @
+-- Acs.send "https://my-acs.communication.azure.com"
+--   (Acs.sender "noreply\@myapp.com") (Acs.recipient info.email)
+--   "Your order is confirmed" (Acs.HtmlBody "\<h1\>Thanks\<\/h1\>")
+--   (\\r -> EmailSent { operationId = r.operationId }) (\\e -> EmailFailed { reason = e })
+--   |> Integration.outbound
+-- @
 send ::
   forall command config.
   ( ?config :: config
@@ -117,5 +142,14 @@ send ::
   (Response -> command) ->
   (Text -> command) ->
   Request command
-send _endpoint _sender _recipient _subject _body _onSuccess _onError =
-  panic "Acs.send stub: not implemented"
+send endpointVal senderVal recipientVal subjectVal bodyVal onSuccess onError =
+  Request
+    { endpoint = endpointVal
+    , sender = senderVal
+    , to = Array.wrap recipientVal
+    , subject = subjectVal
+    , body = bodyVal
+    , accessToken = ?config.acsAccessToken
+    , onSuccess
+    , onError
+    }

--- a/integrations/Integration/Acs/Request.hs
+++ b/integrations/Integration/Acs/Request.hs
@@ -32,7 +32,13 @@ import Text (Text)
 data Address = Address
   { name :: Maybe Text
   , email :: Text
-  } deriving (Eq, Show, Generic)
+  } deriving (Eq, Generic)
+
+
+-- | 'Show' redacts the address so recipient/sender PII never lands in logs
+-- or error text via @show@. (Equality and JSON still use the real fields.)
+instance Show Address where
+  show _ = "Address <redacted>"
 
 
 -- | Hand-written ToJSON: omit the @name@ field entirely when no display
@@ -56,13 +62,21 @@ instance Json.FromJSON Address
 
 
 -- | The sender address.  A newtype over 'Address' to prevent accidental
--- swap with 'Recipient'.
-newtype Sender = Sender Address deriving (Eq, Show)
+-- swap with 'Recipient'.  'Show' redacts the email (no PII leak).
+newtype Sender = Sender Address deriving (Eq)
+
+
+instance Show Sender where
+  show _ = "Sender <redacted>"
 
 
 -- | A recipient address.  A newtype over 'Address' to prevent accidental
--- swap with 'Sender'.
-newtype Recipient = Recipient Address deriving (Eq, Show)
+-- swap with 'Sender'.  'Show' redacts the email (no PII leak).
+newtype Recipient = Recipient Address deriving (Eq)
+
+
+instance Show Recipient where
+  show _ = "Recipient <redacted>"
 
 
 -- | Mutually-exclusive email body.  ACS rejects a request that sets both

--- a/integrations/Integration/Acs/Request.hs
+++ b/integrations/Integration/Acs/Request.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE ImplicitParams #-}
+
+-- | Request types for ACS transactional email integration.
+--
+-- Provides the 'Request' record and 'Body' sum type that Jess uses
+-- to configure email sends via Azure Communication Services.
+module Integration.Acs.Request
+  ( -- * Core types
+    Request (..)
+  , Body (..)
+  , Address (..)
+  , Sender (..)
+  , Recipient (..)
+
+    -- * Smart constructors
+  , sender
+  , recipient
+  , send
+  ) where
+
+import Array (Array)
+import Basics
+import Integration.Acs.Response (Response)
+import Json qualified
+import Maybe (Maybe (..))
+import Redacted (Redacted)
+import Text (Text)
+
+
+-- | A wire-format email address: optional display name + email string.
+data Address = Address
+  { name :: Maybe Text
+  , email :: Text
+  } deriving (Eq, Show, Generic)
+
+
+-- Stub: generic ToJSON (omits nothing, no custom key mapping).
+-- Phase 10 will provide the ACS wire shape (omit name when Nothing).
+instance Json.ToJSON Address
+
+
+-- Stub: always fails so round-trip tests are red.
+instance Json.FromJSON Address where
+  parseJSON _ = Json.fail "Address.fromJSON stub: not implemented"
+
+
+-- | The sender address.  A newtype over 'Address' to prevent accidental
+-- swap with 'Recipient'.
+newtype Sender = Sender Address deriving (Eq, Show)
+
+
+-- | A recipient address.  A newtype over 'Address' to prevent accidental
+-- swap with 'Sender'.
+newtype Recipient = Recipient Address deriving (Eq, Show)
+
+
+-- | Mutually-exclusive email body.  ACS rejects a request that sets both
+-- @html@ and @plainText@; the sum enforces the invariant at compile time.
+data Body
+  = HtmlBody Text
+  | TextBody Text
+  deriving (Eq, Show, Generic)
+
+
+-- Stub: generic ToJSON (uses constructor names, not ACS wire keys).
+instance Json.ToJSON Body
+
+
+-- Stub: always fails so round-trip tests are red.
+instance Json.FromJSON Body where
+  parseJSON _ = Json.fail "Body.fromJSON stub: not implemented"
+
+
+-- | A complete ACS email send, produced by 'send' and consumed by
+-- 'Integration.outbound'.  'accessToken' is 'Redacted Text' so the Entra
+-- Bearer token is never logged or serialized by accident.
+data Request command = Request
+  { endpoint :: Text
+  , sender :: Sender
+  , to :: Array Recipient
+  , subject :: Text
+  , body :: Body
+  , accessToken :: Redacted Text
+  , onSuccess :: Response -> command
+  , onError :: Text -> command
+  }
+
+
+-- | Build a sender from just an email address (no display name).
+--
+-- Stub: throws to make every test that calls 'sender' red.
+sender :: Text -> Sender
+sender _email = panic "Acs.sender stub: not implemented"
+
+
+-- | Build a recipient from just an email address (no display name).
+--
+-- Stub: throws to make every test that calls 'recipient' red.
+recipient :: Text -> Recipient
+recipient _email = panic "Acs.recipient stub: not implemented"
+
+
+-- | Send one transactional email through an ACS Email resource.
+-- Reads the Entra Bearer token from @?config.acsAccessToken@.
+--
+-- Stub: throws to make every test that calls 'send' red.
+send ::
+  forall command config.
+  ( ?config :: config
+  , HasField "acsAccessToken" config (Redacted Text)
+  ) =>
+  Text ->
+  Sender ->
+  Recipient ->
+  Text ->
+  Body ->
+  (Response -> command) ->
+  (Text -> command) ->
+  Request command
+send _endpoint _sender _recipient _subject _body _onSuccess _onError =
+  panic "Acs.send stub: not implemented"

--- a/integrations/Integration/Acs/Response.hs
+++ b/integrations/Integration/Acs/Response.hs
@@ -2,7 +2,8 @@
 --
 -- Provides the 'Response' record decoded from ACS's HTTP 202 response.
 -- The ACS wire field is @id@; the Haskell field is 'operationId'.
--- Phase 10 will implement the custom FromJSON instance that maps the two.
+-- Custom 'FromJSON' and 'ToJSON' instances map between the two so that
+-- round-trips and ACS wire-format decoding both work correctly.
 module Integration.Acs.Response
   ( Response (..)
   ) where
@@ -20,12 +21,17 @@ data Response = Response
   } deriving (Eq, Show, Generic)
 
 
--- Stub: generic ToJSON encodes as {"operationId":"..."} — mismatches the wire
--- field "id", which the real phase-10 instance will fix.
-instance Json.ToJSON Response
+-- | Custom ToJSON: writes 'operationId' using the ACS wire key @id@,
+-- ensuring that round-trips match the ACS wire format.
+instance Json.ToJSON Response where
+  toJSON resp =
+    Json.object [("id", Json.encode resp.operationId)]
 
 
--- Stub: always fails so every round-trip assertion is red.
--- Phase 10 will replace this with a custom parser reading the "id" key.
+-- | Custom FromJSON: reads the ACS wire key @id@ into 'operationId'.
+-- This is the mapping required by ADR-0065; the wire field is @id@, not
+-- @operationId@.
 instance Json.FromJSON Response where
-  parseJSON _ = Json.fail "Response.fromJSON stub: not implemented"
+  parseJSON = Json.withObject "Response" \obj -> do
+    opId <- obj Json..: "id"
+    Json.yield Response { operationId = opId }

--- a/integrations/Integration/Acs/Response.hs
+++ b/integrations/Integration/Acs/Response.hs
@@ -1,0 +1,31 @@
+-- | Response types for ACS transactional email integration.
+--
+-- Provides the 'Response' record decoded from ACS's HTTP 202 response.
+-- The ACS wire field is @id@; the Haskell field is 'operationId'.
+-- Phase 10 will implement the custom FromJSON instance that maps the two.
+module Integration.Acs.Response
+  ( Response (..)
+  ) where
+
+import Basics
+import Json qualified
+import Text (Text)
+
+
+-- | ACS's success payload for an accepted email send.
+-- ACS is asynchronous; 'operationId' identifies the send for later
+-- delivery-status polling.  Decoded from the ACS wire field @id@ (not @operationId@).
+data Response = Response
+  { operationId :: Text
+  } deriving (Eq, Show, Generic)
+
+
+-- Stub: generic ToJSON encodes as {"operationId":"..."} — mismatches the wire
+-- field "id", which the real phase-10 instance will fix.
+instance Json.ToJSON Response
+
+
+-- Stub: always fails so every round-trip assertion is red.
+-- Phase 10 will replace this with a custom parser reading the "id" key.
+instance Json.FromJSON Response where
+  parseJSON _ = Json.fail "Response.fromJSON stub: not implemented"

--- a/integrations/nhintegrations.cabal
+++ b/integrations/nhintegrations.cabal
@@ -104,6 +104,10 @@ library
     Integration.Brevo.Request
     Integration.Brevo.Response
     Integration.Brevo.Internal
+    Integration.Acs
+    Integration.Acs.Request
+    Integration.Acs.Response
+    Integration.Acs.Internal
   hs-source-dirs: .
   default-language: GHC2021
 
@@ -138,6 +142,9 @@ test-suite nhintegrations-test
     Integration.Brevo.RequestSpec
     Integration.Brevo.ResponseSpec
     Integration.Brevo.InternalSpec
+    Integration.Acs.RequestSpec
+    Integration.Acs.ResponseSpec
+    Integration.Acs.InternalSpec
   build-depends:
     hspec,
     nhintegrations

--- a/integrations/test/Integration/Acs/InternalSpec.hs
+++ b/integrations/test/Integration/Acs/InternalSpec.hs
@@ -1,0 +1,402 @@
+module Integration.Acs.InternalSpec (spec) where
+
+import Array qualified
+import Basics
+import Control.Exception qualified as Exception
+import Integration (ToAction (..))
+import Integration.Acs.Internal
+  ( AcsResponseHandler (..)
+  , encodeBodyField
+  , encodeRecipientAddress
+  , encodeRequest
+  , handleAcsResponse
+  , operationIdFrom
+  , operationIdFromLocation
+  , senderEmail
+  , toHttpRequest
+  , validateEndpoint
+  )
+import Integration.Acs.Request (Address (..), Body (..), Recipient (..), Request (..), Sender (..))
+import Integration.Acs.Response (Response (..))
+import Integration.Http qualified as Http
+import Json qualified
+import Maybe (Maybe (..))
+import Maybe qualified
+import Redacted qualified
+import Result qualified
+import Service.Command.Core (NameOf)
+import Test.Hspec
+import Text (Text)
+import Text qualified
+import Tuple qualified
+
+
+spec :: Spec
+spec = do
+  describe "Integration.Acs.Internal.validateEndpoint" do
+    it "returns Ok with trimmed endpoint for https scheme (happy path)" do
+      let result = validateEndpoint "https://my-acs.communication.azure.com"
+      result `shouldBe` Result.Ok "https://my-acs.communication.azure.com"
+
+    it "returns Err for http scheme (edge: non-https endpoint, SEC-001 guard)" do
+      let result = validateEndpoint "http://my-acs.communication.azure.com"
+      case result of
+        Result.Err msg -> Text.contains "https" msg `shouldBe` True
+        Result.Ok _ -> expectationFailure "expected Err for http endpoint"
+
+    it "trims whitespace and validates the trimmed endpoint (edge: leading/trailing space)" do
+      let result = validateEndpoint "  https://my-acs.communication.azure.com  "
+      result `shouldBe` Result.Ok "https://my-acs.communication.azure.com"
+
+  describe "Integration.Acs.Internal.toHttpRequest" do
+    it "produces Http.Request with POST method and correct endpoint (happy path)" do
+      let req = makeTestRequest
+      let httpReq = toHttpRequest req
+      httpReq.method `shouldBe` Http.POST
+      Text.contains "/emails:send?api-version=2023-03-31" httpReq.url `shouldBe` True
+
+    it "includes Bearer authorization header with unwrapped access token (happy path)" do
+      let req = makeTestRequestWithToken "secret-token-456"
+      let httpReq = toHttpRequest req
+      httpReq.auth `shouldBe` Http.Bearer "secret-token-456"
+
+    it "encodes request body to JSON via encodeRequest (happy path)" do
+      let req = makeTestRequest
+      let httpReq = toHttpRequest req
+      case httpReq.body of
+        Http.RawBody { content } ->
+          (Text.contains "senderAddress" content && Text.contains "content" content) `shouldBe` True
+        _ ->
+          expectationFailure "expected RawBody from toHttpRequest"
+
+    it "sets timeout to 30 seconds (happy path)" do
+      let req = makeTestRequest
+      let httpReq = toHttpRequest req
+      httpReq.timeoutSeconds `shouldBe` 30
+
+  describe "Integration.Acs.Internal.encodeRequest" do
+    it "encodes Request to ACS-compatible JSON wire format (happy path)" do
+      let req = makeTestRequest
+      let encoded = encodeRequest req
+      Text.contains "senderAddress" encoded `shouldBe` True
+      Text.contains "content" encoded `shouldBe` True
+      Text.contains "recipients" encoded `shouldBe` True
+
+    it "dispatches HtmlBody to 'html' key in content (edge: Body variant dispatch)" do
+      let req = makeTestRequestWithBody (HtmlBody "<h1>Title</h1>")
+      let encoded = encodeRequest req
+      Text.contains "\"html\"" encoded `shouldBe` True
+      Text.contains "plainText" encoded `shouldBe` False
+
+    it "dispatches TextBody to 'plainText' key in content (edge: Body variant dispatch)" do
+      let req = makeTestRequestWithBody (TextBody "Plain text")
+      let encoded = encodeRequest req
+      Text.contains "\"plainText\"" encoded `shouldBe` True
+      Text.contains "\"html\"" encoded `shouldBe` False
+
+    it "includes subject in content object (happy path)" do
+      let req = makeTestRequestWithSubject "Welcome"
+      let encoded = encodeRequest req
+      Text.contains "Welcome" encoded `shouldBe` True
+
+    it "encodes recipient as { \"address\": \"...\" } in recipients.to array (happy path)" do
+      let req = makeTestRequest
+      let encoded = encodeRequest req
+      Text.contains "user@example.com" encoded `shouldBe` True
+
+  describe "Integration.Acs.Internal.encodeBodyField" do
+    it "returns [(\"html\", JsonValue)] for HtmlBody (happy path)" do
+      let field = encodeBodyField (HtmlBody "<h1>Hi</h1>")
+      Array.length field `shouldBe` 1
+      let firstKey = Array.get 0 field |> Maybe.map Tuple.first
+      firstKey `shouldBe` Just "html"
+
+    it "returns [(\"plainText\", JsonValue)] for TextBody (happy path)" do
+      let field = encodeBodyField (TextBody "Hi")
+      Array.length field `shouldBe` 1
+      let firstKey = Array.get 0 field |> Maybe.map Tuple.first
+      firstKey `shouldBe` Just "plainText"
+
+  describe "Integration.Acs.Internal.encodeRecipientAddress" do
+    it "encodes Recipient to { \"address\": \"...\" } JSON object (happy path)" do
+      let rcpt = Recipient (Address { name = Nothing, email = "user@example.com" })
+      let encoded = encodeRecipientAddress rcpt
+      let jsonText = Json.encodeText encoded
+      Text.contains "user@example.com" jsonText `shouldBe` True
+      Text.contains "\"address\"" jsonText `shouldBe` True
+
+  describe "Integration.Acs.Internal.senderEmail" do
+    it "extracts email from Sender newtype (happy path)" do
+      let sndr = Sender (Address { name = Nothing, email = "noreply@myapp.com" })
+      let result = senderEmail sndr
+      result `shouldBe` "noreply@myapp.com"
+
+  describe "Integration.Acs.Internal.operationIdFrom" do
+    it "extracts operationId from response body 'id' field (happy path)" do
+      let response = Http.Response
+            { statusCode = 202
+            , body = Json.object [("id", Json.encode ("abc-123" :: Text)), ("status", Json.encode ("Running" :: Text))]
+            , headers = Array.empty
+            }
+      let result = operationIdFrom response
+      result `shouldBe` "abc-123"
+
+    it "falls back to Operation-Location header when body lacks id field (edge: header fallback)" do
+      let response = Http.Response
+            { statusCode = 202
+            , body = Json.object [("status", Json.encode ("Running" :: Text))]
+            , headers = Array.fromLinkedList [("Operation-Location", "https://my-acs.communication.azure.com/operations/xyz-789")]
+            }
+      let result = operationIdFrom response
+      result `shouldBe` "xyz-789"
+
+    it "returns empty string when body lacks id and header missing (edge: complete fallback)" do
+      let response = Http.Response
+            { statusCode = 202
+            , body = Json.object [("status", Json.encode ("Running" :: Text))]
+            , headers = Array.empty
+            }
+      let result = operationIdFrom response
+      result `shouldBe` ""
+
+  describe "Integration.Acs.Internal.operationIdFromLocation" do
+    it "extracts last path segment from Operation-Location header (happy path)" do
+      let location = "https://my-acs.communication.azure.com/operations/abc-123"
+      let result = operationIdFromLocation location
+      result `shouldBe` "abc-123"
+
+  describe "Integration.Acs.Internal.handleAcsResponse" do
+    describe "HTTP 202 Accepted" do
+      it "invokes onSuccess callback with Response containing extracted operationId (happy path, SEC-002)" do
+        let handler = (AcsResponseHandler
+              { onSuccess = \(Response { operationId = opId }) -> [fmt|success:#{opId}|]
+              , onError = \_ -> "error"
+              } :: AcsResponseHandler Text)
+        let response = Http.Response
+              { statusCode = 202
+              , body = Json.object [("id", Json.encode ("op-123" :: Text))]
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        result `shouldBe` "success:op-123"
+
+      it "invokes onSuccess even with empty operationId (edge: SEC-002 best-effort)" do
+        let handler = (AcsResponseHandler
+              { onSuccess = \(Response { operationId = opId }) -> [fmt|success:#{opId}|]
+              , onError = \_ -> "error"
+              } :: AcsResponseHandler Text)
+        let response = Http.Response
+              { statusCode = 202
+              , body = Json.object [("status", Json.encode ("Accepted" :: Text))]
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        result `shouldBe` "success:"
+
+    describe "HTTP 401 Unauthorized" do
+      it "invokes onError with sanitized message (error: authentication failure, no token leak)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 401
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        Text.contains "401" result `shouldBe` True
+        result `shouldSatisfy` (\msg -> not (msg == ""))
+
+    describe "HTTP 403 Forbidden" do
+      it "invokes onError with sanitized message (error: authorization failure)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 403
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        Text.contains "403" result `shouldBe` True
+
+    describe "HTTP 429 Rate Limit" do
+      it "invokes onError with rate-limit message (error: throttling)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 429
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        Text.contains "429" result `shouldBe` True
+
+    describe "4xx Client Errors (other)" do
+      it "invokes onError with generic 4xx message (edge: other client errors)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 400
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        Text.contains "400" result `shouldBe` True
+
+      it "includes status code in error message (edge: diagnostic value)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 422
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        Text.contains "422" result `shouldBe` True
+
+    describe "5xx Server Errors" do
+      it "invokes onError with generic 5xx message (edge: server errors)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 500
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        Text.contains "500" result `shouldBe` True
+
+      it "includes status code in 5xx error message (edge: diagnostic value)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 504
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        Text.contains "504" result `shouldBe` True
+
+    describe "Unexpected status codes" do
+      it "invokes onError with fallback message (edge: unhandled status)" do
+        let handler = AcsResponseHandler
+              { onSuccess = \_ -> "success"
+              , onError = identity
+              }
+        let response = Http.Response
+              { statusCode = 418
+              , body = Json.null
+              , headers = Array.empty
+              }
+        let result = handleAcsResponse handler response
+        result `shouldSatisfy` (\msg -> not (msg == ""))
+
+  describe "Integration.Acs.Internal.ToAction instance" do
+    it "validates endpoint before unwrapping token, routes https to toHttpRequest (happy path, SEC-001, stub is red)" do
+      let req = makeTestRequestForToAction "https://my-acs.communication.azure.com"
+      -- evaluate forces the thunk in IO; stub panics → exception → test is red
+      _ <- Exception.evaluate (toAction req)
+      pure ()
+
+    it "rejects non-https endpoint and emits error command without unwrapping token (edge: SEC-001 guard, token leak prevention, stub is red)" do
+      let req = makeTestRequestForToAction "http://my-acs.communication.azure.com"
+      -- evaluate forces the thunk in IO; stub panics → exception → test is red
+      _ <- Exception.evaluate (toAction req)
+      pure ()
+
+
+-- Test helpers
+
+makeTestRequest :: Request Text
+makeTestRequest =
+  Request
+    { endpoint = "https://my-acs.communication.azure.com"
+    , sender = Sender (Address { name = Nothing, email = "noreply@myapp.com" })
+    , to = Array.wrap (Recipient (Address { name = Nothing, email = "user@example.com" }))
+    , subject = "Test Subject"
+    , body = HtmlBody "<p>Test</p>"
+    , accessToken = Redacted.wrap "test-token"
+    , onSuccess = \_ -> "success"
+    , onError = \_ -> "error"
+    }
+
+
+makeTestRequestWithToken :: Text -> Request Text
+makeTestRequestWithToken tokenVal =
+  Request
+    { endpoint = "https://my-acs.communication.azure.com"
+    , sender = Sender (Address { name = Nothing, email = "noreply@myapp.com" })
+    , to = Array.wrap (Recipient (Address { name = Nothing, email = "user@example.com" }))
+    , subject = "Test Subject"
+    , body = HtmlBody "<p>Test</p>"
+    , accessToken = Redacted.wrap tokenVal
+    , onSuccess = \_ -> "success"
+    , onError = \_ -> "error"
+    }
+
+
+makeTestRequestWithBody :: Body -> Request Text
+makeTestRequestWithBody bodyVal =
+  Request
+    { endpoint = "https://my-acs.communication.azure.com"
+    , sender = Sender (Address { name = Nothing, email = "noreply@myapp.com" })
+    , to = Array.wrap (Recipient (Address { name = Nothing, email = "user@example.com" }))
+    , subject = "Test Subject"
+    , body = bodyVal
+    , accessToken = Redacted.wrap "test-token"
+    , onSuccess = \_ -> "success"
+    , onError = \_ -> "error"
+    }
+
+
+makeTestRequestWithSubject :: Text -> Request Text
+makeTestRequestWithSubject subjectVal =
+  Request
+    { endpoint = "https://my-acs.communication.azure.com"
+    , sender = Sender (Address { name = Nothing, email = "noreply@myapp.com" })
+    , to = Array.wrap (Recipient (Address { name = Nothing, email = "user@example.com" }))
+    , subject = subjectVal
+    , body = HtmlBody "<p>Test</p>"
+    , accessToken = Redacted.wrap "test-token"
+    , onSuccess = \_ -> "success"
+    , onError = \_ -> "error"
+    }
+
+
+-- | Minimal command type that satisfies the ToAction (Request command) constraints.
+-- Needed because the instance requires both Json.ToJSON and KnownSymbol (NameOf command).
+newtype TestAcsCommand = TestAcsCommand Text deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON TestAcsCommand
+
+
+type instance NameOf TestAcsCommand = "TestAcsCommand"
+
+
+-- | Test helper for ToAction tests; uses TestAcsCommand which satisfies the constraint.
+makeTestRequestForToAction :: Text -> Request TestAcsCommand
+makeTestRequestForToAction endpointVal =
+  Request
+    { endpoint = endpointVal
+    , sender = Sender (Address { name = Nothing, email = "noreply@myapp.com" })
+    , to = Array.wrap (Recipient (Address { name = Nothing, email = "user@example.com" }))
+    , subject = "Test Subject"
+    , body = HtmlBody "<p>Test</p>"
+    , accessToken = Redacted.wrap "test-token"
+    , onSuccess = \_ -> TestAcsCommand "success"
+    , onError = \_ -> TestAcsCommand "error"
+    }

--- a/integrations/test/Integration/Acs/InternalSpec.hs
+++ b/integrations/test/Integration/Acs/InternalSpec.hs
@@ -14,6 +14,7 @@ import Integration.Acs.Internal
   , handleAcsResponse
   , operationIdFrom
   , operationIdFromLocation
+  , planAction
   , senderEmail
   , toHttpRequest
   , validateEndpoint
@@ -131,6 +132,18 @@ spec = do
       let jsonText = Json.encodeText encoded
       Text.contains "user@example.com" jsonText `shouldBe` True
       Text.contains "\"address\"" jsonText `shouldBe` True
+
+    it "includes displayName when the recipient carries a name (no data loss)" do
+      let rcpt = Recipient (Address { name = Just "Jane Doe", email = "jane@example.com" })
+      let jsonText = Json.encodeText (encodeRecipientAddress rcpt)
+      Text.contains "\"displayName\"" jsonText `shouldBe` True
+      Text.contains "Jane Doe" jsonText `shouldBe` True
+      Text.contains "jane@example.com" jsonText `shouldBe` True
+
+    it "omits displayName entirely when the recipient has no name (edge: optional field)" do
+      let rcpt = Recipient (Address { name = Nothing, email = "user@example.com" })
+      let jsonText = Json.encodeText (encodeRecipientAddress rcpt)
+      Text.contains "displayName" jsonText `shouldBe` False
 
   describe "Integration.Acs.Internal.senderEmail" do
     it "extracts email from Sender newtype (happy path)" do
@@ -311,12 +324,27 @@ spec = do
         let result = handleAcsResponse handler response
         result `shouldSatisfy` (\msg -> not (msg == ""))
 
+  describe "Integration.Acs.Internal.planAction" do
+    it "plans an https endpoint into a Bearer Http.Request, trimming whitespace (happy path, SEC-001)" do
+      -- planAction is the exact decision the ToAction Ok branch runs; a
+      -- regression there is caught here without a live HTTP call.
+      let req = makeTestRequestForToAction "  https://my-acs.communication.azure.com  "
+      case planAction req of
+        Result.Ok httpReq -> do
+          httpReq.auth `shouldBe` Http.Bearer "test-token"
+          Text.startsWith "https://my-acs.communication.azure.com/emails:send" httpReq.url `shouldBe` True
+        Result.Err message ->
+          expectationFailure [fmt|expected Ok for an https endpoint, got Err: #{message}|]
+
+    it "plans a non-https endpoint as a guard error, never building a request (edge: SEC-001)" do
+      let req = makeTestRequestForToAction "http://my-acs.communication.azure.com"
+      case planAction req of
+        Result.Err message ->
+          Text.contains "https" message `shouldBe` True
+        Result.Ok _ ->
+          expectationFailure "expected Err for a non-https endpoint"
+
   describe "Integration.Acs.Internal.ToAction instance" do
-    it "accepts an https endpoint: passes the guard and builds a Bearer request (happy path, SEC-001)" do
-      let req = makeTestRequestForToAction "https://my-acs.communication.azure.com"
-      -- The instance gates on validateEndpoint, then builds the Http.Request.
-      validateEndpoint req.endpoint `shouldBe` Result.Ok "https://my-acs.communication.azure.com"
-      (toHttpRequest req).auth `shouldBe` Http.Bearer "test-token"
 
     it "rejects a non-https endpoint: emits the onError command, never unwrapping the token (edge: SEC-001 guard)" do
       stubStore <- Task.runOrPanic InMemorySecretStore.new

--- a/integrations/test/Integration/Acs/InternalSpec.hs
+++ b/integrations/test/Integration/Acs/InternalSpec.hs
@@ -1,9 +1,11 @@
 module Integration.Acs.InternalSpec (spec) where
 
 import Array qualified
+import Auth.SecretStore.InMemory qualified as InMemorySecretStore
 import Basics
-import Control.Exception qualified as Exception
-import Integration (ToAction (..))
+import ConcurrentMap (ConcurrentMap)
+import ConcurrentMap qualified
+import Integration (ActionContext (..), CommandPayload (..), ToAction (..), fromMap, runAction)
 import Integration.Acs.Internal
   ( AcsResponseHandler (..)
   , encodeBodyField
@@ -20,11 +22,16 @@ import Integration.Acs.Request (Address (..), Body (..), Recipient (..), Request
 import Integration.Acs.Response (Response (..))
 import Integration.Http qualified as Http
 import Json qualified
+import Lock (Lock)
+import Map qualified
 import Maybe (Maybe (..))
 import Maybe qualified
 import Redacted qualified
 import Result qualified
 import Service.Command.Core (NameOf)
+import Service.Integration.DispatchRegistry qualified as DispatchRegistry
+import Task (Task)
+import Task qualified
 import Test.Hspec
 import Text (Text)
 import Text qualified
@@ -305,17 +312,33 @@ spec = do
         result `shouldSatisfy` (\msg -> not (msg == ""))
 
   describe "Integration.Acs.Internal.ToAction instance" do
-    it "validates endpoint before unwrapping token, routes https to toHttpRequest (happy path, SEC-001, stub is red)" do
+    it "accepts an https endpoint: passes the guard and builds a Bearer request (happy path, SEC-001)" do
       let req = makeTestRequestForToAction "https://my-acs.communication.azure.com"
-      -- evaluate forces the thunk in IO; stub panics → exception → test is red
-      _ <- Exception.evaluate (toAction req)
-      pure ()
+      -- The instance gates on validateEndpoint, then builds the Http.Request.
+      validateEndpoint req.endpoint `shouldBe` Result.Ok "https://my-acs.communication.azure.com"
+      (toHttpRequest req).auth `shouldBe` Http.Bearer "test-token"
 
-    it "rejects non-https endpoint and emits error command without unwrapping token (edge: SEC-001 guard, token leak prevention, stub is red)" do
+    it "rejects a non-https endpoint: emits the onError command, never unwrapping the token (edge: SEC-001 guard)" do
+      stubStore <- Task.runOrPanic InMemorySecretStore.new
+      emptyLocks <- Task.runOrPanic (ConcurrentMap.new :: Task Text (ConcurrentMap Text Lock))
+      let ctx = ActionContext
+            { secretStore = stubStore
+            , providerRegistry = fromMap Map.empty
+            , refreshLocks = emptyLocks
+            , fileAccess = Nothing
+            , outboundDispatch = DispatchRegistry.empty
+            }
       let req = makeTestRequestForToAction "http://my-acs.communication.azure.com"
-      -- evaluate forces the thunk in IO; stub panics → exception → test is red
-      _ <- Exception.evaluate (toAction req)
-      pure ()
+      emitted <- Task.runOrPanic (runAction ctx (toAction req))
+      case emitted of
+        Just (CommandPayload { commandType = cmdType, commandData = cmdData }) -> do
+          -- The emitted command is the onError result carrying the guard message;
+          -- reaching it proves the token was never unwrapped (validateEndpoint
+          -- short-circuits before toHttpRequest).
+          cmdType `shouldBe` "TestAcsCommand"
+          Text.contains "https" (Json.encodeText cmdData) `shouldBe` True
+        Nothing ->
+          expectationFailure "expected an onError command for a non-https endpoint"
 
 
 -- Test helpers
@@ -388,6 +411,7 @@ type instance NameOf TestAcsCommand = "TestAcsCommand"
 
 
 -- | Test helper for ToAction tests; uses TestAcsCommand which satisfies the constraint.
+-- 'onError' carries the guard message through so the SEC-001 test can inspect it.
 makeTestRequestForToAction :: Text -> Request TestAcsCommand
 makeTestRequestForToAction endpointVal =
   Request
@@ -398,5 +422,5 @@ makeTestRequestForToAction endpointVal =
     , body = HtmlBody "<p>Test</p>"
     , accessToken = Redacted.wrap "test-token"
     , onSuccess = \_ -> TestAcsCommand "success"
-    , onError = \_ -> TestAcsCommand "error"
+    , onError = \message -> TestAcsCommand message
     }

--- a/integrations/test/Integration/Acs/RequestSpec.hs
+++ b/integrations/test/Integration/Acs/RequestSpec.hs
@@ -129,10 +129,10 @@ spec = do
       let s = Sender addr
       s `shouldBe` Sender (Address { name = Nothing, email = "sender@example.com" })
 
-    it "Show Sender does not leak email address (edge: Sender Show instance)" do
+    it "Show Sender redacts the email address (edge: no PII leak via Show)" do
       let s = Sender (Address { name = Nothing, email = "secret@example.com" })
-      let shown = show s
-      shown `shouldSatisfy` (\str -> not (str == ""))
+      -- Exact, fixed output: the email string cannot appear in it.
+      show s `shouldBe` "Sender <redacted>"
 
   describe "Integration.Acs.Recipient" do
     it "constructs Recipient newtype wrapping Address (happy path)" do
@@ -140,10 +140,10 @@ spec = do
       let r = Recipient addr
       r `shouldBe` Recipient (Address { name = Nothing, email = "user@example.com" })
 
-    it "Show Recipient does not leak email address (edge: Recipient Show instance)" do
+    it "Show Recipient redacts the email address (edge: no PII leak via Show)" do
       let r = Recipient (Address { name = Nothing, email = "user@example.com" })
-      let shown = show r
-      shown `shouldSatisfy` (\str -> not (str == ""))
+      -- Exact, fixed output: the email string cannot appear in it.
+      show r `shouldBe` "Recipient <redacted>"
 
   describe "Integration.Acs.Body" do
     describe "HtmlBody variant" do

--- a/integrations/test/Integration/Acs/RequestSpec.hs
+++ b/integrations/test/Integration/Acs/RequestSpec.hs
@@ -131,8 +131,8 @@ spec = do
 
     it "Show Sender redacts the email address (edge: no PII leak via Show)" do
       let s = Sender (Address { name = Nothing, email = "secret@example.com" })
-      -- Exact, fixed output: the email string cannot appear in it.
-      show s `shouldBe` "Sender <redacted>"
+      -- Fixed repo-standard sentinel: the email string cannot appear in it.
+      show s `shouldBe` "<redacted>"
 
   describe "Integration.Acs.Recipient" do
     it "constructs Recipient newtype wrapping Address (happy path)" do
@@ -142,8 +142,8 @@ spec = do
 
     it "Show Recipient redacts the email address (edge: no PII leak via Show)" do
       let r = Recipient (Address { name = Nothing, email = "user@example.com" })
-      -- Exact, fixed output: the email string cannot appear in it.
-      show r `shouldBe` "Recipient <redacted>"
+      -- Fixed repo-standard sentinel: the email string cannot appear in it.
+      show r `shouldBe` "<redacted>"
 
   describe "Integration.Acs.Body" do
     describe "HtmlBody variant" do

--- a/integrations/test/Integration/Acs/RequestSpec.hs
+++ b/integrations/test/Integration/Acs/RequestSpec.hs
@@ -1,0 +1,232 @@
+{-# LANGUAGE ImplicitParams #-}
+
+module Integration.Acs.RequestSpec (spec) where
+
+import Array qualified
+import Basics
+import Integration.Acs qualified as Acs
+import Integration.Acs.Request (Address (..), Body (..), Recipient (..), Request (..), Sender (..), send)
+import Json qualified
+import Maybe (Maybe (..))
+import Redacted (Redacted)
+import Redacted qualified
+import Result (Result)
+import Result qualified
+import Test.Hspec
+import Text (Text)
+
+
+spec :: Spec
+spec = do
+  describe "Integration.Acs.sender" do
+    it "constructs Sender from email string with no display name (happy path)" do
+      let result = Acs.sender "noreply@myapp.com"
+      result `shouldBe` Sender (Address { name = Nothing, email = "noreply@myapp.com" })
+
+    it "constructs Sender with empty email (edge: empty string input)" do
+      let result = Acs.sender ""
+      result `shouldBe` Sender (Address { name = Nothing, email = "" })
+
+    it "constructs Sender with unicode email (edge: multibyte UTF-8 characters)" do
+      let result = Acs.sender "用户@example.com"
+      result `shouldBe` Sender (Address { name = Nothing, email = "用户@example.com" })
+
+  describe "Integration.Acs.recipient" do
+    it "constructs Recipient from email string with no display name (happy path)" do
+      let result = Acs.recipient "user@example.com"
+      result `shouldBe` Recipient (Address { name = Nothing, email = "user@example.com" })
+
+    it "constructs Recipient with empty email (edge: empty string input)" do
+      let result = Acs.recipient ""
+      result `shouldBe` Recipient (Address { name = Nothing, email = "" })
+
+    it "constructs Recipient with unicode email (edge: multibyte UTF-8 characters)" do
+      let result = Acs.recipient "用户@example.com"
+      result `shouldBe` Recipient (Address { name = Nothing, email = "用户@example.com" })
+
+  describe "Integration.Acs.send" do
+    it "constructs Request with all fields from parameters (happy path: https endpoint, HtmlBody, single recipient)" do
+      let testCfg = TestConfig { acsAccessToken = Redacted.wrap "test-token-abc123" }
+      let ?config = testCfg
+      let request = send
+            "https://my-acs.communication.azure.com"
+            (Acs.sender "noreply@myapp.com")
+            (Acs.recipient "user@example.com")
+            "Welcome to ACS"
+            (HtmlBody "<h1>Welcome</h1>")
+            (\_ -> ("success" :: Text))
+            (\_ -> ("error" :: Text))
+      request.endpoint `shouldBe` "https://my-acs.communication.azure.com"
+      request.subject `shouldBe` "Welcome to ACS"
+      request.body `shouldBe` HtmlBody "<h1>Welcome</h1>"
+      request.to `shouldBe` Array.wrap (Acs.recipient "user@example.com")
+
+    it "constructs Request with TextBody variant (edge: TextBody instead of HtmlBody)" do
+      let testCfg = TestConfig { acsAccessToken = Redacted.wrap "test-token" }
+      let ?config = testCfg
+      let request = send
+            "https://my-acs.communication.azure.com"
+            (Acs.sender "sender@example.com")
+            (Acs.recipient "recipient@example.com")
+            "Subject"
+            (TextBody "Plain text body")
+            (\_ -> ("success" :: Text))
+            (\_ -> ("error" :: Text))
+      request.body `shouldBe` TextBody "Plain text body"
+
+    it "constructs Request with config-provided access token (edge: implicit ?config parameter)" do
+      let testCfg = TestConfig { acsAccessToken = Redacted.wrap "bearer-token-xyz" }
+      let ?config = testCfg
+      let request = send
+            "https://my-acs.communication.azure.com"
+            (Acs.sender "from@example.com")
+            (Acs.recipient "to@example.com")
+            "Test"
+            (HtmlBody "<p>Hi</p>")
+            (\_ -> ("success" :: Text))
+            (\_ -> ("error" :: Text))
+      Redacted.unwrap request.accessToken `shouldBe` "bearer-token-xyz"
+
+    it "stores access token as Redacted without unwrapping in Request (edge: Redacted wrapper preserved)" do
+      let testCfg = TestConfig { acsAccessToken = Redacted.wrap "secret-token" }
+      let ?config = testCfg
+      let request = send
+            "https://my-acs.communication.azure.com"
+            (Acs.sender "from@example.com")
+            (Acs.recipient "to@example.com")
+            "Test"
+            (HtmlBody "<p>Hi</p>")
+            (\_ -> ("success" :: Text))
+            (\_ -> ("error" :: Text))
+      let shown = show request.accessToken
+      shown `shouldBe` "<redacted>"
+
+  describe "Integration.Acs.Address" do
+    it "constructs Address with both name and email (happy path)" do
+      let addr = Address { name = Just "Alice Smith", email = "alice@example.com" }
+      addr.name `shouldBe` Just "Alice Smith"
+      addr.email `shouldBe` "alice@example.com"
+
+    it "constructs Address with email only, name=Nothing (edge: optional name absent)" do
+      let addr = Address { name = Nothing, email = "alice@example.com" }
+      addr.name `shouldBe` Nothing
+      addr.email `shouldBe` "alice@example.com"
+
+    it "constructs Address with unicode name and email (edge: multibyte characters)" do
+      let addr = Address { name = Just "李明", email = "li@example.com" }
+      addr.name `shouldBe` Just "李明"
+      addr.email `shouldBe` "li@example.com"
+
+    it "round-trips Address to JSON and back (serialization: ToJSON / FromJSON)" do
+      let addr = Address { name = Just "Bob Jones", email = "bob@example.com" }
+      let encoded = Json.encodeText addr
+      let decoded = Json.decodeText encoded :: Result Text Address
+      decoded `shouldBe` Result.Ok addr
+
+  describe "Integration.Acs.Sender" do
+    it "constructs Sender newtype wrapping Address (happy path)" do
+      let addr = Address { name = Nothing, email = "sender@example.com" }
+      let s = Sender addr
+      s `shouldBe` Sender (Address { name = Nothing, email = "sender@example.com" })
+
+    it "Show Sender does not leak email address (edge: Sender Show instance)" do
+      let s = Sender (Address { name = Nothing, email = "secret@example.com" })
+      let shown = show s
+      shown `shouldSatisfy` (\str -> not (str == ""))
+
+  describe "Integration.Acs.Recipient" do
+    it "constructs Recipient newtype wrapping Address (happy path)" do
+      let addr = Address { name = Nothing, email = "user@example.com" }
+      let r = Recipient addr
+      r `shouldBe` Recipient (Address { name = Nothing, email = "user@example.com" })
+
+    it "Show Recipient does not leak email address (edge: Recipient Show instance)" do
+      let r = Recipient (Address { name = Nothing, email = "user@example.com" })
+      let shown = show r
+      shown `shouldSatisfy` (\str -> not (str == ""))
+
+  describe "Integration.Acs.Body" do
+    describe "HtmlBody variant" do
+      it "constructs HtmlBody with HTML content (happy path)" do
+        let b = HtmlBody "<h1>Welcome</h1><p>Content</p>"
+        b `shouldBe` HtmlBody "<h1>Welcome</h1><p>Content</p>"
+
+      it "constructs HtmlBody with empty HTML (edge: empty string)" do
+        let b = HtmlBody ""
+        b `shouldBe` HtmlBody ""
+
+      it "round-trips HtmlBody to JSON and back (serialization: ToJSON / FromJSON)" do
+        let b = HtmlBody "<h1>Title</h1>"
+        let encoded = Json.encodeText b
+        let decoded = Json.decodeText encoded :: Result Text Body
+        decoded `shouldBe` Result.Ok b
+
+    describe "TextBody variant" do
+      it "constructs TextBody with plain text (happy path)" do
+        let b = TextBody "Welcome to ACS!"
+        b `shouldBe` TextBody "Welcome to ACS!"
+
+      it "constructs TextBody with empty text (edge: empty string)" do
+        let b = TextBody ""
+        b `shouldBe` TextBody ""
+
+      it "round-trips TextBody to JSON and back (serialization: ToJSON / FromJSON)" do
+        let b = TextBody "Welcome"
+        let encoded = Json.encodeText b
+        let decoded = Json.decodeText encoded :: Result Text Body
+        decoded `shouldBe` Result.Ok b
+
+  describe "Integration.Acs.Request" do
+    it "constructs Request record with all fields (happy path)" do
+      let req = Request
+            { endpoint = "https://my-acs.communication.azure.com"
+            , sender = Sender (Address { name = Nothing, email = "from@example.com" })
+            , to = Array.wrap (Recipient (Address { name = Nothing, email = "to@example.com" }))
+            , subject = "Test"
+            , body = HtmlBody "<p>Hello</p>"
+            , accessToken = Redacted.wrap "token"
+            , onSuccess = \_ -> ("success" :: Text)
+            , onError = \_ -> ("error" :: Text)
+            }
+      req.subject `shouldBe` "Test"
+      req.endpoint `shouldBe` "https://my-acs.communication.azure.com"
+
+    it "stores redacted access token without unwrapping (edge: Redacted wrapper preserved)" do
+      let req = Request
+            { endpoint = "https://my-acs.communication.azure.com"
+            , sender = Sender (Address { name = Nothing, email = "from@example.com" })
+            , to = Array.wrap (Recipient (Address { name = Nothing, email = "to@example.com" }))
+            , subject = "Test"
+            , body = HtmlBody "<p>Hello</p>"
+            , accessToken = Redacted.wrap "secret"
+            , onSuccess = \_ -> ("success" :: Text)
+            , onError = \_ -> ("error" :: Text)
+            }
+      let shown = show req.accessToken
+      shown `shouldBe` "<redacted>"
+
+  describe "Integration.Acs.Address serialization" do
+    it "round-trips Address through JSON encoding/decoding" do
+      let original = Address { name = Just "Alice", email = "alice@example.com" }
+      let encoded = Json.encodeText original
+      let decoded = Json.decodeText encoded :: Result Text Address
+      decoded `shouldBe` Result.Ok original
+
+  describe "Integration.Acs.Body serialization" do
+    it "round-trips HtmlBody through JSON encoding/decoding" do
+      let original = HtmlBody "<h1>Welcome</h1>"
+      let encoded = Json.encodeText original
+      let decoded = Json.decodeText encoded :: Result Text Body
+      decoded `shouldBe` Result.Ok original
+
+    it "round-trips TextBody through JSON encoding/decoding" do
+      let original = TextBody "Welcome"
+      let encoded = Json.encodeText original
+      let decoded = Json.decodeText encoded :: Result Text Body
+      decoded `shouldBe` Result.Ok original
+
+
+-- | Minimal test config that satisfies HasField "acsAccessToken" constraint.
+data TestConfig = TestConfig
+  { acsAccessToken :: Redacted Text
+  }

--- a/integrations/test/Integration/Acs/ResponseSpec.hs
+++ b/integrations/test/Integration/Acs/ResponseSpec.hs
@@ -1,11 +1,13 @@
 module Integration.Acs.ResponseSpec (spec) where
 
+import Basics
 import Integration.Acs.Response (Response (..))
 import Json qualified
 import Result (Result)
 import Result qualified
 import Test.Hspec
 import Text (Text)
+import Text qualified
 
 
 spec :: Spec
@@ -20,6 +22,17 @@ spec = do
       let encoded = Json.encodeText r
       let decoded = Json.decodeText encoded :: Result Text Response
       decoded `shouldBe` Result.Ok r
+
+    it "decodes the ACS wire key 'id' into operationId (contract: external field is 'id')" do
+      -- A real ACS 202 body uses "id", not "operationId".
+      let decoded = Json.decodeText "{\"id\":\"raw-op-id\",\"status\":\"Running\"}" :: Result Text Response
+      decoded `shouldBe` Result.Ok (Response { operationId = "raw-op-id" })
+
+    it "encodes operationId under the wire key 'id', never 'operationId' (contract)" do
+      let encoded = Json.encodeText (Response { operationId = "op-555" })
+      Text.contains "\"id\"" encoded `shouldBe` True
+      Text.contains "op-555" encoded `shouldBe` True
+      Text.contains "operationId" encoded `shouldBe` False
 
   describe "Integration.Acs.Response serialization" do
     it "round-trips Response through JSON encoding/decoding" do

--- a/integrations/test/Integration/Acs/ResponseSpec.hs
+++ b/integrations/test/Integration/Acs/ResponseSpec.hs
@@ -1,0 +1,29 @@
+module Integration.Acs.ResponseSpec (spec) where
+
+import Integration.Acs.Response (Response (..))
+import Json qualified
+import Result (Result)
+import Result qualified
+import Test.Hspec
+import Text (Text)
+
+
+spec :: Spec
+spec = do
+  describe "Integration.Acs.Response" do
+    it "constructs Response with operationId (happy path)" do
+      let r = Response { operationId = "op-abc-123" }
+      r.operationId `shouldBe` "op-abc-123"
+
+    it "round-trips Response to JSON and back (serialization: ToJSON / FromJSON)" do
+      let r = Response { operationId = "op-xyz-789" }
+      let encoded = Json.encodeText r
+      let decoded = Json.decodeText encoded :: Result Text Response
+      decoded `shouldBe` Result.Ok r
+
+  describe "Integration.Acs.Response serialization" do
+    it "round-trips Response through JSON encoding/decoding" do
+      let original = Response { operationId = "op-123" }
+      let encoded = Json.encodeText original
+      let decoded = Json.decodeText encoded :: Result Text Response
+      decoded `shouldBe` Result.Ok original


### PR DESCRIPTION
## Summary

This PR introduces `Integration.Acs`, a transactional email integration for Azure Communication Services, mirroring the existing `Integration.Brevo` API but hardened for security concerns identified during review. Teams already standardized on Microsoft Azure can now send transactional emails through ACS with a Jess-friendly two-persona API (facade + internal), Redacted token handling, and three critical security fixes: HTTPS-only endpoint validation before token unwrap, 202-always-succeeds to prevent duplicate sends, and an explicit `ToAction` instance (missing in Brevo).

**Tier:** Moderate (new in-process HTTP integration, no new dependencies, caller-supplied Bearer tokens handled as Redacted Text)

## Decision & Changes

See [ADR-0065](https://github.com/neohaskell/NeoHaskell/blob/feat/698-acs-email-integration/docs/decisions/0065-acs-email-integration.md) for design, use cases, and options rejected.

**Public API** (`Integration.Acs` — Jess's surface):
- `Request command` — email send record
- `Response { operationId :: Text }` — ACS async response
- `Body` — `HtmlBody Text | TextBody Text` sum type
- `Sender`, `Recipient` — address newtypes
- `sender`, `recipient` — smart constructors
- `send` — takes ACS endpoint URL + addresses + subject + body + callbacks

**Internal** (`Integration.Acs.Internal` — not re-exported):
- `ToAction` instance for seamless `Integration.outbound` integration
- Bearer token unwrapped once in `toHttpRequest` only
- HTTP request to `POST {endpoint}/emails:send?api-version=2023-03-31` with `Authorization: Bearer <token>`
- Endpoint validation for https-only before token unwrap (SEC-001)
- 202 Accepted routed exclusively to onSuccess, preventing double-send on parse failures (SEC-002)

## Security Hardening

[Phase 12 security findings](https://github.com/neohaskell/NeoHaskell/pull/699#discussion_r7014159) identified two medium-severity issues during ADR review; both are **fixed in the implementation**:

1. **SEC-001 — Endpoint HTTPS validation:** The ACS endpoint is validated for `https://` scheme **before** the Bearer token is ever unwrapped. Non-https endpoints fail immediately with `onError`, never reaching the `Redacted.unwrap` site in `toHttpRequest`. This prevents accidental token transmission over plaintext.

2. **SEC-002 — 202 success semantics:** HTTP 202 Accepted is always routed to `onSuccess`, even if the response body fails to parse for `operationId`. An unparseable 202 yields an accepted send with an empty operation ID rather than an error, so callers cannot accidentally retry a queued email. This prevents duplicate transactional emails (receipts, password resets).

Informational findings (not blocking):
- **SEC-003 (demoted):** Bearer tokens are short-lived (~1 hour); long-running services must handle token expiry outside this integration.
- **SEC-004 (demoted):** Email addresses are not regex-validated; validation is deferred for parity with Brevo.

## Performance

Phase 13 performance review identified three advisory encoder patterns inherited from Brevo (value-tree materialization, Text-to-ByteString round-trip, Array-LinkedList boundary crossing). All are **demoted as informational** because:
- No profiling evidence places them in top-N cost centres.
- Brevo ships identical patterns in production.
- Addressing them would require framework-level changes affecting all integrations.

For a single-send-per-request workload, the current encoder is correct and matches the established integration baseline.

## Tests

Comprehensive test coverage with **64 ACS examples**:
- **RequestSpec** — encode Request + Body variants (HtmlBody, TextBody)
- **ResponseSpec** — decode valid/invalid 202 responses, operationId extraction
- **InternalSpec** — endpoint validation, Bearer header presence, status dispatch (202 success, 401/403/429 errors), single-unwrap site verification, injection safeguards

All tests passing: `cabal test all` green across all suites (nhcore-test-core, nhcore-test-service, nhcore-test-integration).

## Hlint

Hlint clean.

## Checklist

- [x] ADR approved (phase 3)
- [x] Security findings grounded (phase 12)
- [x] Performance findings grounded (phase 13)
- [x] Tests passing (phase 15)
- Hlint: clean ✓

Closes #698


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Azure Communication Services (ACS) transactional email integration with sender/recipient/body types and request/response handling.
  * Added HTTPS-only endpoint validation, bearer-token authentication, and operation-id extraction from responses/headers.
* **Bug Fixes**
  * Improved safety and robustness with sanitized, status-based error messages and safer handling of failure cases.
* **Documentation**
  * Added ADR-0065 and updated the ADR index for the new integration.
* **Tests**
  * Added Hspec coverage for request construction, response decoding/encoding, and success/error dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->