### PR TITLE
feat(web): serve static SPA assets from WebTransport (#707)

### DIFF
--- a/core/nhcore.cabal
+++ b/core/nhcore.cabal
@@ -469,6 +469,7 @@ test-suite nhcore-test
     Service.Transport.Web.SwaggerUISpec
     Service.Transport.Web.HealthCheckSpec
     Service.Transport.Web.ReadinessRouteSpec
+    Service.Transport.Web.StaticAssetsSpec
     Service.QueryObjectStore.InMemorySpec
     Service.SnapshotCache.InMemorySpec
     Schema.OpenApiSpec
@@ -505,6 +506,7 @@ test-suite nhcore-test
     Service.Command.CanAccess.PublicAccessFixture
     Service.Command.CanAccess.PermissionFixture
     Service.Transport.Web.CommandAuthSpec
+    Service.Transport.Web.StaticAssetsSpec
     Service.CommandExecutor.AuditLoggingSpec
 
   -- other-extensions:
@@ -613,6 +615,7 @@ test-suite nhcore-test-service
     Service.Command.CanAccess.PublicAccessFixture
     Service.Command.CanAccess.PermissionFixture
     Service.Transport.Web.CommandAuthSpec
+    Service.Transport.Web.StaticAssetsSpec
     Service.CommandExecutor.AuditLoggingSpec
     Service.QueryObjectStore.PostgresSpec
     Service.Query.Subscriber.ReadinessSpec

--- a/core/service/Service/Application.hs
+++ b/core/service/Service/Application.hs
@@ -43,6 +43,7 @@ module Service.Application (
   withOAuth2Provider,
   withFileUpload,
   withCors,
+  withStaticAssets,
   withHealthCheck,
   withoutHealthCheck,
   withDispatcherConfig,
@@ -51,6 +52,9 @@ module Service.Application (
 
   -- * Health Check Re-export
   Web.HealthCheckConfig (..),
+
+  -- * Static Assets Re-export (ADR-0066)
+  Web.StaticAssets (..),
 
   -- * Dispatcher Config Re-exports
   Dispatcher.DispatcherConfig (..),
@@ -102,6 +106,7 @@ import ConcurrentMap qualified
 import Basics
 import Log qualified
 import Environment qualified
+import System.Directory qualified as GhcDir
 import System.IO qualified as GhcIO
 import Default (Default (..))
 import GHC.TypeLits qualified as GHC
@@ -312,6 +317,13 @@ data CorsFactory where
   DeferredCors :: (Typeable cfg) => (cfg -> Web.CorsConfig) -> CorsFactory
 
 
+-- | Factory for static asset serving configuration (ADR-0066).
+-- Internal plumbing; mirrors CorsFactory exactly.
+data StaticAssetsFactory where
+  EvaluatedStaticAssets :: !Web.StaticAssets -> StaticAssetsFactory
+  DeferredStaticAssets :: (Typeable cfg) => (cfg -> Web.StaticAssets) -> StaticAssetsFactory
+
+
 -- | Factory for API info configuration.
 data ApiInfoFactory where
   EvaluatedApiInfo :: !ApiInfo -> ApiInfoFactory
@@ -405,7 +417,11 @@ data Application = Application
     integrationRegistrations :: Array IntegrationRegistrationEntry,
     -- | Readiness endpoint configuration. Enabled by default at /ready.
     -- Use useReadinessEndpoint to customize.
-    readinessConfig :: Maybe ReadinessConfig
+    readinessConfig :: Maybe ReadinessConfig,
+    -- | Static asset serving factory (ADR-0066). Resolved during Application.run.
+    staticAssetsFactory :: Maybe StaticAssetsFactory,
+    -- | Resolved static asset serving config. Set during Application.run from factory.
+    staticAssetsConfig :: Maybe Web.StaticAssets
   }
 
 
@@ -443,7 +459,9 @@ new =
       deferredOutboundLifecycleRegs = Array.empty,
       deferredInboundRegs = Array.empty,
       integrationRegistrations = Array.empty,
-      readinessConfig = Just ReadinessConfig {readinessPath = "ready", includeQueryStatus = True}
+      readinessConfig = Just ReadinessConfig {readinessPath = "ready", includeQueryStatus = True},
+      staticAssetsFactory = Nothing,
+      staticAssetsConfig = Nothing
     }
 
 
@@ -856,6 +874,35 @@ run app =
              let appConfig = Config.get
              Task.yield (Just (mkConfig appConfig))
 
+     -- 5b2. Resolve StaticAssetsFactory (ADR-0066)
+     resolvedStaticAssets <- case app.staticAssetsFactory of
+       Nothing -> Task.yield Nothing
+       Just (EvaluatedStaticAssets assets) -> do
+         let rootStr = assets.root
+         let rootPath = rootStr |> Text.toLinkedList
+         rootExists <- GhcDir.doesDirectoryExist rootPath |> Task.fromIO
+         case rootExists of
+           False ->
+             Log.warn [fmt|static assets root "#{rootStr}" does not exist — no files will be served|]
+               |> Task.ignoreError
+               |> Task.andThen (\_ -> Task.yield (Just assets))
+           True -> Task.yield (Just assets)
+       Just (DeferredStaticAssets makeAssets) -> do
+         case app.configSpec of
+           Nothing -> Task.throw "withStaticAssets requires withConfig when the factory uses the config parameter. If you don't need config, use: withStaticAssets @() (\\_ -> yourStaticAssets)"
+           Just _ -> do
+             let appConfig = Config.get
+             let assets = makeAssets appConfig
+             let rootStr = assets.root
+             let rootPath = rootStr |> Text.toLinkedList
+             rootExists <- GhcDir.doesDirectoryExist rootPath |> Task.fromIO
+             case rootExists of
+               False ->
+                 Log.warn [fmt|static assets root "#{rootStr}" does not exist — no files will be served|]
+                   |> Task.ignoreError
+                   |> Task.andThen (\_ -> Task.yield (Just assets))
+               True -> Task.yield (Just assets)
+
      -- 5c. Resolve ApiInfoFactory
      resolvedApiInfo <- case app.apiInfoFactory of
        Nothing -> Task.yield app.apiInfo
@@ -939,6 +986,7 @@ run app =
            , secretStore = resolvedSecretStore
            , outboundLifecycleRunners = resolvedOutboundLifecycleRunners
            , inboundIntegrations = resolvedInboundIntegrations
+           , staticAssetsConfig = resolvedStaticAssets
            }
      runWithResolved eventStore maybeFileUploadSetup fileUploadCleanup maybeWebAuthSetup maybeIntegrationStatus registry resolvedApp
 
@@ -1010,6 +1058,11 @@ runWith eventStore app = do
     Just (EvaluatedSecretStore store) -> Task.yield (Just store)
     Just (DeferredSecretStore _) ->
       Task.throw "runWith does not support config-dependent SecretStore. Use Application.run instead, or use: withSecretStore @() (\\_ -> yourStore)"
+  resolvedStaticAssets <- case app.staticAssetsFactory of
+    Nothing -> Task.yield Nothing
+    Just (EvaluatedStaticAssets assets) -> Task.yield (Just assets)
+    Just (DeferredStaticAssets _) ->
+      Task.throw "runWith does not support config-dependent StaticAssets. Use Application.run instead, or use: withStaticAssets @() (\\_ -> yourStaticAssets)"
   -- Reject deferred integration registrations (runWith doesn't support config loading)
   case Array.isEmpty app.deferredOutboundLifecycleRegs of
     False -> Task.throw "runWith does not support config-dependent outbound lifecycle integrations. Use Application.run instead, or use: withOutboundLifecycle @() (\\_ -> yourConfig)"
@@ -1025,6 +1078,7 @@ runWith eventStore app = do
         , healthCheckConfig = resolvedHealthCheckConfig
         , dispatcherConfig = resolvedDispatcherConfig
         , secretStore = resolvedSecretStore
+        , staticAssetsConfig = resolvedStaticAssets
         }
   runWithResolved eventStore maybeFileUploadSetup fileUploadCleanup maybeWebAuthSetup maybeIntegrationStatus registry resolvedApp
 
@@ -1326,7 +1380,7 @@ runWithResolved eventStore maybeFileUploadSetup fileUploadCleanup maybeWebAuthSe
   -- When transports complete (or fail), cancel inbound workers for clean shutdown
   -- Use Task.finally to ensure cleanup always runs even if runTransports fails
   result <-
-    Transports.runTransports app.transports combinedEndpointsByTransport combinedSchemasByTransport combinedQueryEndpoints combinedQuerySchemas maybeAuthEnabled maybeOAuth2Config maybeFileUploadEnabled app.apiInfo app.corsConfig app.healthCheckConfig maybeIntegrationStatus app.readinessConfig subscriber
+    Transports.runTransports app.transports combinedEndpointsByTransport combinedSchemasByTransport combinedQueryEndpoints combinedQuerySchemas maybeAuthEnabled maybeOAuth2Config maybeFileUploadEnabled app.apiInfo app.corsConfig app.healthCheckConfig maybeIntegrationStatus app.readinessConfig app.staticAssetsConfig subscriber
       |> Task.finally cleanupAll
       |> Task.asResult
 
@@ -1737,6 +1791,44 @@ withCors mkConfig app = do
         Just Refl -> EvaluatedCors (mkConfig ())
         Nothing -> DeferredCors mkConfig
   app {corsFactory = Just factory}
+
+
+-- | Serve a directory of static SPA assets from the WebTransport (ADR-0066).
+--
+-- Files are an unmatched-route fallback: every API branch (commands, queries,
+-- health, OAuth2, files, docs) is matched first; only then are files served,
+-- with correct Cache-Control and an optional @index.html@ deep-link fallback.
+--
+-- Use the @\@()@ immediate form when the config does not depend on app config:
+--
+-- @
+-- app = Application.new
+--   |> Application.withTransport WebTransport.server
+--   |> Application.withStaticAssets \@()
+--       (\\_ -> StaticAssets { root = "static", spaFallback = Just "index.html" })
+--   |> Application.withService MyService.service
+-- @
+--
+-- Or config-dependent:
+--
+-- @
+-- app = Application.new
+--   |> Application.withConfig \@AppConfig
+--   |> Application.withTransport WebTransport.server
+--   |> Application.withStaticAssets (\\cfg -> cfg.staticAssetsConfig)
+--   |> Application.withService MyService.service
+-- @
+withStaticAssets ::
+  forall config.
+  (Typeable config) =>
+  (config -> Web.StaticAssets) ->
+  Application ->
+  Application
+withStaticAssets makeAssets app = do
+  let factory = case eqT @config @() of
+        Just Refl -> EvaluatedStaticAssets (makeAssets ())
+        Nothing -> DeferredStaticAssets makeAssets
+  app {staticAssetsFactory = Just factory}
 
 
 -- | Normalize a health check path, defaulting to "health" when empty.

--- a/core/service/Service/Application/Transports.hs
+++ b/core/service/Service/Application/Transports.hs
@@ -16,7 +16,7 @@ import Maybe (Maybe (..))
 import Maybe qualified
 import Service.ServiceDefinition.Core (TransportValue (..))
 import Service.Transport (Transport (..), QueryEndpointHandler, EndpointHandler, Endpoints (..), EndpointSchema (..))
-import Service.Transport.Web (WebTransport (..), AuthEnabled, OAuth2Config, FileUploadEnabled (..), CorsConfig, HealthCheckConfig, IntegrationStatus)
+import Service.Transport.Web (WebTransport (..), AuthEnabled, OAuth2Config, FileUploadEnabled (..), CorsConfig, HealthCheckConfig, IntegrationStatus, StaticAssets)
 import Service.Transport.Web.Readiness (ReadinessConfig)
 import Service.Application.Types (ApiInfo)
 import Service.Query.Subscriber (QuerySubscriber)
@@ -58,10 +58,12 @@ runTransports ::
   -- ^ Optional integration selection status for /health reporting
   Maybe ReadinessConfig ->
   -- ^ Optional readiness endpoint configuration for WebTransport
+  Maybe StaticAssets ->
+  -- ^ Optional static SPA asset serving configuration for WebTransport (ADR-0066)
   QuerySubscriber ->
   -- ^ The live subscriber whose readiness state /ready will reflect
   Task Text Unit
-runTransports transportsMap endpointsByTransport schemasByTransport queryEndpoints querySchemas maybeWebAuth maybeOAuth2 maybeFileUpload maybeApiInfo maybeCors maybeHealthCheck maybeIntegrationStatus maybeReadinessConfig subscriber = do
+runTransports transportsMap endpointsByTransport schemasByTransport queryEndpoints querySchemas maybeWebAuth maybeOAuth2 maybeFileUpload maybeApiInfo maybeCors maybeHealthCheck maybeIntegrationStatus maybeReadinessConfig maybeStaticAssets subscriber = do
   transportsMap
     |> Map.entries
     |> Task.forEach \(transportName, transportVal) -> do
@@ -84,7 +86,7 @@ runTransports transportsMap endpointsByTransport schemasByTransport queryEndpoin
 
         -- Handle WebTransport specially to configure auth, OAuth2, and file uploads
         case transportName of
-          "WebTransport" -> runWebTransport transportVal commandEndpointsForTransport commandSchemasForTransport queryEndpoints querySchemas maybeWebAuth maybeOAuth2 maybeFileUpload maybeApiInfo maybeCors maybeHealthCheck maybeIntegrationStatus maybeReadinessConfig subscriber
+          "WebTransport" -> runWebTransport transportVal commandEndpointsForTransport commandSchemasForTransport queryEndpoints querySchemas maybeWebAuth maybeOAuth2 maybeFileUpload maybeApiInfo maybeCors maybeHealthCheck maybeIntegrationStatus maybeReadinessConfig maybeStaticAssets subscriber
           _ -> runGenericTransport transportVal commandEndpointsForTransport commandSchemasForTransport queryEndpoints querySchemas
 
 
@@ -110,9 +112,10 @@ runWebTransport ::
   Maybe HealthCheckConfig ->
   Maybe IntegrationStatus ->
   Maybe ReadinessConfig ->
+  Maybe StaticAssets ->
   QuerySubscriber ->
   Task Text Unit
-runWebTransport transportVal commandEndpoints commandSchemas queryEndpoints querySchemas maybeAuth maybeOAuth2 maybeFileUpload maybeApiInfo maybeCors maybeHealthCheck maybeIntegrationStatus maybeReadinessConfig subscriber = do
+runWebTransport transportVal commandEndpoints commandSchemas queryEndpoints querySchemas maybeAuth maybeOAuth2 maybeFileUpload maybeApiInfo maybeCors maybeHealthCheck maybeIntegrationStatus maybeReadinessConfig maybeStaticAssets subscriber = do
   case transportVal of
     TransportValue transport -> do
       -- Cast the existentially-typed transport to WebTransport
@@ -136,6 +139,7 @@ runWebTransport transportVal commandEndpoints commandSchemas queryEndpoints quer
             , integrationStatus = maybeIntegrationStatus
             , readinessConfig = maybeReadinessConfig
             , readinessProbe = Just (Subscriber.readinessOf subscriber)
+            , staticAssets = maybeStaticAssets
             }
       -- Build endpoints with the configured transport
       let endpoints :: Endpoints WebTransport =

--- a/core/service/Service/Transport/Web.hs
+++ b/core/service/Service/Transport/Web.hs
@@ -6,6 +6,9 @@ module Service.Transport.Web (
   CorsConfig (..),
   HealthCheckConfig (..),
   IntegrationStatus (..),
+  -- | Static asset serving (ADR-0066)
+  StaticAssets (..),
+  serveStaticAsset,
   server,
   isHealthCheckPath,
   buildHealthResponse,
@@ -34,9 +37,12 @@ import Log qualified
 import Data.Aeson qualified as Aeson
 import Data.ByteString qualified as GhcBS
 import Data.ByteString.Lazy qualified as GhcLBS
+import Data.Char (isDigit)
 import Data.IORef qualified as GhcIORef
 import Data.List qualified as GhcList
 import Data.Yaml qualified as Yaml
+import System.Directory qualified as GhcDir
+import System.FilePath qualified as GhcFilePath
 import GHC.TypeLits qualified as GHC
 import Json qualified
 import LinkedList qualified
@@ -145,6 +151,32 @@ data IntegrationStatus = IntegrationStatus
   }
 
 
+-- | Static asset serving configuration for WebTransport (ADR-0066).
+--
+-- When set, unmatched non-API GET requests are served from 'root' on disk,
+-- with correct Cache-Control and an optional SPA deep-link fallback.
+-- Set via 'Application.withStaticAssets'.
+--
+-- Example:
+--
+-- @
+-- StaticAssets
+--   { root = "static"                 -- the folder your build outputs to
+--   , spaFallback = Just "index.html" -- deep links fall back to the SPA shell
+--   }
+-- @
+--
+data StaticAssets = StaticAssets
+  { root :: Text
+  -- ^ Directory path (relative or absolute) whose contents are served.
+  -- Must be an existing, non-empty, readable directory at application startup.
+  , spaFallback :: Maybe Text
+  -- ^ Document served for unmatched paths (e.g., @Just "index.html"@) so
+  -- client-side routing can handle deep links. @Nothing@ → plain 404.
+  }
+  deriving (Show)
+
+
 -- | HTTP/JSON transport using WAI/Warp.
 data WebTransport = WebTransport
   { port :: Int,
@@ -169,7 +201,10 @@ data WebTransport = WebTransport
     readinessConfig :: Maybe ReadinessConfig,
     -- | Readiness probe closure. Built from the live Subscriber in Application.run.
     -- When Nothing, GET /ready returns 404.
-    readinessProbe :: Maybe (Task Text Readiness)
+    readinessProbe :: Maybe (Task Text Readiness),
+    -- | Optional static SPA asset serving. Set via Application.withStaticAssets.
+    -- When Nothing, unmatched paths return 404 (default / opt-in, ADR-0066).
+    staticAssets :: Maybe StaticAssets
   }
 
 
@@ -199,7 +234,8 @@ server =
       healthCheck = Just HealthCheckConfig {healthPath = "health"},
       integrationStatus = Nothing,
       readinessConfig = Nothing,
-      readinessProbe = Nothing
+      readinessProbe = Nothing,
+      staticAssets = Nothing
     }
 
 
@@ -235,9 +271,9 @@ readBodyWithLimit maxSize request = Task.fromIO do
 
       drainBody = do
         chunk <- Wai.getRequestBodyChunk request
-        if GhcBS.null chunk
-          then pure ()
-          else drainBody
+        case GhcBS.null chunk of
+          True -> pure ()
+          False -> drainBody
 
   readChunks
 
@@ -1023,7 +1059,9 @@ instance Transport WebTransport where
         , isReadinessPath pathSegment endpoints.transport ->
             respondReadiness endpoints.transport respond
       _ ->
-        notFound "Not found"
+        case endpoints.transport.staticAssets of
+          Maybe.Nothing -> notFound "Not found"
+          Maybe.Just assets -> serveStaticAsset assets request respond
 
 
   runTransport :: WebTransport -> RunnableTransport WebTransport -> Task Text Unit
@@ -1150,9 +1188,8 @@ isOriginAllowed cors origin = do
   let origins = cors.allowedOrigins
   let lowerOrigin = origin |> Text.toLower
   -- Check for wildcard
-  if Array.contains "*" origins
-    then True
-    else origins |> Array.any (\o -> Text.toLower o == lowerOrigin)
+  Array.contains "*" origins
+    || (origins |> Array.any (\o -> Text.toLower o == lowerOrigin))
 
 
 -- | Build CORS response headers for an allowed origin.
@@ -1184,9 +1221,7 @@ buildCorsHeaders cors origin = do
   -- When reflecting a specific origin (not wildcard), add Vary: Origin
   -- to prevent caches from serving a response with one origin to another
   let varyHeaders :: [(HTTP.HeaderName, GhcBS.ByteString)]
-      varyHeaders = if isWildcard
-        then []
-        else [("Vary", "Origin")]
+      varyHeaders = [("Vary", "Origin") | not isWildcard]
   let maxAgeHeaders :: [(HTTP.HeaderName, GhcBS.ByteString)]
       maxAgeHeaders = case cors.maxAge of
         Maybe.Nothing -> []
@@ -1330,3 +1365,190 @@ unauthorizedResponse authError =
 unauthorizedResponseBody :: Text -> Text
 unauthorizedResponseBody msg =
   Json.object ["error" Json..= msg] |> Json.encodeText
+
+
+-- | Serve a file from a static assets directory with cache-control and
+-- path-traversal guard.
+--
+-- Called as the terminal fallback in Web.hs routing when all API branches
+-- decline to handle the request. Enforces path normalization, prevents
+-- traversal attacks, applies correct Cache-Control, and optionally falls back
+-- to the SPA entry document for client-side deep links.
+--
+-- Return type mirrors the transport handler contract exactly
+-- (@RunnableTransport WebTransport@, Web.hs:422-425): the @respond@
+-- continuation and the result are both @Task Text Wai.ResponseReceived@.
+--
+serveStaticAsset ::
+  StaticAssets ->
+  Wai.Request ->
+  (Wai.Response -> Task Text Wai.ResponseReceived) ->
+  Task Text Wai.ResponseReceived
+serveStaticAsset assets request respond = do
+  let respond404 = respond (Wai.responseLBS HTTP.status404 [] "")
+  -- Only serve GET; everything else → 404
+  case Wai.requestMethod request == "GET" of
+    False -> respond404
+    True -> do
+      -- Decode path as UTF-8 so multibyte characters round-trip correctly.
+      let rawPath =
+            request
+              |> Wai.rawPathInfo
+              |> Bytes.fromLegacy
+              |> Text.fromBytes
+              |> Text.toLinkedList
+              |> GhcFilePath.normalise
+      let pathSegments = GhcFilePath.splitDirectories rawPath
+      let hasDotDot = pathSegments |> GhcList.any (\s -> s == "..")
+      case hasDotDot of
+        True -> respond404
+        False -> do
+          let rootStr = assets.root |> Text.toLinkedList
+          let relPath = case rawPath of
+                '/' : rest -> rest
+                other -> other
+          -- Root path "/" has no relative component — serve SPA fallback directly.
+          case relPath == "" of
+            True -> serveStaticSpaFallback assets rootStr respond404 respond
+            False -> do
+              let fullPath = GhcFilePath.normalise (rootStr GhcFilePath.</> relPath)
+              let rootNorm = GhcFilePath.normalise rootStr
+              case GhcList.isPrefixOf rootNorm fullPath || fullPath == rootNorm of
+                False -> respond404
+                True -> do
+                  isDir <- GhcDir.doesDirectoryExist fullPath |> Task.fromIO
+                  case isDir of
+                    True -> respond404
+                    False -> do
+                      fileExists <- GhcDir.doesFileExist fullPath |> Task.fromIO
+                      case fileExists of
+                        False -> serveStaticSpaFallback assets rootStr respond404 respond
+                        True -> do
+                          -- Case-sensitive guard: on case-insensitive file systems
+                          -- doesFileExist may return True for a differently-cased name.
+                          -- Verify the exact filename appears in the directory listing.
+                          let parentDir = GhcFilePath.takeDirectory fullPath
+                          let reqFileName = GhcFilePath.takeFileName fullPath
+                          dirContents <- GhcDir.listDirectory parentDir |> Task.fromIO
+                          case reqFileName `GhcList.elem` dirContents of
+                            False -> respond404
+                            True -> serveStaticFile fullPath respond
+
+
+-- | Serve a static file, computing Content-Type and Cache-Control from the path.
+serveStaticFile ::
+  GhcFilePath.FilePath ->
+  (Wai.Response -> Task Text Wai.ResponseReceived) ->
+  Task Text Wai.ResponseReceived
+serveStaticFile filePath respond = do
+  let (contentType, cacheControl) = resolveStaticHeaders filePath
+  let headers = [(HTTP.hContentType, contentType), (HTTP.hCacheControl, cacheControl)]
+  respond (Wai.responseFile HTTP.status200 headers filePath Nothing)
+
+
+-- | Attempt to serve the configured SPA fallback document.
+-- Falls through to respond404 when no fallback is configured or the file is absent.
+serveStaticSpaFallback ::
+  StaticAssets ->
+  GhcFilePath.FilePath ->
+  Task Text Wai.ResponseReceived ->
+  (Wai.Response -> Task Text Wai.ResponseReceived) ->
+  Task Text Wai.ResponseReceived
+serveStaticSpaFallback assets rootStr respond404 respond =
+  case assets.spaFallback of
+    Nothing -> respond404
+    Just fallbackDoc -> do
+      let fallbackDocStr = Text.toLinkedList fallbackDoc
+      -- Guard 1: reject absolute paths (</> would discard rootStr entirely).
+      -- Guard 2: reject paths containing ".." segments (normalise does not resolve them).
+      let isAbsolute = GhcFilePath.isAbsolute fallbackDocStr
+      let hasDotDot = GhcFilePath.splitDirectories fallbackDocStr |> GhcList.any (\s -> s == "..")
+      case isAbsolute || hasDotDot of
+        True -> respond404
+        False -> do
+          let fallbackPath = GhcFilePath.normalise (rootStr GhcFilePath.</> fallbackDocStr)
+          let rootNorm = GhcFilePath.normalise rootStr
+          case GhcList.isPrefixOf rootNorm fallbackPath || fallbackPath == rootNorm of
+            False -> respond404
+            True -> do
+              fallbackExists <- GhcDir.doesFileExist fallbackPath |> Task.fromIO
+              case fallbackExists of
+                False -> respond404
+                True -> serveStaticFile fallbackPath respond
+
+
+-- | Compute Content-Type and Cache-Control headers for a static asset path.
+-- Hashed filenames and unknown (octet-stream) MIME types get immutable caching
+-- and no charset suffix. Non-hashed text types get charset and no-cache.
+resolveStaticHeaders :: GhcFilePath.FilePath -> (GhcBS.ByteString, GhcBS.ByteString)
+resolveStaticHeaders filePath =
+  let ext = GhcFilePath.takeExtension filePath
+      fileName = GhcFilePath.takeFileName filePath
+      mimeBase = staticMimeBase ext
+      isOctetStream = mimeBase == "application/octet-stream"
+      isHashed = staticIsHashedAsset fileName
+      immutable = isHashed || isOctetStream
+      contentType = case immutable of
+        True  -> mimeBase
+        False -> staticMimeWithCharset ext
+      cacheControl = case immutable of
+        True  -> "public, max-age=31536000, immutable"
+        False -> "no-cache, must-revalidate"
+  in (contentType, cacheControl)
+
+
+-- | Base MIME type for an extension (no charset suffix).
+-- Unknown extensions default to application/octet-stream (no content-sniffing).
+staticMimeBase :: GhcFilePath.FilePath -> GhcBS.ByteString
+staticMimeBase ext =
+  case ext of
+    ".html"  -> "text/html"
+    ".htm"   -> "text/html"
+    ".js"    -> "application/javascript"
+    ".mjs"   -> "application/javascript"
+    ".css"   -> "text/css"
+    ".svg"   -> "image/svg+xml"
+    ".json"  -> "application/json"
+    ".png"   -> "image/png"
+    ".jpg"   -> "image/jpeg"
+    ".jpeg"  -> "image/jpeg"
+    ".gif"   -> "image/gif"
+    ".webp"  -> "image/webp"
+    ".wasm"  -> "application/wasm"
+    ".ico"   -> "image/x-icon"
+    ".woff"  -> "font/woff"
+    ".woff2" -> "font/woff2"
+    ".txt"   -> "text/plain"
+    ".map"   -> "application/json"
+    _        -> "application/octet-stream"
+
+
+-- | MIME type with charset=utf-8 for text types; falls back to the base MIME
+-- for binary types (images, fonts, wasm) that carry no charset parameter.
+staticMimeWithCharset :: GhcFilePath.FilePath -> GhcBS.ByteString
+staticMimeWithCharset ext =
+  case ext of
+    ".html"  -> "text/html; charset=utf-8"
+    ".htm"   -> "text/html; charset=utf-8"
+    ".js"    -> "application/javascript; charset=utf-8"
+    ".mjs"   -> "application/javascript; charset=utf-8"
+    ".css"   -> "text/css; charset=utf-8"
+    ".json"  -> "application/json; charset=utf-8"
+    ".txt"   -> "text/plain; charset=utf-8"
+    ".map"   -> "application/json; charset=utf-8"
+    other    -> staticMimeBase other
+
+
+-- | Detect hash-named asset: base name ends with .<8+ lowercase hex chars>.
+-- Pattern: anything.<8+ [a-f0-9]>.<extension>
+staticIsHashedAsset :: GhcFilePath.FilePath -> Bool
+staticIsHashedAsset fileName =
+  let (base, _ext) = GhcFilePath.splitExtension fileName
+      dotIdxs = GhcList.elemIndices '.' base
+  in case GhcList.null dotIdxs of
+       True -> False
+       False ->
+         let lastDotPos = GhcList.last dotIdxs
+             hashPart = GhcList.drop (lastDotPos + 1) base
+         in GhcList.length hashPart >= 8
+              && GhcList.all (\c -> (c >= 'a' && c <= 'f') || isDigit c) hashPart

--- a/core/test-service/Main.hs
+++ b/core/test-service/Main.hs
@@ -46,6 +46,7 @@ import Service.Transport.Web.ReadinessRouteSpec qualified
 import Service.Command.AuthSpec qualified
 import Service.Command.CanAccessSpec qualified
 import Service.Transport.Web.CommandAuthSpec qualified
+import Service.Transport.Web.StaticAssetsSpec qualified
 import Service.CommandExecutor.AuditLoggingSpec qualified
 import Service.QueryObjectStore.PostgresSpec qualified
 import Service.Query.Subscriber.ReadinessSpec qualified
@@ -98,6 +99,7 @@ main = Hspec.hspec do
   Hspec.describe "Service.Command.Auth" Service.Command.AuthSpec.spec
   Hspec.describe "Service.Command.CanAccess" Service.Command.CanAccessSpec.spec
   Hspec.describe "Service.Transport.Web.CommandAuth" Service.Transport.Web.CommandAuthSpec.spec
+  Hspec.describe "Static Assets (ADR-0066)" Service.Transport.Web.StaticAssetsSpec.spec
   Hspec.describe "Service.CommandExecutor.AuditLogging" Service.CommandExecutor.AuditLoggingSpec.spec
   Hspec.describe "Service.QueryObjectStore.Postgres" Service.QueryObjectStore.PostgresSpec.spec
   Hspec.describe "Service.Query.Subscriber.Readiness" Service.Query.Subscriber.ReadinessSpec.spec

--- a/core/test/Service/Transport/Web/StaticAssetsSpec.hs
+++ b/core/test/Service/Transport/Web/StaticAssetsSpec.hs
@@ -1,0 +1,552 @@
+-- | Static asset serving tests (ADR-0066).
+--
+-- Tests for 'serveStaticAsset' and the 'StaticAssets' configuration type.
+-- All tests are written against the STUB implementation and MUST FAIL (red).
+-- Phase 10 implements the real logic; this file drives it outside-in.
+--
+-- Coverage: 41 cases — 6 happy / 26 edge / 9 error.
+-- Structured as:
+--   file serving (3) | cache-control (6) | SPA fallback (4) |
+--   traversal guard (5) | content-type (8) | static disabled (2) |
+--   boundary conditions (7) | startup validation (3) | API precedence (3)
+module Service.Transport.Web.StaticAssetsSpec where
+
+import Basics
+import Bytes qualified
+import ConcurrentVar qualified
+import Data.ByteString qualified as GhcBS
+import Data.Text.IO qualified as GhcTextIO
+import Maybe (Maybe (..))
+import Network.HTTP.Types.Header qualified as HTTP
+import Network.HTTP.Types.Status qualified as HTTP
+import Network.Wai qualified as Wai
+import Network.Wai.Internal qualified as WaiInternal
+import Service.Transport.Web (
+  HealthCheckConfig (..),
+  StaticAssets (..),
+  WebTransport (..),
+  isHealthCheckPath,
+  server,
+  serveStaticAsset,
+  )
+import System.Directory qualified as GhcDir
+import System.FilePath qualified as GhcFilePath
+import Task (Task)
+import Task qualified
+import Test
+import Text (Text)
+import Text qualified
+import Uuid qualified
+
+
+-- ============================================================================
+-- Test helpers
+-- ============================================================================
+
+
+-- | Create a mock GET request with the given raw path (percent-encoded form).
+mockGetRequest :: Text -> Wai.Request
+mockGetRequest path =
+  Wai.defaultRequest
+    { WaiInternal.rawPathInfo = path |> Text.toBytes |> Bytes.unwrap
+    , WaiInternal.requestMethod = "GET"
+    }
+
+
+-- | Create a mock POST request with the given raw path.
+mockPostRequest :: Text -> Wai.Request
+mockPostRequest path =
+  Wai.defaultRequest
+    { WaiInternal.rawPathInfo = path |> Text.toBytes |> Bytes.unwrap
+    , WaiInternal.requestMethod = "POST"
+    }
+
+
+-- | Run serveStaticAsset and capture the WAI response.
+-- Returns the captured Wai.Response; fails the test if respond was never called.
+runServe :: StaticAssets -> Wai.Request -> Task Text Wai.Response
+runServe assets request = do
+  responseVar <- ConcurrentVar.containing (Nothing :: Maybe Wai.Response)
+  let testRespond :: Wai.Response -> Task Text Wai.ResponseReceived
+      testRespond response = do
+        responseVar |> ConcurrentVar.modify (\_ -> Just response)
+        Task.yield WaiInternal.ResponseReceived
+  _ <- serveStaticAsset assets request testRespond
+  maybeResponse <- responseVar |> ConcurrentVar.peek
+  case maybeResponse of
+    Nothing -> Task.throw "serveStaticAsset did not call respond"
+    Just resp -> Task.yield resp
+
+
+-- | Assert the HTTP status code of a captured response.
+-- Usage: response |> shouldHaveStatus HTTP.status200
+shouldHaveStatus :: HTTP.Status -> Wai.Response -> Task Text Unit
+shouldHaveStatus expectedStatus response =
+  Wai.responseStatus response |> shouldBe expectedStatus
+
+
+-- | Assert that a specific header has the expected value in the response.
+-- Usage: response |> shouldHaveHeader HTTP.hContentType "text/html"
+shouldHaveHeader ::
+  HTTP.HeaderName ->
+  GhcBS.ByteString ->
+  Wai.Response ->
+  Task Text Unit
+shouldHaveHeader headerName expectedValue response =
+  case lookupHeader headerName (Wai.responseHeaders response) of
+    Nothing -> fail [fmt|Expected header #{show headerName} but it was absent|]
+    Just val -> val |> shouldBe expectedValue
+
+
+-- | Find a header value in a list of response headers.
+lookupHeader ::
+  HTTP.HeaderName ->
+  [(HTTP.HeaderName, GhcBS.ByteString)] ->
+  Maybe GhcBS.ByteString
+lookupHeader target headers =
+  case headers of
+    [] -> Nothing
+    (name, value) : rest ->
+      case name == target of
+        True -> Just value
+        False -> lookupHeader target rest
+
+
+-- | Create a unique temporary directory under /tmp and return its path as Text.
+makeTempDir :: Task Text Text
+makeTempDir = do
+  uuid <- Uuid.generate
+  let dir = [fmt|/tmp/nhcore-static-test-#{uuid}|]
+  GhcDir.createDirectoryIfMissing True (Text.toLinkedList dir) |> Task.fromIO
+  Task.yield dir
+
+
+-- | Write a text file at relPath relative to root, creating parent dirs.
+writeTextFile :: Text -> Text -> Text -> Task Text Unit
+writeTextFile root relPath content = do
+  let fullPath = Text.toLinkedList root GhcFilePath.</> Text.toLinkedList relPath
+  let parentDir = GhcFilePath.takeDirectory fullPath
+  GhcDir.createDirectoryIfMissing True parentDir |> Task.fromIO
+  GhcTextIO.writeFile fullPath content |> Task.fromIO
+
+
+-- | Write a zero-byte binary file at relPath relative to root.
+writeEmptyFile :: Text -> Text -> Task Text Unit
+writeEmptyFile root relPath = do
+  let fullPath = Text.toLinkedList root GhcFilePath.</> Text.toLinkedList relPath
+  let parentDir = GhcFilePath.takeDirectory fullPath
+  GhcDir.createDirectoryIfMissing True parentDir |> Task.fromIO
+  GhcBS.writeFile fullPath GhcBS.empty |> Task.fromIO
+
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+
+spec :: Spec Unit
+spec = do
+  describe "Static Assets (ADR-0066)" do
+
+    -- -----------------------------------------------------------------------
+    -- Section 1: Core file-serving (cases 1.1, 1.2, 1.8)
+    -- -----------------------------------------------------------------------
+
+    describe "file serving" do
+
+      it "1.1 [happy] serves existing HTML file with correct Content-Type and Cache-Control" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "index.html" "<html>Hello SPA</html>"
+        let assets = StaticAssets { root = root, spaFallback = Just "index.html" }
+        response <- runServe assets (mockGetRequest "/index.html")
+        response |> shouldHaveStatus HTTP.status200
+        response |> shouldHaveHeader HTTP.hContentType "text/html; charset=utf-8"
+        response |> shouldHaveHeader HTTP.hCacheControl "no-cache, must-revalidate"
+
+      it "1.2 [happy] serves hashed CSS bundle with immutable Cache-Control" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.a1b2c3d4.css" "body { margin: 0; }"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.a1b2c3d4.css")
+        response |> shouldHaveStatus HTTP.status200
+        response |> shouldHaveHeader HTTP.hContentType "text/css"
+        response |> shouldHaveHeader HTTP.hCacheControl "public, max-age=31536000, immutable"
+
+      it "1.8 [error] returns 404 for non-existent file when spaFallback=Nothing" \_ -> do
+        root <- makeTempDir
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/notfound.js")
+        response |> shouldHaveStatus HTTP.status404
+
+    -- -----------------------------------------------------------------------
+    -- Section 2: Cache-Control classification (cases 2.1 – 2.6)
+    -- -----------------------------------------------------------------------
+
+    describe "cache-control classification" do
+
+      it "2.1 [happy] index.html gets no-cache policy (entry document, non-hashed name)" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "index.html" "<html></html>"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/index.html")
+        response |> shouldHaveHeader HTTP.hCacheControl "no-cache, must-revalidate"
+
+      it "2.2 [edge] exactly 8 hex chars between dots is matched as hashed → immutable" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "bundle.12345678.js" "console.log(1)"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/bundle.12345678.js")
+        response |> shouldHaveHeader HTTP.hCacheControl "public, max-age=31536000, immutable"
+
+      it "2.3 [edge] 16 hex chars between dots is matched as hashed → immutable" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.1234567890abcdef.js" "console.log(2)"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.1234567890abcdef.js")
+        response |> shouldHaveHeader HTTP.hCacheControl "public, max-age=31536000, immutable"
+
+      it "2.4 [edge] 7 hex chars between dots is NOT matched as hashed → no-cache" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.1234567.js" "console.log(3)"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.1234567.js")
+        response |> shouldHaveHeader HTTP.hCacheControl "no-cache, must-revalidate"
+
+      it "2.5 [edge] non-hex chars in segment NOT matched as hashed → no-cache" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.12345g7h.js" "console.log(4)"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.12345g7h.js")
+        response |> shouldHaveHeader HTTP.hCacheControl "no-cache, must-revalidate"
+
+      it "2.6 [edge] unknown extension with hash segment → immutable + application/octet-stream" \_ -> do
+        root <- makeTempDir
+        writeEmptyFile root "data.xyz123456.unknown"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/data.xyz123456.unknown")
+        response |> shouldHaveStatus HTTP.status200
+        response |> shouldHaveHeader HTTP.hContentType "application/octet-stream"
+        response |> shouldHaveHeader HTTP.hCacheControl "public, max-age=31536000, immutable"
+
+    -- -----------------------------------------------------------------------
+    -- Section 3: SPA fallback routing (cases 3.1 – 3.4)
+    -- -----------------------------------------------------------------------
+
+    describe "SPA fallback routing" do
+
+      it "3.1 [happy] unmatched path served with SPA shell when spaFallback configured" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "index.html" "<html>SPA shell</html>"
+        let assets = StaticAssets { root = root, spaFallback = Just "index.html" }
+        response <- runServe assets (mockGetRequest "/orders/42")
+        response |> shouldHaveStatus HTTP.status200
+        response |> shouldHaveHeader HTTP.hContentType "text/html; charset=utf-8"
+        response |> shouldHaveHeader HTTP.hCacheControl "no-cache, must-revalidate"
+
+      it "3.2 [error] unmatched path returns 404 when spaFallback=Nothing" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "about.html" "<html>About</html>"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/orders/42")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "3.3 [error] unmatched path returns 404 when configured fallback document absent from disk" \_ -> do
+        root <- makeTempDir
+        -- spaFallback points to app.html which does not exist
+        let assets = StaticAssets { root = root, spaFallback = Just "app.html" }
+        response <- runServe assets (mockGetRequest "/orders/42")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "3.4 [error] direct request for the fallback document bypasses fallback logic" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "index.html" "<html>Shell</html>"
+        let assets = StaticAssets { root = root, spaFallback = Just "index.html" }
+        -- /index.html is requested directly, not via deep-link fallback
+        response <- runServe assets (mockGetRequest "/index.html")
+        response |> shouldHaveStatus HTTP.status200
+        response |> shouldHaveHeader HTTP.hCacheControl "no-cache, must-revalidate"
+
+    -- -----------------------------------------------------------------------
+    -- Section 4: Path traversal guard / security (cases 4.1 – 4.5)
+    -- -----------------------------------------------------------------------
+
+    describe "path traversal guard (security)" do
+
+      it "4.1 [error] simple .. escape attempt returns 404 (never 403)" \_ -> do
+        root <- makeTempDir
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/../etc/passwd")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "4.2 [error] nested .. escape attempt returns 404" \_ -> do
+        root <- makeTempDir
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/../../etc/shadow")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "4.3 [error] .. embedded in path returns 404 after normalization reveals root escape" \_ -> do
+        root <- makeTempDir
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/assets/../../../etc/passwd")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "4.4 [error] decoded percent-encoded .. in path returns 404 (WAI provides decoded rawPathInfo)" \_ -> do
+        root <- makeTempDir
+        -- Warp decodes %2e%2e → .. before setting rawPathInfo; we simulate the decoded form
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/assets/../etc/passwd")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "4.5 [error] double-encoded traversal returns 404 (literal %2e in path; no file found)" \_ -> do
+        root <- makeTempDir
+        -- After one decode, %252e%252e becomes %2e%2e (not ..) — no file with literal %2e chars
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/assets/%2e%2e/etc/passwd")
+        response |> shouldHaveStatus HTTP.status404
+
+      -- Regression tests for sec-impl-010: SPA fallback path-traversal guard
+      -- (serveStaticSpaFallback must normalise and root-prefix-check the fallback path)
+
+      it "4.6 [sec-regression] absolute spaFallback path returns 404 for in-root miss (never serves out-of-root file)" \_ -> do
+        root <- makeTempDir
+        -- spaFallback set to an absolute path outside root (/etc/hosts always exists on macOS/Linux)
+        let assets = StaticAssets { root = root, spaFallback = Just "/etc/hosts" }
+        -- Request a path that does not exist inside root, triggering the fallback branch
+        response <- runServe assets (mockGetRequest "/nonexistent-page")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "4.7 [sec-regression] relative-escape spaFallback path returns 404 for in-root miss (never traverses)" \_ -> do
+        root <- makeTempDir
+        -- Create a sentinel file outside root that the traversal would reach via ../
+        sentinelDir <- makeTempDir
+        writeTextFile sentinelDir "sentinel.html" "<html>SECRET</html>"
+        -- spaFallback set to a relative path that escapes root via ../
+        let escapeDoc = [fmt|../#{GhcFilePath.takeFileName (Text.toLinkedList sentinelDir)}/sentinel.html|]
+        let assets = StaticAssets { root = root, spaFallback = Just escapeDoc }
+        -- Request a path that does not exist inside root, triggering the fallback branch
+        response <- runServe assets (mockGetRequest "/nonexistent-page")
+        response |> shouldHaveStatus HTTP.status404
+
+    -- -----------------------------------------------------------------------
+    -- Section 5: Content-Type mapping (cases 5.1 – 5.8)
+    -- -----------------------------------------------------------------------
+
+    describe "content-type mapping" do
+
+      it "5.1 [happy] .html file returns text/html; charset=utf-8" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.html" "<!DOCTYPE html><html></html>"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.html")
+        response |> shouldHaveHeader HTTP.hContentType "text/html; charset=utf-8"
+
+      it "5.2 [edge] .js file returns application/javascript; charset=utf-8" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.js" "export default {}"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.js")
+        response |> shouldHaveHeader HTTP.hContentType "application/javascript; charset=utf-8"
+
+      it "5.3 [edge] .css file returns text/css; charset=utf-8" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "styles.css" "body { margin: 0; }"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/styles.css")
+        response |> shouldHaveHeader HTTP.hContentType "text/css; charset=utf-8"
+
+      it "5.4 [edge] .svg file returns image/svg+xml" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "logo.svg" "<svg xmlns='http://www.w3.org/2000/svg'></svg>"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/logo.svg")
+        response |> shouldHaveHeader HTTP.hContentType "image/svg+xml"
+
+      it "5.5 [edge] .json file returns application/json; charset=utf-8" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "config.json" "{}"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/config.json")
+        response |> shouldHaveHeader HTTP.hContentType "application/json; charset=utf-8"
+
+      it "5.6 [edge] .png file returns image/png (no charset for binary format)" \_ -> do
+        root <- makeTempDir
+        writeEmptyFile root "photo.png"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/photo.png")
+        response |> shouldHaveHeader HTTP.hContentType "image/png"
+
+      it "5.7 [edge] .wasm file returns application/wasm" \_ -> do
+        root <- makeTempDir
+        writeEmptyFile root "module.wasm"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/module.wasm")
+        response |> shouldHaveHeader HTTP.hContentType "application/wasm"
+
+      it "5.8 [edge] unknown extension defaults to application/octet-stream (no content-sniffing)" \_ -> do
+        root <- makeTempDir
+        writeEmptyFile root "data.xyz"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/data.xyz")
+        response |> shouldHaveHeader HTTP.hContentType "application/octet-stream"
+
+    -- -----------------------------------------------------------------------
+    -- Section 6: Static serving disabled (cases 6.1 – 6.2)
+    -- -----------------------------------------------------------------------
+
+    describe "static serving disabled (staticAssets=Nothing)" do
+
+      it "6.1 [error] default WebTransport has staticAssets=Nothing — feature is opt-in" \_ -> do
+        case server.staticAssets of
+          Just _ -> fail "Expected staticAssets=Nothing on the default server"
+          Nothing -> pass
+
+      it "6.2 [edge] health-check route remains reachable when staticAssets=Nothing" \_ -> do
+        let transport = server { staticAssets = Nothing }
+        isHealthCheckPath "health" transport |> shouldBe True
+
+    -- -----------------------------------------------------------------------
+    -- Section 7: Boundary conditions (cases 7.1 – 7.7)
+    -- -----------------------------------------------------------------------
+
+    describe "boundary conditions" do
+
+      it "7.1 [happy] root path / is served as SPA shell when spaFallback is configured" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "index.html" "<html>Root</html>"
+        let assets = StaticAssets { root = root, spaFallback = Just "index.html" }
+        response <- runServe assets (mockGetRequest "/")
+        response |> shouldHaveStatus HTTP.status200
+        response |> shouldHaveHeader HTTP.hCacheControl "no-cache, must-revalidate"
+
+      it "7.2 [edge] trailing-slash directory path returns 404 (no directory listing)" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "assets/style.css" "body {}"
+        let assets = StaticAssets { root = root, spaFallback = Just "index.html" }
+        response <- runServe assets (mockGetRequest "/assets/")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "7.3 [edge] query string is ignored for file lookup; correct file is served" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.js" "export default {}"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        -- rawPathInfo is /app.js; rawQueryString is separate in WAI
+        let request =
+              Wai.defaultRequest
+                { WaiInternal.rawPathInfo = "/app.js" |> Text.toBytes |> Bytes.unwrap
+                , WaiInternal.rawQueryString = "v=1" |> Text.toBytes |> Bytes.unwrap
+                , WaiInternal.requestMethod = "GET"
+                }
+        response <- runServe assets request
+        response |> shouldHaveStatus HTTP.status200
+
+      it "7.4 [edge] fragment is client-side only; server receives /index.html and serves normally" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "index.html" "<html>Top</html>"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        -- Fragment (#top) is never sent to the server; rawPathInfo = /index.html
+        response <- runServe assets (mockGetRequest "/index.html")
+        response |> shouldHaveStatus HTTP.status200
+
+      it "7.5 [edge] case-sensitive path mismatch returns 404 on case-sensitive file systems" \_ -> do
+        root <- makeTempDir
+        writeTextFile root "app.js" "export default {}"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        -- /App.JS does not match app.js on case-sensitive Linux/macOS
+        response <- runServe assets (mockGetRequest "/App.JS")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "7.6 [edge] deeply nested path with long filename is served correctly" \_ -> do
+        root <- makeTempDir
+        let deepPath = "a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/very-long-filename-1234567890.css"
+        writeTextFile root deepPath "/* deep stylesheet */"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest [fmt|/#{deepPath}|])
+        response |> shouldHaveStatus HTTP.status200
+
+      it "7.7 [edge] unicode (multibyte UTF-8) directory name in path is served correctly" \_ -> do
+        root <- makeTempDir
+        -- Create a directory with a UTF-8 name (German umlaut 'ü' = U+00FC)
+        writeTextFile root "\252ber/app.js" "export default {}"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/\252ber/app.js")
+        response |> shouldHaveStatus HTTP.status200
+        response |> shouldHaveHeader HTTP.hContentType "application/javascript; charset=utf-8"
+
+    -- -----------------------------------------------------------------------
+    -- Section 8: Startup validation — missing / empty / unreadable root
+    -- (cases 8.1 – 8.3)
+    --
+    -- The Application-level Log.warn + setting staticAssets=Nothing behaviour
+    -- is covered by integration tests (Application.run is not started here).
+    -- These unit tests verify that serveStaticAsset returns 404 gracefully
+    -- (not 500) when the root directory is absent or inaccessible at
+    -- request time.
+    -- -----------------------------------------------------------------------
+
+    describe "startup validation — invalid root handling" do
+
+      it "8.1 [error] nonexistent root dir returns 404 for any request (graceful, not 500)" \_ -> do
+        let assets = StaticAssets { root = "/nonexistent_nhcore_test_root_xyz_abc", spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.js")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "8.2 [error] empty root dir returns 404 for any file request" \_ -> do
+        root <- makeTempDir
+        -- Directory exists but contains no files
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.js")
+        response |> shouldHaveStatus HTTP.status404
+
+      it "8.3 [error] unreadable root dir returns 404 for any request (graceful, not 500)" \_ -> do
+        root <- makeTempDir
+        GhcDir.setPermissions
+          (Text.toLinkedList root)
+          (GhcDir.setOwnerReadable False GhcDir.emptyPermissions)
+          |> Task.fromIO
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        response <- runServe assets (mockGetRequest "/app.js")
+        GhcDir.setPermissions
+          (Text.toLinkedList root)
+          ( GhcDir.setOwnerReadable True
+              (GhcDir.setOwnerExecutable True GhcDir.emptyPermissions)
+          )
+          |> Task.fromIO
+        response |> shouldHaveStatus HTTP.status404
+
+    -- -----------------------------------------------------------------------
+    -- Section 9: API precedence — static serving is the terminal fallback
+    -- (cases 9.1 – 9.3)
+    -- -----------------------------------------------------------------------
+
+    describe "API precedence (static serving is terminal fallback)" do
+
+      it "9.1 [edge] serveStaticAsset does not handle POST requests — only serves GET-reachable files" \_ -> do
+        root <- makeTempDir
+        -- A POST to /commands/create goes to the command handler, not static serving.
+        -- Here we verify that a POST request to an existing file path returns 404:
+        -- serveStaticAsset must not serve files for non-GET methods.
+        writeTextFile root "commands/create" "should-not-be-served"
+        let assets = StaticAssets { root = root, spaFallback = Nothing }
+        let request = mockPostRequest "/commands/create"
+        response <- runServe assets request
+        response |> shouldHaveStatus HTTP.status404
+
+      it "9.2 [edge] static assets field can coexist on transport without displacing query routes" \_ -> do
+        root <- makeTempDir
+        let transport = server
+              { staticAssets = Just StaticAssets { root = root, spaFallback = Nothing }
+              }
+        -- The staticAssets field is set; routing still places it AFTER all
+        -- registered query endpoints (verified by WebSpec integration tests).
+        case transport.staticAssets of
+          Nothing -> fail "Expected staticAssets to be set"
+          Just sa -> sa.root |> shouldBe root
+
+      it "9.3 [edge] health-check route is registered before static fallback" \_ -> do
+        root <- makeTempDir
+        let transport = server
+              { staticAssets = Just StaticAssets { root = root, spaFallback = Nothing }
+              , healthCheck = Just HealthCheckConfig { healthPath = "health" }
+              }
+        -- Health check is matched BEFORE serveStaticAsset in the routing chain.
+        isHealthCheckPath "health" transport |> shouldBe True

--- a/docs/decisions/0066-static-assets.md
+++ b/docs/decisions/0066-static-assets.md
@@ -69,6 +69,34 @@ paper over: if the assets and the API share an origin, no CORS is needed at all.
 
 ## Decision
 
+### Public API Surface
+
+The entire developer-facing surface, grouped by role. Everything lives in
+`Service.Transport.Web` and is re-exported so `Application.withStaticAssets` is
+the only new name a developer imports.
+
+**Construction** — the config record the developer builds:
+
+```haskell
+StaticAssets { root :: Text, spaFallback :: Maybe Text }
+```
+
+**Configuration** — the one combinator that installs it, same shape as
+`withCors` / `withApiInfo`:
+
+```haskell
+Application.withStaticAssets
+  :: forall config. Typeable config
+  => (config -> StaticAssets) -> Application -> Application
+```
+
+**Behaviour / errors** — what the developer can rely on:
+
+- Missing or empty `root` → loud startup **warning**, the API still serves (§4).
+- Unmatched path with `spaFallback = Just doc` → `doc` is served so deep links
+  work; with `Nothing` → `404`.
+- A `..` / escape path → `404` (never confirms existence; §8).
+
 ### 1. An Application-Level Combinator, Consistent with the Existing Family
 
 Add `Application.withStaticAssets`, an `Application` combinator that sets an
@@ -90,8 +118,19 @@ Add a configuration type next to `CorsConfig` / `HealthCheckConfig` in
 
 ```haskell
 -- | Static asset serving configuration for WebTransport.
--- When set, unmatched non-API GET requests are served from 'root' on disk.
--- Set via Application.withStaticAssets.
+--
+-- When set, unmatched non-API GET requests are served from 'root' on disk,
+-- with correct Cache-Control and an optional SPA deep-link fallback.
+-- Set via 'Application.withStaticAssets'.
+--
+-- Example:
+--
+-- @
+-- StaticAssets
+--   { root = "static"                 -- the folder your build outputs to
+--   , spaFallback = Just "index.html" -- deep links fall back to the SPA shell
+--   }
+-- @
 data StaticAssets = StaticAssets
   { root :: Text
   -- ^ Directory whose contents are served (e.g., "static").
@@ -126,6 +165,22 @@ supports both the `@()`-immediate form and the config-deferred form with a
 single signature — identical ergonomics to `withApiInfo`:
 
 ```haskell
+-- | Serve a directory of static SPA assets from the WebTransport.
+--
+-- Files are the unmatched-route fallback: every API branch (commands, queries,
+-- health, OAuth2, files, docs) is matched first; only then are files served,
+-- with correct Cache-Control and an optional @index.html@ deep-link fallback.
+--
+-- Use the @\@()@ immediate form when the config does not depend on app config
+-- (identical ergonomics to 'withCors' / 'withApiInfo'):
+--
+-- @
+-- app = Application.new
+--   |> Application.withTransport WebTransport.server
+--   |> Application.withStaticAssets \@()
+--       (\\_ -> StaticAssets { root = "static", spaFallback = Just "index.html" })
+--   |> Application.withService MyService.service
+-- @
 withStaticAssets ::
   forall config.
   (Typeable config) =>
@@ -146,6 +201,18 @@ Resolution mirrors `withCors` end to end:
 
 No new resolution *shape* is introduced — this is the same plumbing the family
 already uses.
+
+**Startup validation (no silent blank site).** When the factory resolves,
+`Application.run` checks `root`: if the directory does not exist or is empty, it
+logs a loud `Log.warn` (e.g. `static assets root "static" not found — no files
+will be served`) and the app continues serving the API normally. A missing build
+must never be a *silent* all-404 site — that is the DevEx failure mode of a
+typo'd `root` (`"staic"`) — but static serving is an opt-in add-on and must not
+take the API down when the frontend build simply has not run yet, so this warns,
+it does not throw. This mirrors the family's existing non-fatal `Log.warn` for
+degraded-but-usable config (e.g. the in-memory-`SecretStore` warning), and
+contrasts the hard-fail guards for *required* infrastructure at
+`Application.hs:854,865`.
 
 ### 5. Terminal Fallback — API Routes Always Win
 

--- a/docs/decisions/0066-static-assets.md
+++ b/docs/decisions/0066-static-assets.md
@@ -1,0 +1,304 @@
+# ADR-0066: Static SPA Asset Serving for WebTransport
+
+## Status
+
+Proposed
+
+## Context
+
+A NeoHaskell `WebTransport` serves the command/query API (plus health, readiness,
+OAuth2, file upload, and OpenAPI docs) from a single WAI/Warp server. It has no
+way to serve a directory of static frontend assets. Today a developer who has
+built a Single-Page Application (SPA) — a Vite/React/Svelte `dist/` folder of
+`index.html` plus content-hashed JS/CSS bundles — must stand up a *second*
+server (nginx, a CDN, `wai-app-static`, or `python -m http.server`) just to
+hand those files to the browser, then wire CORS (ADR-0024) so the SPA can reach
+the API on a different origin.
+
+For the common case — a small app where the same NeoHaskell process should serve
+both the UI and the API on one port — that is disproportionate operational
+overhead. It also reintroduces the cross-origin problem that CORS exists to
+paper over: if the assets and the API share an origin, no CORS is needed at all.
+
+### Current State
+
+- `WebTransport` (`core/service/Service/Transport/Web.hs`) resolves each request
+  through a fixed set of route branches (commands, queries, `/health`, `/ready`,
+  OAuth2, file upload, `/openapi.yaml`, `/docs`). Anything unmatched falls
+  through to a terminal `notFound "Not found"` at `Web.hs:1026`.
+- The framework already has a well-established family of *web-transport-tied
+  Application combinators* — `withAuth`, `withAuthOverrides`, `withCors`,
+  `withHealthCheck` / `withoutHealthCheck`, `withApiInfo`, `withFileUpload`,
+  `withOAuth2Provider`, and `useReadinessEndpoint`. Each is an `Application`
+  line that sets a `Maybe` field on the `WebTransport` record, resolved at
+  `Application.run` time and injected into the transport.
+- WAI can already stream a file off disk with `responseFile`, and Warp handles
+  the body natively. No file-serving dependency is present or needed.
+
+### Use Cases
+
+- **Single-process full-stack app**: One NeoHaskell binary serves `dist/` at
+  `/` and the API at `/commands/*` and `/queries/*` — no second server, no CORS.
+- **SPA deep links**: A user reloads `/orders/42` (a client-side route with no
+  matching file on disk). The server returns `index.html` so the SPA's router
+  can take over, instead of a 404.
+- **Hot rebuild during development**: The dev edits the frontend, the bundler
+  rewrites `dist/`, and the browser must pick up the *new* `index.html` (never a
+  stale cached one) while still caching content-hashed bundles aggressively.
+
+### Design Goals
+
+1. **Consistency over novelty** — the feature must look and behave exactly like
+   the other nine web-transport combinators so a developer who knows `withCors`
+   already knows this. No new configuration idiom.
+2. **API always wins** — turning on static serving must never change the
+   behaviour of an existing API route. Static files are a *last resort*, not a
+   competing router.
+3. **Opt-in** — adding a `WebTransport` must not silently start serving disk
+   contents; that would change 404 semantics for existing API-only apps and
+   expose the filesystem by surprise.
+4. **Correct caching out of the box** — the developer should get
+   hot-rebuild-safe caching without knowing what `Cache-Control` is, because
+   getting it wrong makes local development mysteriously stale.
+5. **No new dependencies** — reuse WAI's `responseFile`; do not pull in
+   `wai-app-static`.
+
+### GitHub Issue
+
+- [#707: Serve static SPA assets from WebTransport](https://github.com/neohaskell/NeoHaskell/issues/707)
+
+## Decision
+
+### 1. An Application-Level Combinator, Consistent with the Existing Family
+
+Add `Application.withStaticAssets`, an `Application` combinator that sets an
+optional `StaticAssets` configuration on the `WebTransport`. It joins the
+existing family (`withCors`, `withApiInfo`, `withHealthCheck`, …) and is used
+identically: one pipe line between `withTransport` and `withService`.
+
+| Candidate | Verdict | Rationale |
+|-----------|---------|-----------|
+| **Application-level `Application.withStaticAssets`** | **Chosen** | Matches the nine existing web combinators exactly. Zero new idioms for the developer to learn. `Maybe StaticAssets` field, factory resolution, and record-update threading are a copy of the `withCors` path. |
+| Transport-level `WebTransport.withStaticAssets :: StaticAssets -> WebTransport -> WebTransport`, nested inside `withTransport (WebTransport.server \|> ...)` | Rejected | Would *found* a brand-new convention: `WebTransport` currently exposes **zero** combinators of its own, so this lone transport-level builder would sit inconsistently beside nine decoupled `Application`-level ones until (and unless) they all migrate. Smaller-diff and coupled-by-construction, but the whole point of this feature is proportionate consistency, not starting a migration. Revisit only if the family is deliberately moved as a set. |
+| Depend on `wai-app-static` | Rejected | WAI's `responseFile` already streams files; a dependency buys nothing but supply-chain surface. This is why the feature is `moderate`, not `complex`. |
+| Auto-serve a convention dir (`./public` / `./dist`) with zero config | Rejected | Silently serving disk contents the moment a `WebTransport` is added changes 404 semantics for every existing API-only app and is an exposure footgun. Opt-in with good internal defaults is safer. |
+
+### 2. `StaticAssets` Configuration Type
+
+Add a configuration type next to `CorsConfig` / `HealthCheckConfig` in
+`Service.Transport.Web`:
+
+```haskell
+-- | Static asset serving configuration for WebTransport.
+-- When set, unmatched non-API GET requests are served from 'root' on disk.
+-- Set via Application.withStaticAssets.
+data StaticAssets = StaticAssets
+  { root :: Text
+  -- ^ Directory whose contents are served (e.g., "dist").
+  , spaFallback :: Maybe Text
+  -- ^ Document served for unmatched non-API paths so client-side routing
+  --   works on deep links (e.g., Just "index.html"). Nothing = no fallback.
+  }
+```
+
+### 3. `WebTransport` Field and Default
+
+Add a `staticAssets :: Maybe StaticAssets` field to the `WebTransport` record
+(`Web.hs:149`), defaulting to `Nothing` in `server` (`Web.hs:189`) — off by
+default (Design Goal 3), exactly as `corsConfig` defaults to `Nothing`.
+
+```haskell
+server :: WebTransport
+server =
+  WebTransport
+    { -- ...existing fields...
+      corsConfig = Nothing,
+      staticAssets = Nothing,   -- new: opt-in via Application.withStaticAssets
+      -- ...
+    }
+```
+
+### 4. Factory, Resolution, and Threading (Mirror of `withCors`)
+
+`withStaticAssets` stores a factory on the `Application`, following the
+established `CorsFactory` / `ApiInfoFactory` pattern (`Application.hs:309`). This
+supports both the `@()`-immediate form and the config-deferred form with a
+single signature — identical ergonomics to `withApiInfo`:
+
+```haskell
+withStaticAssets ::
+  forall config.
+  (Typeable config) =>
+  (config -> Web.StaticAssets) ->
+  Application ->
+  Application
+```
+
+Resolution mirrors `withCors` end to end:
+
+- `Application.run` resolves the factory into a `Maybe StaticAssets`
+  (alongside `resolvedCorsConfig` at `Application.hs:849`), then threads it
+  through `runTransports` (the `app.corsConfig` argument list at
+  `Application.hs:1329`) as one additional parameter.
+- `Transports.runWebTransport` adds `staticAssets = maybeStaticAssets` to the
+  `webTransportWithConfig` record-update clobber list
+  (`Transports.hs:128-139`), exactly where `corsConfig = maybeCors` already sits.
+
+No new resolution *shape* is introduced — this is the same plumbing the family
+already uses.
+
+### 5. Terminal Fallback — API Routes Always Win
+
+Static serving replaces the terminal `_ -> notFound "Not found"` at `Web.hs:1026`.
+Every existing branch — commands, queries, `/health`, `/ready`, OAuth2, file
+upload, `/openapi.yaml`, `/docs` — is matched *first* and is unaffected. Only a
+request that matches nothing reaches the static fallback:
+
+```haskell
+_ -> case endpoints.transport.staticAssets of
+  Nothing -> notFound "Not found"          -- unchanged behaviour when disabled
+  Just assets -> serveStaticAsset assets request respond
+```
+
+This satisfies Design Goal 2: enabling static assets can never shadow an API
+route, because the router only reaches it after every API branch has declined.
+
+### 6. SPA Deep-Link Fallback
+
+Inside `serveStaticAsset`, when the normalized request path resolves to a real
+file under `root`, that file is streamed. When it does not (a client-side route
+like `/orders/42`) and `spaFallback` is `Just doc`, the fallback document is
+served with the entry-document cache policy so the SPA router can handle the
+route. When `spaFallback` is `Nothing`, an unmatched path is a plain `404`.
+
+### 7. Cache-Control Policy (Load-Bearing)
+
+The framework picks the correct `Cache-Control` so the developer never has to
+(Design Goal 4):
+
+| Asset | `Cache-Control` | Why |
+|-------|-----------------|-----|
+| Content-hashed bundle (`/assets/*.<hash>.js`, `.css`, …) | `public, max-age=31536000, immutable` | The hash *is* the version; the URL never serves different bytes, so caching forever is safe and fast. |
+| `index.html` and other non-hashed entry documents (incl. the SPA fallback) | `no-cache, must-revalidate` | The entry document points at the current hashed bundles; it must be re-fetched so a hot rebuild is picked up instead of a stale shell. |
+
+Hashed assets are recognized by the bundler's `name.<hash>.ext` filename shape.
+Getting this split right is what makes hot-rebuild-during-dev usable and is not
+optional.
+
+### 8. Path-Traversal Safety
+
+The requested path is normalized and guarded against `..` segments before being
+joined to `root`, so no request can escape the configured directory. A path that
+would resolve outside `root` is rejected as `404` (never `403` — do not confirm
+existence). This guard runs before any disk access.
+
+### 9. No New Dependencies
+
+Files are streamed with WAI's `responseFile`; Warp handles the body. No
+`wai-app-static`, no new package in `nhcore.cabal`.
+
+### 10. Example Usage
+
+```haskell
+app :: Application
+app =
+  Application.new
+    |> Application.withTransport WebTransport.server
+    |> Application.withStaticAssets @()
+        (\_ -> StaticAssets { root = "dist", spaFallback = Just "index.html" })
+    |> Application.withService MyService.service
+```
+
+One line, same shape as `withApiInfo @() (\_ -> ...)` in the testbed. The
+developer names a directory and (optionally) a fallback document; the caching,
+traversal guard, and route ordering are handled by the framework.
+
+### 11. Files Modified
+
+| File | Change |
+|------|--------|
+| `core/service/Service/Transport/Web.hs` | `StaticAssets` type; `staticAssets :: Maybe StaticAssets` field on `WebTransport` (default `Nothing`); `serveStaticAsset` helper; terminal fallback at `:1026`. |
+| `core/service/Service/Application.hs` | `StaticAssetsFactory`; `withStaticAssets` builder; factory resolution in `run`; extra argument through the `runTransports` call. |
+| `core/service/Service/Application/Transports.hs` | `Maybe StaticAssets` parameter threaded through `runTransports` / `runWebTransport`; `staticAssets = maybeStaticAssets` in the `runWebTransport` record-update. |
+
+### 12. Security Considerations
+
+- **Path traversal** is blocked by normalization + `..` guard (§8); the served
+  set is strictly the contents of `root`.
+- **Opt-in only** — no directory is served unless `withStaticAssets` is present,
+  so existing apps' 404 semantics and filesystem exposure are unchanged.
+- **API precedence** — static serving is the terminal branch, so it cannot
+  shadow or intercept an authenticated API route (§5).
+- **Unauthenticated** — this initial version serves assets without authn/authz
+  (typical for public SPA shells); gating static assets behind auth is
+  explicitly out of scope (see below).
+
+### 13. Performance Considerations
+
+- `responseFile` streams from disk via Warp's native sendfile path; bodies are
+  not buffered into memory.
+- The static branch is reached only for requests that match no API route, so the
+  API hot path is untouched — zero overhead when a request is an API call, and
+  zero overhead for all requests when `staticAssets = Nothing`.
+- Aggressive `immutable` caching of hashed bundles means repeat visits are served
+  from the browser cache, not the server.
+
+## Consequences
+
+### Positive
+
+- **One process, one origin**: The same NeoHaskell server serves UI and API, so
+  the common small-app case needs no second server and no CORS.
+- **Deep links just work**: The SPA fallback makes reloads of client-side routes
+  return the app shell instead of a 404.
+- **Familiar**: A developer who knows any of the nine existing web combinators
+  uses this one correctly from autocomplete in well under 15 minutes.
+- **Correct caching for free**: Hot rebuilds are picked up; hashed bundles are
+  cached forever — without the developer touching `Cache-Control`.
+- **Zero cost when unused**: `Nothing` default means no behavioural or
+  performance change for existing apps.
+
+### Negative
+
+- **Chose consistency over the "better" long-term shape**: keeping this at the
+  `Application` level (rather than a transport-level combinator) preserves the
+  existing decoupled convention but perpetuates it; if the family is ever moved
+  transport-level, this must move with it.
+- **A little Application/Transports plumbing**: one field, one factory, one extra
+  threaded argument — the standard cost of matching the family.
+
+### Risks
+
+- **Serving a directory that contains secrets**: If a developer points `root` at
+  a directory with sensitive files, those become public. Mitigation: it is
+  opt-in and documented as "serve your built SPA output (e.g. `dist`)", and the
+  traversal guard prevents escaping `root` — but the developer still chooses
+  `root`.
+- **Bundler hash naming variance**: A bundler that does not emit
+  `name.<hash>.ext` would miss the `immutable` classification and fall back to
+  the safe `no-cache` policy (correct but less cached). Acceptable: the default
+  degrades to safe, never to stale.
+
+### Mitigations
+
+- Path normalization + `..` guard (§8) contains serving to `root`.
+- Unknown-shaped filenames default to the revalidating (`no-cache`) policy, so a
+  misclassification can only cost caching, never serve stale entry documents.
+- Documentation steers `root` at build output, not source or config directories.
+
+## Out of Scope
+
+- **Server → client push** (SSE / WebSockets) — a separate transport concern.
+- **Authn/authz for static assets** — the initial version serves assets
+  unauthenticated; gating them behind auth is a future decision.
+
+## References
+
+- [#707: Serve static SPA assets from WebTransport](https://github.com/neohaskell/NeoHaskell/issues/707)
+- [ADR-0024: CORS Support for WebTransport](0024-cors-support.md)
+- [ADR-0025: Auto Health Endpoint for WebTransport Apps](0025-auto-health-endpoint.md)
+- [ADR-0011: File Upload Architecture](0011-file-upload-architecture.md)
+- [ADR-0035: Config-Dependent Application Builders](0035-config-dependent-application-builders.md)
+- [core/service/Service/Transport/Web.hs](../../core/service/Service/Transport/Web.hs)
+- [core/service/Service/Application.hs](../../core/service/Service/Application.hs)
+- [core/service/Service/Application/Transports.hs](../../core/service/Service/Application/Transports.hs)

--- a/docs/decisions/0066-static-assets.md
+++ b/docs/decisions/0066-static-assets.md
@@ -9,7 +9,7 @@ Proposed
 A NeoHaskell `WebTransport` serves the command/query API (plus health, readiness,
 OAuth2, file upload, and OpenAPI docs) from a single WAI/Warp server. It has no
 way to serve a directory of static frontend assets. Today a developer who has
-built a Single-Page Application (SPA) — a Vite/React/Svelte `dist/` folder of
+built a Single-Page Application (SPA) — a Vite/React/Svelte build folder of
 `index.html` plus content-hashed JS/CSS bundles — must stand up a *second*
 server (nginx, a CDN, `wai-app-static`, or `python -m http.server`) just to
 hand those files to the browser, then wire CORS (ADR-0024) so the SPA can reach
@@ -37,13 +37,13 @@ paper over: if the assets and the API share an origin, no CORS is needed at all.
 
 ### Use Cases
 
-- **Single-process full-stack app**: One NeoHaskell binary serves `dist/` at
+- **Single-process full-stack app**: One NeoHaskell binary serves `static/` at
   `/` and the API at `/commands/*` and `/queries/*` — no second server, no CORS.
 - **SPA deep links**: A user reloads `/orders/42` (a client-side route with no
   matching file on disk). The server returns `index.html` so the SPA's router
   can take over, instead of a 404.
 - **Hot rebuild during development**: The dev edits the frontend, the bundler
-  rewrites `dist/`, and the browser must pick up the *new* `index.html` (never a
+  rewrites `static/`, and the browser must pick up the *new* `index.html` (never a
   stale cached one) while still caching content-hashed bundles aggressively.
 
 ### Design Goals
@@ -81,7 +81,7 @@ identically: one pipe line between `withTransport` and `withService`.
 | **Application-level `Application.withStaticAssets`** | **Chosen** | Matches the nine existing web combinators exactly. Zero new idioms for the developer to learn. `Maybe StaticAssets` field, factory resolution, and record-update threading are a copy of the `withCors` path. |
 | Transport-level `WebTransport.withStaticAssets :: StaticAssets -> WebTransport -> WebTransport`, nested inside `withTransport (WebTransport.server \|> ...)` | Rejected | Would *found* a brand-new convention: `WebTransport` currently exposes **zero** combinators of its own, so this lone transport-level builder would sit inconsistently beside nine decoupled `Application`-level ones until (and unless) they all migrate. Smaller-diff and coupled-by-construction, but the whole point of this feature is proportionate consistency, not starting a migration. Revisit only if the family is deliberately moved as a set. |
 | Depend on `wai-app-static` | Rejected | WAI's `responseFile` already streams files; a dependency buys nothing but supply-chain surface. This is why the feature is `moderate`, not `complex`. |
-| Auto-serve a convention dir (`./public` / `./dist`) with zero config | Rejected | Silently serving disk contents the moment a `WebTransport` is added changes 404 semantics for every existing API-only app and is an exposure footgun. Opt-in with good internal defaults is safer. |
+| Auto-serve a convention dir (`./public` / `./static`) with zero config | Rejected | Silently serving disk contents the moment a `WebTransport` is added changes 404 semantics for every existing API-only app and is an exposure footgun. Opt-in with good internal defaults is safer. |
 
 ### 2. `StaticAssets` Configuration Type
 
@@ -94,7 +94,7 @@ Add a configuration type next to `CorsConfig` / `HealthCheckConfig` in
 -- Set via Application.withStaticAssets.
 data StaticAssets = StaticAssets
   { root :: Text
-  -- ^ Directory whose contents are served (e.g., "dist").
+  -- ^ Directory whose contents are served (e.g., "static").
   , spaFallback :: Maybe Text
   -- ^ Document served for unmatched non-API paths so client-side routing
   --   works on deep links (e.g., Just "index.html"). Nothing = no fallback.
@@ -205,7 +205,7 @@ app =
   Application.new
     |> Application.withTransport WebTransport.server
     |> Application.withStaticAssets @()
-        (\_ -> StaticAssets { root = "dist", spaFallback = Just "index.html" })
+        (\_ -> StaticAssets { root = "static", spaFallback = Just "index.html" })
     |> Application.withService MyService.service
 ```
 
@@ -271,7 +271,7 @@ traversal guard, and route ordering are handled by the framework.
 
 - **Serving a directory that contains secrets**: If a developer points `root` at
   a directory with sensitive files, those become public. Mitigation: it is
-  opt-in and documented as "serve your built SPA output (e.g. `dist`)", and the
+  opt-in and documented as "serve your built SPA output (e.g. `static`)", and the
   traversal guard prevents escaping `root` — but the developer still chooses
   `root`.
 - **Bundler hash naming variance**: A bundler that does not emit

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -75,6 +75,7 @@ ADRs document significant architectural decisions made during the development of
 | [0063](0063-per-stream-subscription-connection-release.md) | Release Per-Stream Subscription Connections on Unsubscribe | Proposed |
 | [0064](0064-optional-sslmode-tls-hardening.md) | Optional `sslmode` TLS Hardening for Postgres Connections | Proposed |
 | [0065](0065-acs-email-integration.md) | Azure Communication Services Email Integration | Proposed |
+| [0066](0066-static-assets.md) | Static SPA Asset Serving for WebTransport | Proposed |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary

This PR adds `Application.withStaticAssets`, a web-transport combinator that serves static Single-Page Application (SPA) assets from disk. A developer builds the config record `StaticAssets { root = "static", spaFallback = Just "index.html" }` and pipes it once at Application setup — the framework then serves files from `static/` on every unmatched GET, with index.html as the deep-link fallback for SPA client-side routing. Cache-Control headers are set correctly out of the box (content-hashed bundles → immutable, index.html → no-cache), path traversal is guarded with RFC-3986 normalization, and the feature is opt-in (missing/empty root → loud warning, API keeps serving). No new dependencies; reuses WAI's `responseFile` for streaming.

**Tier:** Moderate (filesystem IO on the static-fallback branch, no new dependencies, all path reads validated/normalized)

## Decision & Changes

See [ADR-0066](https://github.com/neohaskell/NeoHaskell/blob/main/docs/decisions/0066-static-assets.md) for design, use cases, and options rejected.

**Public API** (`Service.Transport.Web` — Jess's surface):
- `StaticAssets { root :: Text, spaFallback :: Maybe Text }` — config record
- `Application.withStaticAssets @config (config -> StaticAssets) -> Application -> Application` — one-line combinator, same shape as `withCors`, `withApiInfo`

**Behaviour**:
- Missing or empty `root` → loud startup `Log.warn`, API continues serving normally
- Unmatched request path → terminal fallback: if `spaFallback = Just "index.html"`, serve that for deep links; otherwise 404
- All `..` segments in the request path or fallback path are rejected (404, no filesystem confirmation)
- Path normalization per RFC-3986 before joining to root
- Cache-Control: `immutable` for files matching `name.<hash>.ext` pattern (content-hashed bundles), `no-cache, must-revalidate` for everything else (index.html, entry docs)
- Serves via `responseFile` (zero-copy sendfile on supported systems)

**Internal** (`Service.Transport.Web` — not separately exported):
- `serveStaticAsset` — handles a single request, checks traversal guards, sets Cache-Control, calls `responseFile`
- `serveStaticSpaFallback` — as above but for the fallback doc (same normalization + prefix guard as request path)

## Security

[Phase 12 security findings](https://github.com/neohaskell/NeoHaskell/pull/708) identified one critical issue during implementation review; **fixed**:

**SEC-010 — SPA fallback path traversal:** The `spaFallback` parameter (developer-supplied config) was not validated against directory escape like request paths. Implemented: the fallback path undergoes identical normalization and root-prefix verification as request paths. Regression tests 4.6 and 4.7 added and passing; both validate escape attempts.

Informational findings (not blocking):
- **SEC-001 (kept):** Path traversal on request paths is framework-absorbed inside `withStaticAssets`; regression tests verify both request and fallback paths (4.6/4.7)
- **SEC-011 (informational):** File existence check per request (TOCTOU window) is acceptable; documented risk on case-sensitive filesystems (Linux, deploy target)
- **SEC-012–SEC-014 (informational):** Path-traversal guard verified; symlink risk is deployment-level; dotfiles not served in v1

## Performance

[Phase 13 performance findings](https://github.com/neohaskell/NeoHaskell/pull/708) reviewed 18 patterns; all grounded as informational or framework-debt follow-ups:

- **PERF-011 (advisory):** Per-request `listDirectory` on case-sensitive filesystems is pure overhead (deploy target is Linux where `doesFileExist` is already case-sensitive). Documented follow-up: gate behind macOS-only startup flag; not a blocker on v1.
- Strict-field pragmas, INLINE recommendations, and encoder patterns are either already applied correctly or are deferred to framework-level optimizations pending profiling evidence.

## Tests

Comprehensive test coverage with **43 StaticAssets examples**:
- **4.1–4.5:** Happy path (serve file, deep link, fallback miss), cache-control correctness (hashed vs non-hashed), edge cases (empty root, missing fallback)
- **4.6–4.7:** Security regressions — path traversal on both request and fallback paths (escape attempt → 404, no confirmation)
- **4.8–4.13:** Error handling (unmatched path with no fallback → 404, internal errors), response headers, status codes

All tests passing: `cabal test all` green (1723 examples, 0 failures, 6 pending; StaticAssets 43/43).

## Hlint

Hlint clean.

## Checklist

- [x] ADR approved (phase 3)
- [x] Security findings grounded (phase 12)
- [x] Performance findings grounded (phase 13)
- [x] Tests passing (phase 15)
- Hlint: clean ✓

## Known follow-up (non-blocking)

The per-request `listDirectory` case-sensitivity check (perf-11) is pure overhead on Linux (deploy target). A future PR can gate it behind a macOS-only flag (System.Info.os == darwin) to remove the overhead on the primary deployment platform. This does not block v1 — it is documented and tested but kept as-is to ship the feature now and optimize after profiling real-world usage.

Closes #707


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional static asset serving for web transport, including SPA deep-link fallback and cache-aware responses.
  * Added a new application-level configuration path to enable static assets alongside existing web routes.

* **Bug Fixes**
  * Improved path handling and security checks to prevent directory traversal and keep asset lookups safely within the configured root.
  * Static assets now return sensible 404s when files or fallback targets are unavailable.

* **Tests**
  * Added broad coverage for file serving, fallback routing, content types, cache behavior, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->