### PR TITLE
fix(skills): make verify-leaf blocker-counting envelope-aware

### DIFF
--- a/.claude/skills/feature-pipeline-preview/scripts/verify-leaf.py
+++ b/.claude/skills/feature-pipeline-preview/scripts/verify-leaf.py
@@ -74,11 +74,25 @@ def count_blockers(findings_path: Path) -> int | None:
     except json.JSONDecodeError as e:
         print(f"verify-leaf: cannot parse {findings_path}: {e}", file=sys.stderr)
         return None
-    if not isinstance(data, list):
-        print(f"verify-leaf: {findings_path}: expected array", file=sys.stderr)
+    # record-findings.py writes an envelope: {"blockers": N, "findings": [...]}.
+    # A bare array (hand-authored / legacy) is still accepted for compatibility.
+    if isinstance(data, dict):
+        if isinstance(data.get("blockers"), int):
+            return data["blockers"]
+        entries = data.get("findings")
+    elif isinstance(data, list):
+        entries = data
+    else:
+        entries = None
+    if not isinstance(entries, list):
+        print(
+            f"verify-leaf: {findings_path}: expected an array or an "
+            f"envelope with 'blockers'/'findings'",
+            file=sys.stderr,
+        )
         return None
     blockers = 0
-    for entry in data:
+    for entry in entries:
         if not isinstance(entry, dict):
             continue
         if entry.get("blocker") is True or entry.get("severity") == "blocker":
@@ -130,9 +144,16 @@ def verify_opus_review() -> int:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as e:
         return fail(f"phase 17: cannot parse {path}: {e}")
-    if not isinstance(data, list):
-        return fail("phase 17: findings-17.json is not an array")
-    return ok(f"phase 17: {len(data)} findings recorded in findings-17.json")
+    if isinstance(data, dict) and isinstance(data.get("findings"), list):
+        n = len(data["findings"])
+    elif isinstance(data, list):
+        n = len(data)
+    else:
+        return fail(
+            "phase 17: findings-17.json is neither an array nor an "
+            "envelope with 'findings'"
+        )
+    return ok(f"phase 17: {n} findings recorded in findings-17.json")
 
 
 def verify_ci() -> int:

--- a/.claude/skills/integration-pipeline-preview/scripts/verify-leaf.py
+++ b/.claude/skills/integration-pipeline-preview/scripts/verify-leaf.py
@@ -77,11 +77,25 @@ def count_blockers(findings_path: Path) -> int | None:
     except json.JSONDecodeError as e:
         print(f"verify-leaf: cannot parse {findings_path}: {e}", file=sys.stderr)
         return None
-    if not isinstance(data, list):
-        print(f"verify-leaf: {findings_path}: expected array", file=sys.stderr)
+    # record-findings.py writes an envelope: {"blockers": N, "findings": [...]}.
+    # A bare array (hand-authored / legacy) is still accepted for compatibility.
+    if isinstance(data, dict):
+        if isinstance(data.get("blockers"), int):
+            return data["blockers"]
+        entries = data.get("findings")
+    elif isinstance(data, list):
+        entries = data
+    else:
+        entries = None
+    if not isinstance(entries, list):
+        print(
+            f"verify-leaf: {findings_path}: expected an array or an "
+            f"envelope with 'blockers'/'findings'",
+            file=sys.stderr,
+        )
         return None
     blockers = 0
-    for entry in data:
+    for entry in entries:
         if not isinstance(entry, dict):
             continue
         if entry.get("blocker") is True or entry.get("severity") == "blocker":


### PR DESCRIPTION
## Summary

Both pipelines' `record-findings.py` write findings as an **envelope** — `{"phase":N,"total_findings":N,"blockers":N,"findings":[...]}` — but both `verify-leaf.py` files assumed a top-level JSON array and bailed with `expected array` on every real findings file. The trust-but-verify gate for the security / performance / fix-findings phases (12/13/14, plus 17 in the feature pipeline) therefore *silently failed* instead of confirming the blocker count.

Surfaced while running the Azure AI integration pipeline (#700 / #702): `verify-leaf.py 12` returned `FAIL: expected array` on a clean 0-blocker findings file.

## Fix

- `count_blockers()` now prefers the authoritative top-level `"blockers"` int when the file is an envelope, falls back to counting the `"findings"` array, and still accepts a bare array for backward compatibility.
- The feature pipeline's `verify_opus_review()` (findings-17) gets the same envelope-or-array handling.
- Applied to **both** `feature-pipeline-preview` and `integration-pipeline-preview` (identical latent bug in each).

## Verification

- Against this session's real envelope findings: `verify-leaf 12/13/14` now report `0 blockers` (previously `expected array`).
- Against a synthetic bare array `[blocker, blocker, non-blocker]`: reports `2 blockers` (backward-compat path intact).
- Both files `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of findings data so both the legacy list format and the newer wrapped format are handled correctly.
  * Blocker counts and review checks now work more reliably across pipeline phases, with clearer error messages when input data is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->