### PR TITLE
Pipeline Phase 5 — contract-delta spec gate + verification architecture

### DIFF
--- a/.claude/hooks/expectation-guard-cases.json
+++ b/.claude/hooks/expectation-guard-cases.json
@@ -1,0 +1,160 @@
+[
+  {
+    "name": "edit-rewrites-shouldBe-value",
+    "tag": "edit-expectation",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "core/test-core/TextSpec.hs",
+      "old_string": "      Text.length result |> shouldBe 5",
+      "new_string": "      Text.length result |> shouldBe 6"
+    },
+    "expect_block": true
+  },
+  {
+    "name": "edit-deletes-expectation",
+    "tag": "edit-expectation",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "core/test-core/TextSpec.hs",
+      "old_string": "      result |> shouldBe expected\n      count |> shouldBe 3",
+      "new_string": "      result |> shouldBe expected"
+    },
+    "expect_block": true
+  },
+  {
+    "name": "edit-adds-new-expectation-keeps-old",
+    "tag": "edit-expectation",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "core/test-core/TextSpec.hs",
+      "old_string": "      result |> shouldBe expected",
+      "new_string": "      result |> shouldBe expected\n      count |> shouldBe 3"
+    },
+    "expect_block": false
+  },
+  {
+    "name": "edit-moves-expectation-unchanged",
+    "tag": "edit-expectation",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "core/test-service/EventStoreSpec.hs",
+      "old_string": "      events |> shouldBe expected\n      -- old comment",
+      "new_string": "      -- new comment\n      events |> shouldBe expected"
+    },
+    "expect_block": false
+  },
+  {
+    "name": "edit-reindents-expectation-only",
+    "tag": "edit-expectation",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "core/test-core/TextSpec.hs",
+      "old_string": "      result |> shouldBe expected",
+      "new_string": "        result |> shouldBe expected"
+    },
+    "expect_block": false
+  },
+  {
+    "name": "edit-nontest-file-with-shouldBe-prose",
+    "tag": "non-test-file",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "core/core/Task.hs",
+      "old_string": "-- the result shouldBe forwarded",
+      "new_string": "-- forwarded"
+    },
+    "expect_block": false
+  },
+  {
+    "name": "edit-testbed-hurl-assert-changed",
+    "tag": "hurl-assertion",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "testbed/test/create-user.hurl",
+      "old_string": "status == 201",
+      "new_string": "status == 200"
+    },
+    "expect_block": true
+  },
+  {
+    "name": "edit-hurl-new-block-appended",
+    "tag": "hurl-assertion",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "testbed/test/create-user.hurl",
+      "old_string": "status == 201",
+      "new_string": "status == 201\njsonpath \"$.id\" exists"
+    },
+    "expect_block": false
+  },
+  {
+    "name": "write-overwrites-spec-losing-expectation",
+    "tag": "write-overwrite",
+    "tool": "Write",
+    "tool_input": {
+      "file_path": "core/test-core/UuidSpec.hs",
+      "content": "spec = it \"parses\" do\n  result |> shouldBe uuid\n"
+    },
+    "disk_content": "spec = it \"parses\" do\n  result |> shouldBe uuid\n  version |> shouldBe 4\n",
+    "expect_block": true
+  },
+  {
+    "name": "write-new-spec-file-no-prior-content",
+    "tag": "write-overwrite",
+    "tool": "Write",
+    "tool_input": {
+      "file_path": "core/test-core/NewFeatureSpec.hs",
+      "content": "spec = it \"works\" do\n  result |> shouldBe expected\n"
+    },
+    "disk_content": "",
+    "expect_block": false
+  },
+  {
+    "name": "multiedit-one-edit-rewrites-expectation",
+    "tag": "multiedit",
+    "tool": "MultiEdit",
+    "tool_input": {
+      "file_path": "core/test-auth/JwtSpec.hs",
+      "edits": [
+        {"old_string": "import Jwt qualified", "new_string": "import Jwt qualified\nimport Claims qualified"},
+        {"old_string": "  claims |> shouldBe expected", "new_string": "  claims |> shouldSatisfy isValid"}
+      ]
+    },
+    "expect_block": true
+  },
+  {
+    "name": "multiedit-only-nonexpectation-edits",
+    "tag": "multiedit",
+    "tool": "MultiEdit",
+    "tool_input": {
+      "file_path": "core/test-auth/JwtSpec.hs",
+      "edits": [
+        {"old_string": "import Jwt qualified", "new_string": "import Jwt qualified\nimport Claims qualified"}
+      ]
+    },
+    "expect_block": false
+  },
+  {
+    "name": "approved-run-may-edit-expectation",
+    "tag": "approval-marker",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "core/test-core/TextSpec.hs",
+      "old_string": "      result |> shouldBe 5",
+      "new_string": "      result |> shouldBe 6"
+    },
+    "approved": true,
+    "expect_block": false
+  },
+  {
+    "name": "archive-copies-are-exempt",
+    "tag": "non-test-file",
+    "tool": "Edit",
+    "tool_input": {
+      "file_path": "docs/archive/2026-07-ai-artifacts/core/testSpec.hs",
+      "old_string": "  x |> shouldBe 1",
+      "new_string": "  x |> shouldBe 2"
+    },
+    "expect_block": false
+  }
+]

--- a/.claude/hooks/expectation-guard.py
+++ b/.claude/hooks/expectation-guard.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""PreToolUse expectation guard (pipeline Phase 5, task 6).
+
+Mechanizes the standing rule "never modify existing test expectations without
+maintainer approval" (AGENTS.md, Non-negotiable): an Edit/Write/MultiEdit that
+REMOVES or CHANGES an existing expectation line in a test file is blocked
+unless the run carries an explicit approval marker.
+
+What counts:
+- test files: *Spec.hs, files under test dirs (core/test*, testbed/test,
+  integrations/**/tests), and .hurl acceptance files
+- expectation lines: hspec matchers (shouldBe & friends) and hurl assertions
+- a violation is an expectation line present in the OLD text and absent from
+  the NEW text (whitespace-normalized). Moving a line or adding new
+  expectations never trips the guard; deleting or rewording one does.
+
+Approval marker: `.pipeline/allow-expectation-edits` — a file the MAINTAINER
+creates (or explicitly tells the agent to create), naming who approved and
+why. It is inside gitignored `.pipeline/`, so approval is per-checkout and
+per-run, never committed, never ambient. Delete it when the approved change
+lands. There is deliberately NO inline escape hatch (HOOK-ALLOW) — changing
+recorded expectations is exactly the action that must go through a human.
+
+Contract mirrors dialect-guard: stdin JSON payload, exit 2 = rejection,
+--self-test enforces case coverage from expectation-guard-cases.json
+(runs in CI via ./dev doctor).
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+APPROVAL_FILE = REPO_ROOT / ".pipeline" / "allow-expectation-edits"
+CASES_FILE = Path(__file__).parent / "expectation-guard-cases.json"
+
+TEST_FILE = re.compile(r"(Spec\.hs$|\.hurl$|(^|/)(core/test[^/]*|testbed/test|tests)/)")
+EXPECTATION = re.compile(
+    r"\bshould(Be|Return|Satisfy|MatchList|Contain|StartWith|EndWith|Throw|NotBe)\b"
+    r"|\bexpectationFailure\b"
+    r"|^HTTP\b|^\[Asserts\]|^jsonpath\s|^status\s|^header\s|^body\s")
+
+
+def norm(line: str) -> str:
+    return " ".join(line.split())
+
+
+def expectation_lines(text: str):
+    """Multiset of normalized expectation lines (count matters: rewriting one
+    of two identical assertions is still a change)."""
+    out = {}
+    for line in text.splitlines():
+        if EXPECTATION.search(line):
+            key = norm(line)
+            out[key] = out.get(key, 0) + 1
+    return out
+
+
+def removed_expectations(old: str, new: str):
+    before, after = expectation_lines(old), expectation_lines(new)
+    return sorted(k for k, n in before.items() if after.get(k, 0) < n)
+
+
+def old_new_pairs(tool: str, payload: dict, read_disk):
+    if tool == "Edit":
+        return [(payload.get("old_string", ""), payload.get("new_string", ""))]
+    if tool == "MultiEdit":
+        return [(e.get("old_string", ""), e.get("new_string", ""))
+                for e in payload.get("edits", [])]
+    if tool == "Write":
+        # overwrite: the old text is the file's current content
+        return [(read_disk(payload.get("file_path", "")), payload.get("content", ""))]
+    return []
+
+
+def check(tool: str, payload: dict, approved: bool, read_disk=None):
+    """Returns [removed expectation lines] — pure, testable."""
+    path = payload.get("file_path", "")
+    if not TEST_FILE.search(path) or "docs/archive/" in path:
+        return []
+    if approved:
+        return []
+    if read_disk is None:
+        def read_disk(p):
+            try:
+                return Path(p).read_text()
+            except OSError:
+                return ""
+    removed = []
+    for old, new in old_new_pairs(tool, payload, read_disk):
+        removed += removed_expectations(old, new)
+    return removed
+
+
+def read_event():
+    tool, payload = "", {}
+    if not sys.stdin.isatty():
+        try:
+            event = json.loads(sys.stdin.read() or "{}")
+            tool = event.get("tool_name", "")
+            payload = event.get("tool_input", {}) or {}
+        except json.JSONDecodeError:
+            pass
+    if not tool:
+        tool = os.environ.get("CLAUDE_TOOL_NAME", "")
+        try:
+            payload = json.loads(os.environ.get("CLAUDE_TOOL_INPUT", "") or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+    return tool, payload
+
+
+def self_test() -> int:
+    """Every case runs through check() with approved=False unless the case
+    sets `approved`; coverage: >=1 blocking and >=1 passing case per
+    scenario tag."""
+    cases = json.loads(CASES_FILE.read_text())
+    tags_blocked, tags_passed, fails = set(), set(), 0
+    for case in cases:
+        removed = check(case["tool"], case["tool_input"],
+                        case.get("approved", False),
+                        read_disk=lambda _p, c=case: c.get("disk_content", ""))
+        want_block = case["expect_block"]
+        if bool(removed) != want_block:
+            print(f"self-test FAIL {case['name']}: expected "
+                  f"{'block' if want_block else 'pass'}, removed={removed}")
+            fails += 1
+        (tags_blocked if want_block else tags_passed).add(case["tag"])
+    for tag in sorted(tags_blocked - tags_passed):
+        print(f"self-test FAIL coverage: tag '{tag}' has no passing counter-case")
+        fails += 1
+    if fails == 0:
+        print(f"expectation-guard self-test: OK — {len(cases)} cases, "
+              f"{len(tags_blocked | tags_passed)} scenarios covered")
+    return 1 if fails else 0
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        return self_test()
+
+    tool, payload = read_event()
+    removed = check(tool, payload, approved=APPROVAL_FILE.exists())
+    if removed:
+        print(
+            "Expectation guard — edit rejected: this change removes or rewrites "
+            "existing test expectations:\n"
+            + "\n".join(f"  ↳ {line[:120]}" for line in removed[:6])
+            + "\n\nExisting expectations are the recorded contract — changing them "
+            "requires MAINTAINER approval (AGENTS.md, Non-negotiable). If the "
+            "maintainer has approved this in writing, record it:\n"
+            "  echo 'approved by <name>: <reason / spec ref>' > "
+            ".pipeline/allow-expectation-edits\n"
+            "then retry, and delete the marker when the change lands. "
+            "Adding NEW tests never needs this.",
+            file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/expectation-guard.py
+++ b/.claude/hooks/expectation-guard.py
@@ -14,21 +14,28 @@ What counts:
   the NEW text (whitespace-normalized). Moving a line or adding new
   expectations never trips the guard; deleting or rewording one does.
 
-Approval marker: `.pipeline/allow-expectation-edits` — a file the MAINTAINER
-creates (or explicitly tells the agent to create), naming who approved and
-why. It is inside gitignored `.pipeline/`, so approval is per-checkout and
-per-run, never committed, never ambient. Delete it when the approved change
-lands. There is deliberately NO inline escape hatch (HOOK-ALLOW) — changing
-recorded expectations is exactly the action that must go through a human.
+Two layers, because a local hook alone is not a gate:
+- This hook is the fast LOCAL teacher. Approval marker
+  `.pipeline/allow-expectation-edits` — a per-checkout, gitignored file the
+  MAINTAINER creates (or tells the agent to). No inline escape hatch. It fails
+  LOUD-open on unparseable stdin (a harness schema change must be visible, not
+  a silently-disabled guard).
+- `--pr-diff BASE` is the ENFORCED CI backstop (checks.yml `expectations`
+  job): it census-diffs the committed test files against the merge base and
+  blocks a net-removed/reworded expectation unless a maintainer applied the
+  `expectations-approved` PR label. Operating on the committed result (not an
+  edit payload) covers the rename / non-test-path / Bash-mutation vectors the
+  local hook's path+payload matcher cannot; the label, unlike the local
+  marker, is not agent-writable.
 
 Contract mirrors dialect-guard: stdin JSON payload, exit 2 = rejection,
---self-test enforces case coverage from expectation-guard-cases.json
-(runs in CI via ./dev doctor).
+--self-test enforces coverage (runs in CI via ./dev doctor).
 """
 
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -94,21 +101,95 @@ def check(tool: str, payload: dict, approved: bool, read_disk=None):
     return removed
 
 
-def read_event():
-    tool, payload = "", {}
-    if not sys.stdin.isatty():
+# ── CI census gate (--pr-diff) ────────────────────────────────────────────────
+
+def removed_from_census(before, after):
+    """Pure: normalized expectation lines whose count dropped from before→after.
+    Census-over-files (not per-file diff) nets moves to zero and catches
+    reworded/deleted expectations regardless of which file or tool touched them."""
+    return sorted(k for k, n in before.items() if after.get(k, 0) < n)
+
+
+def _git(*args):
+    return subprocess.run(["git", *args], capture_output=True, text=True)
+
+
+def changed_test_files(base):
+    # --no-renames so a rename surfaces as delete(old)+add(new): the census then
+    # sees the old file's expectations leave and the new file's arrive.
+    proc = _git("diff", "--name-only", "--no-renames", "--diff-filter=ACMD",
+                f"{base}...HEAD")
+    if proc.returncode != 0:
+        print(f"expectation-guard: git diff against `{base}` failed — bad base ref? "
+              f"({proc.stderr.strip()})", file=sys.stderr)
+        sys.exit(2)
+    return [p for p in proc.stdout.splitlines()
+            if TEST_FILE.search(p) and "docs/archive/" not in p]
+
+
+def pr_diff(base, approved):
+    """CI backstop: fail on a net-removed/reworded expectation across the changed
+    test files unless a maintainer approved it (the `expectations-approved`
+    label). Returns an exit code."""
+    before, after = {}, {}
+    for path in changed_test_files(base):
+        shown = _git("show", f"{base}:{path}")
+        for k, n in expectation_lines(shown.stdout if shown.returncode == 0 else "").items():
+            before[k] = before.get(k, 0) + n
         try:
-            event = json.loads(sys.stdin.read() or "{}")
+            head_text = Path(path).read_text()
+        except OSError:
+            head_text = ""  # deleted at HEAD
+        for k, n in expectation_lines(head_text).items():
+            after[k] = after.get(k, 0) + n
+    removed = removed_from_census(before, after)
+    if not removed:
+        print("expectation-guard: OK — no test expectations removed or reworded")
+        return 0
+    if approved:
+        print(f"expectation-guard: {len(removed)} expectation change(s) allowed "
+              "(maintainer-approved via the `expectations-approved` label)")
+        return 0
+    print("expectation-guard — PR blocked: removes or rewrites existing test "
+          "expectations:\n" + "\n".join(f"  ↳ {k[:120]}" for k in removed[:12])
+          + "\n\nExisting expectations are the recorded contract (AGENTS.md, "
+          "Non-negotiable). A maintainer who approved this change must apply the "
+          "`expectations-approved` label to the PR. Adding NEW tests never trips "
+          "this.", file=sys.stderr)
+    return 1
+
+
+def parse_event(stdin_text, env):
+    """Pure: (tool, payload, parse_error) from a stdin payload + env fallback.
+    parse_error is True only when stdin held real content that did NOT parse as
+    the expected JSON event — an empty/absent payload is not an error."""
+    tool, payload, parse_error = "", {}, False
+    stripped = (stdin_text or "").strip()
+    if stripped and stripped != "{}":
+        try:
+            event = json.loads(stripped)
             tool = event.get("tool_name", "")
             payload = event.get("tool_input", {}) or {}
-        except json.JSONDecodeError:
-            pass
+        except (json.JSONDecodeError, AttributeError):
+            parse_error = True
     if not tool:
-        tool = os.environ.get("CLAUDE_TOOL_NAME", "")
+        tool = env.get("CLAUDE_TOOL_NAME", "")
         try:
-            payload = json.loads(os.environ.get("CLAUDE_TOOL_INPUT", "") or "{}")
+            payload = json.loads(env.get("CLAUDE_TOOL_INPUT", "") or "{}")
         except json.JSONDecodeError:
             payload = {}
+    return tool, payload, parse_error
+
+
+def read_event():
+    stdin_text = "" if sys.stdin.isatty() else sys.stdin.read()
+    tool, payload, parse_error = parse_event(stdin_text, os.environ)
+    if parse_error and not tool:
+        # fail loud-open: we cannot inspect this edit, but the CI census gate is
+        # the real backstop — surface it rather than silently allowing forever
+        print("expectation-guard: WARNING — stdin present but unparseable as a tool "
+              "event; cannot inspect this edit (harness schema change?). Allowing it "
+              "— the CI `expectations` gate is the enforced backstop.", file=sys.stderr)
     return tool, payload
 
 
@@ -131,15 +212,43 @@ def self_test() -> int:
     for tag in sorted(tags_blocked - tags_passed):
         print(f"self-test FAIL coverage: tag '{tag}' has no passing counter-case")
         fails += 1
+
+    # Fix 3: malformed stdin fails LOUD (parse_error set), not silently open
+    _, _, err = parse_event("{not json", {})
+    if not err:
+        print("self-test FAIL parse-event: malformed stdin must set parse_error")
+        fails += 1
+    tool, _, err2 = parse_event('{"tool_name": "Edit", "tool_input": {}}', {})
+    if tool != "Edit" or err2:
+        print("self-test FAIL parse-event: a valid event must parse without error")
+        fails += 1
+    _, _, err3 = parse_event("", {})  # no stdin is normal, not an error
+    if err3:
+        print("self-test FAIL parse-event: empty stdin must not be an error")
+        fails += 1
+
+    # Fix 3: census-diff detects a net-removed/reworded expectation across files
+    before = {"x `shouldBe` 1": 2, "y `shouldBe` 2": 1}
+    if removed_from_census(before, {"x `shouldBe` 1": 2}) != ["y `shouldBe` 2"]:
+        print("self-test FAIL census: a net removal must be detected")
+        fails += 1
+    if removed_from_census(before, before) != []:
+        print("self-test FAIL census: an unchanged census must be clean")
+        fails += 1
+
     if fails == 0:
         print(f"expectation-guard self-test: OK — {len(cases)} cases, "
-              f"{len(tags_blocked | tags_passed)} scenarios covered")
+              f"{len(tags_blocked | tags_passed)} scenarios, parse+census covered")
     return 1 if fails else 0
 
 
 def main() -> int:
     if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
         return self_test()
+    if len(sys.argv) > 1 and sys.argv[1] == "--pr-diff":
+        base = sys.argv[2] if len(sys.argv) > 2 else "origin/main"
+        approved = os.environ.get("EXPECTATIONS_APPROVED", "").strip().lower() == "true"
+        return pr_diff(base, approved)
 
     tool, payload = read_event()
     removed = check(tool, payload, approved=APPROVAL_FILE.exists())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,11 @@
             "type": "command",
             "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/dialect-guard.py",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "python3 $CLAUDE_PROJECT_DIR/.claude/hooks/expectation-guard.py",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/skills/neohaskell-performance-design-review/SKILL.md
+++ b/.claude/skills/neohaskell-performance-design-review/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: neohaskell-performance-design-review
+description: Design-time performance review of an approved contract-delta spec, before implementation. Runs when the spec's touches list intersects perf-sensitive capabilities. Produces the committed review record; measurement lives in the nightly bench harness, not here.
+---
+
+# Performance design review (risk-tiered, design-time)
+
+Rebuilt 2026-07-08 (Phase 5; predecessors archived in
+`docs/archive/2026-07-ai-artifacts/claude-skills/` — note the archive's
+blanket-INLINE/UNPACK advice was CORRECTED against GHC reality during
+salvage; this file is the fixed version). Target: ~50k req/s event-sourcing
+services. Hot-path budgets: command intake <1ms, event apply <0.5ms, query
+<0.2ms, event persistence <1ms.
+
+## When this runs (mechanical, not judgment)
+
+`./dev spec-check --plan docs/changes/NNN-slug.md` → `design_reviews`
+contains `"perf"` (spec `touches:` ∩ `perf-sensitive` capabilities). After
+spec approval, before implementation. Untagged specs skip this. This review
+is per-PR *assurance by reasoning*; per-night *measurement* is `./dev bench`
+(nightly-bench.yml) — never conflate the two, and never demand benchmarks
+in a PR.
+
+## Compiler context (facts the review must not contradict)
+
+- `Strict` is ON globally: let-bindings, args, and constructor fields are
+  already strict. Never advise "add strictness" / bangs / `foldl'`.
+- `Strict` does NOT cover: imported types (Prelude `Maybe`/lists/tuples stay
+  lazy), nested patterns, or values inside containers (`Map k v` holds lazy
+  `v`s). These are where leaks actually hide.
+- At `-O` GHC unboxes small strict fields itself
+  (`-funbox-small-strict-fields`): `UNPACK` on a word-sized field of a
+  single-constructor type is noise. `UNPACK` earns its place only on
+  multi-word strict fields or where the unfolding shows re-boxing at lazy
+  call sites — and that claim needs a profile.
+
+## Checklist (numbered — the record cites these IDs)
+
+- **P1 Hot-path placement:** which promised functions sit on command intake /
+  event apply / query / persistence? Budget impact estimate for each. Not on
+  a hot path → the rest of this list demotes to informational.
+- **P2 Specialisation:** exported polymorphic (typeclass-constrained)
+  function called cross-module on a hot path → needs `INLINABLE` (GHC cannot
+  specialise across modules without it). `INLINE` only for small functions
+  that unlock fusion/RULES — never on >~10-line bodies.
+- **P3 Laziness escapes:** `~` opt-outs in hot-path types need a justifying
+  comment; hot-path data relying on Prelude `Maybe`/list under the false
+  assumption `Strict` covers it; recursive accumulators building non-flat
+  structures (thunk-graph retention).
+- **P4 Serialization:** hand-written `ToJSON` on a hot codec (events, API
+  responses, projections) must define `toEncoding`, not just `toJSON`
+  (the default `toEncoding` via `toJSON` gives zero speedup; Generic/TH
+  derivation emits a real one).
+- **P5 Allocation:** `pack`/`unpack` or `encodeUtf8`/`decodeUtf8` round-trips
+  more than once per request; `[fmt|…|]` inside tight loops; unfused
+  `Array.map f |> Array.map g` chains; constants rebuilt inside loops.
+- **P6 Contention:** `ConcurrentVar`/`TVar` wrapping a whole `Map` with
+  multiple writer threads serialises all writers — push toward
+  `ConcurrentMap` (stm-containers) or per-key sharding. Single-writer or
+  read-mostly state: the plain var is correct, the swap is overkill.
+- **P7 Evidence discipline:** any "this is faster" claim in the spec beyond
+  removing the named anti-patterns requires measurement (a criterion/
+  tasty-bench number or a profile) — otherwise downgrade the claim and note
+  it for the nightly harness. New perf-tagged surface should propose a
+  bench-budgets entry (`telemetry/bench-budgets.json`).
+
+## Grounding filter (mandatory)
+
+Same 4-question discipline as the security review: (1) measurable impact on
+the 50k req/s budget given the workload tier? (2) is the path actually
+exercised? (3) can the framework absorb the fix so users never see a pragma?
+(4) proportional — no pragma cascades on code no profile has shown hot?
+Findings failing any question are demoted to `informational` with the failed
+question named. Premature-optimization cascades (INLINE+UNPACK+SPECIALIZE
+everywhere) are a net negative: compile time, code size, lost fusion.
+
+## Output (the committed record)
+
+Write `docs/changes/NNN-slug.perf-review.md` on the PR branch (same shape as
+the security record: checklist-ID table, grounding column, verdict, blocker
+count + resolution). Blockers amend the plan or park the run; zero-finding
+reviews still commit the record.

--- a/.claude/skills/neohaskell-pipeline/SKILL.md
+++ b/.claude/skills/neohaskell-pipeline/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: neohaskell-pipeline
+description: Orchestrate a NeoHaskell change end-to-end through the spec-gated pipeline - intake to merged PR with exactly two human gates. Use when implementing a feature, fixing a bug, or running any request that should produce a PR.
+---
+
+# The change pipeline (Phase 5)
+
+Exactly **two human gates**: spec approval (draft PR) and final PR review.
+Everything between them is mechanical or agent-run, resumable from
+`.pipeline/state.json`, and telemetered. Stage names below are the telemetry
+schema v2 canon (`telemetry/SCHEMA.md`) — state, telemetry lines, and this
+skill share one vocabulary.
+
+## Stage flow
+
+```
+intake ─ localize ─ spec ─▶ DRAFT PR ══ GATE 1 (maintainer) ══▶ design-review
+        ─ plan ─ test-writing ─ implement ─ verify ─ pr ══ GATE 2 ══▶ ci ─ merged
+```
+
+1. **intake** — `./dev pipeline init --run-id YYYY-MM-DD-NNN --request issue#N
+   --branch <branch>`; `scripts/telemetry.py` run start. Restate the request;
+   ambiguity that changes the contract → one clarifying question NOW (cheap
+   here, a wrong PR later).
+2. **localize** — `neohaskell-localizer` skill. Output: capability IDs +
+   `touches:`/`files:`/`uses:` lists → `./dev pipeline set plan.touches …`
+   etc. The plan is now BINDING: resume never re-plans; a wrong plan parks
+   the run (`wrong-localization`) and re-enters from intake, visibly.
+3. **spec** — copy `docs/changes/TEMPLATE.md` → `NNN-slug.md` (next 3-digit
+   number). Contract delta in signatures vocabulary; criteria C1…Cn each
+   naming its proving test AND level (`unit|integration|acceptance` — a
+   boundary-crossing behavior must declare integration/acceptance).
+   `kind: bug` → C1 is the failing repro test, committed RED in the draft PR:
+   the repro is the spec. ADR trigger flags honest (`./dev spec-check`
+   cross-checks removals vs `breaking:`); triggered → write the ADR, link it
+   — it's part of what the maintainer approves.
+4. **GATE 1** — open a **draft PR** whose diff is the spec (+ADR, +red repro).
+   Park: `./dev pipeline park` is NOT used here — waiting on the gate is
+   `waiting_on_human_s`, not a failure. The continue signal is a maintainer
+   comment (`@claude` + instruction) — `claude.yml` ignores non-maintainers
+   (author-association check). On approval: `./dev pipeline approve spec
+   --by <who> --via pr-comment` (advance past `spec` is mechanically blocked
+   without it), then `./dev pipeline advance`.
+5. **design-review** — `./dev spec-check --plan <spec>` → `design_reviews`.
+   `security` → `neohaskell-security-design-review` skill; `perf` →
+   `neohaskell-performance-design-review`. Review records are committed to
+   the PR branch (`NNN-slug.<kind>-review.md`). Empty list → skip (stage
+   recorded with ~0 duration; the skip is the risk-tiering working).
+6. **plan** — order the work: which files in what sequence, which neighbor
+   module each copy-adapts from (`neohaskell-implementer` discipline).
+7. **test-writing** — tests FIRST, from the criteria table, red before any
+   implementation. Never weaken an existing expectation: the
+   expectation-guard hook blocks it without the maintainer marker
+   (`.pipeline/allow-expectation-edits`). New spec modules: register in the
+   suite's `Main.hs` AND cabal `other-modules` (only `nhcore-test` is
+   hspec-discovered).
+8. **implement** — `neohaskell-implementer` skill; repair loop via
+   `./dev check` (never `cabal build` in the loop); max 2 repair rounds per
+   error, then the failure policy below.
+9. **verify** — in order, no skipping:
+   a. criteria tests green at their DECLARED levels (`./dev test "<pattern>" <suite>`)
+   b. targeted regression: `./dev spec-check --plan <spec>` →
+      `test_impact_globs` → run those suites
+   c. `./dev lint` + `./dev spec-drift <spec>` (the promise check)
+   d. full suite (`./dev test-all`) only here, once, at PR-ready
+10. **pr** — flip the draft to ready-for-review (this re-triggers the full CI
+    matrix; drafts run only the cheap checks). PR body: spec link, criteria →
+    test mapping, review records. GATE 2 is the maintainer's normal review.
+11. **ci** — watch checks; bot comments triaged (fix real findings; push
+    back with evidence on wrong ones). Merge is the maintainer's.
+
+After merge: `scripts/telemetry.py` finish (outcome `ok`), golden archive
+(`telemetry/golden/<run_id>/`: request.md, spec.md, final.diff, verdict.md,
+transcript.md).
+
+## Failure policy (time-boxes → retry → escalate → park)
+
+Per-stage time-boxes, v1 defaults (wall-clock, excluding `waiting_on_human_s`;
+the weekly telemetry review recalibrates from measured stage times):
+
+| intake | localize | spec | design-review | plan | test-writing | implement | verify | pr | ci |
+|---|---|---|---|---|---|---|---|---|---|
+| 10m | 10m | 30m | 20m | 15m | 30m | 45m | 30m | 10m | 45m |
+
+On breach: **retry once** (fresh attempt, same plan) → **escalate model
+tier** (haiku→sonnet→opus; record `model` per stage in telemetry) → **park**:
+`./dev pipeline park --label <taxonomy> --note <one-liner>` + a structured
+report comment on the PR/issue: stage, elapsed, label, last error verbatim,
+what was tried. **A parked report beats a wrong PR** — parking is the
+pipeline succeeding at honesty, not failing at work. Labels are the closed
+taxonomy (SCHEMA.md); `other` requires `failure_note` and a weekly-review
+reclassification.
+
+## Resume contract
+
+`./dev pipeline status` → resume at the recorded stage with the recorded
+plan. Never re-derive `touches:`/`files:`/`uses:` on resume. If reality
+contradicts the plan (file moved, API changed under you), park with
+`wrong-localization` — the asset fix (alias, capability, extension point)
+ships with the retry, per the failure→asset-delta protocol (Phase 6).

--- a/.claude/skills/neohaskell-security-design-review/SKILL.md
+++ b/.claude/skills/neohaskell-security-design-review/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: neohaskell-security-design-review
+description: Design-time security review of an approved contract-delta spec, before implementation. Runs when the spec's touches list intersects security-sensitive capabilities. Produces the committed review record the PR carries (compliance audit trail).
+---
+
+# Security design review (risk-tiered, design-time)
+
+Rebuilt 2026-07-08 (Phase 5; predecessors archived in
+`docs/archive/2026-07-ai-artifacts/claude-skills/`). NeoHaskell serves
+national-level European infrastructure: security compliance is a hard
+requirement, and the committed review record is the audit-trail artifact.
+
+## When this runs (mechanical, not judgment)
+
+`./dev spec-check --plan docs/changes/NNN-slug.md` → `design_reviews`
+contains `"security"`. That is the ONLY trigger: it fires exactly when the
+spec's `touches:` intersects a capability tagged `security-sensitive` in
+`codemap/capabilities.yaml`. Untagged specs skip this entirely — gates scale
+with blast radius. Timing: after the maintainer approves the spec (the
+draft-PR gate), before any implementation.
+
+## Inputs
+
+1. The approved spec (`docs/changes/NNN-slug.md`) — contract delta + criteria.
+2. The plan fragment (resolved `touches:`/`files:`/`uses:` — `./dev pipeline status`).
+3. The touched capabilities' `responsibility:` lines (`codemap/capabilities.yaml`).
+
+This reviews the *design*: the promised API, data flows, and trust boundaries.
+Do not review code — none exists yet; findings amend the plan cheaply now
+instead of the diff expensively later.
+
+## Checklist (numbered — the record cites these IDs)
+
+- **S1 Trust boundaries (STRIDE):** for every new boundary, data flow, or
+  store the spec introduces, one question per STRIDE letter. No new boundary
+  → S1 collapses to Tampering + Information-disclosure only.
+- **S2 Parse, don't validate:** does the promised API take raw
+  `Text`/`Int`/`Bytes` where a newtype + smart constructor would make the
+  illegal state unrepresentable? Does anything return `Maybe`/`Task err ()`
+  solely to report "input was invalid"?
+- **S3 Secrets:** any value whose secrecy gates access → `Redacted` wrap or
+  hand-written `Show` printing `<REDACTED>`; never `deriving (Show)` /
+  derived `ToJSON` on a secret-bearing type; no secret in `[fmt|…|]`, error
+  values, or logs. (Existing patterns: `Redacted`, OAuth2 `ClientSecret` /
+  `AccessToken` / `HmacKey` hand-written Shows.)
+- **S4 Comparison & randomness:** attacker-submittable long-lived secret
+  compared → `constEq` (keeps its `{-# INLINE #-}` pragma); value that gates
+  access / seeds crypto → `Crypto.Random`, never `System.Random`. A public
+  ID needs neither.
+- **S5 Authorization surface:** new queries define both `canAccess` and
+  `canView`; `publicAccess` only with a justifying comment; new commands get
+  `RequestContext` threaded (the type system forces this — verify the spec
+  doesn't design around it).
+- **S6 SQL / data access:** Hasql typed `Statement`/`Encoders`/`Decoders`
+  only; entity names and stream IDs sanitized; never string concatenation.
+- **S7 Supply chain:** `new-dependency: true` in the spec header → the dep
+  must land in the hash-verified lockfile (`flake.lock` / cabal pin); any
+  build step fetching a mutable URL or unpinned action is a blocker.
+- **S8 Error surface:** no internals (connection strings, raw SQL, stack
+  traces, tokens) in production-facing error messages; generic messages for
+  401/403/500.
+
+## Grounding filter (mandatory — proportionality is load-bearing)
+
+Every finding must survive all four questions, or it is demoted to
+`informational` with the failed question named:
+
+1. **Blast radius** — can a realistic attacker, given the spec's reachable
+   surface, convert this to concrete impact (exfil, integrity loss, DoS, EoP)?
+2. **Reachability** — does the promised design actually exercise the path?
+3. **User affordance** — is the mitigation absorbable by the framework
+   (default, smart constructor) so downstream users never see a knob? Prefer
+   that shape; if only a knob works, record `framework-debt`.
+4. **Proportionality** — would a senior reviewer agree the fix matches the
+   change's tier? No `constEq` on public IDs, no CSPRNG for retry jitter, no
+   `Redacted` on values already in public logs. Control-cascades on a change
+   touching no secret and no boundary are security theater — reject them.
+
+## Output (the committed record)
+
+Write `docs/changes/NNN-slug.security-review.md` on the PR branch — it lands
+with the merge; that commit is the audit trail. Format:
+
+```markdown
+# Security design review: <spec title>
+Spec: docs/changes/NNN-slug.md | Capabilities: <security-sensitive ones> | Date: <date>
+
+| # | Checklist | Finding | Grounding | Verdict |
+|---|-----------|---------|-----------|---------|
+| 1 | S3 | <what> | kept / demoted (failed Q1: <why>) | blocker / advisory / informational |
+
+**Blockers:** N — <resolution: plan amended / escalated to maintainer>
+```
+
+Blockers either amend the plan (`./dev pipeline set plan.files …` + note in
+the record) or park the run for the maintainer (`./dev pipeline park --label
+human-rejected-spec --note …`). Zero-finding reviews still commit the record
+— "reviewed, nothing found" is audit data.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -74,6 +74,35 @@ jobs:
           # template-injection defense-in-depth for workflow expressions
           BASE_REF: ${{ github.base_ref }}
         run: ./dev spec-drift --pr "origin/${BASE_REF}"
+      # Review-record gate: at PR-ready, every design review a changed spec
+      # ROUTES (touches ∩ risk tags) must have its committed record — the
+      # compliance audit trail the ADR requires, now enforced not just prosed.
+      - name: Design-review records present (PR-ready only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: ./dev spec-check --reviews-pr "origin/${BASE_REF}"
+
+  expectations:
+    name: expectation guard (test-contract diff)
+    # PRs only (drafts included — weakening a test is never OK); never on push.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          # census-diffs committed test files against the merge base
+          fetch-depth: 0
+      - name: Expectation census (maintainer label overrides)
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          # a maintainer-only PR label — labels need write access, so the agent
+          # cannot self-apply it (unlike the local, gitignored marker). This is
+          # the load-bearing approval signal.
+          EXPECTATIONS_APPROVED: ${{ contains(github.event.pull_request.labels.*.name, 'expectations-approved') }}
+        run: python3 .claude/hooks/expectation-guard.py --pr-diff "origin/${BASE_REF}"
 
   lint:
     name: hlint (dialect gate)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,7 +69,11 @@ jobs:
       # still implementing its spec — drift there is expected, not an error.
       - name: Spec drift (PR-ready only)
         if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
-        run: ./dev spec-drift --pr origin/${{ github.base_ref }}
+        env:
+          # env-var indirection, not inline ${{ }} in run: — the standard
+          # template-injection defense-in-depth for workflow expressions
+          BASE_REF: ${{ github.base_ref }}
+        run: ./dev spec-drift --pr "origin/${BASE_REF}"
 
   lint:
     name: hlint (dialect gate)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,9 @@ name: checks
 
 on:
   pull_request:
+    # ready_for_review included so the spec job's drift gate fires the moment
+    # a draft (parked spec) is promoted — default types would miss the flip
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
 
@@ -45,6 +48,28 @@ jobs:
       # the PYTHON override is the sanctioned CI path, like lint's HLINT=).
       - run: python3 -c "import yaml" 2>/dev/null || pip3 install pyyaml==6.0.3
       - run: PYTHON=python3 ./dev codemap-check
+
+  spec:
+    name: spec check (contract-delta gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          # spec-drift --pr diffs against the merge base — needs history
+          fetch-depth: 0
+      # Structure gate: every committed spec (incl. TEMPLATE.md, which is a
+      # validated instance) parses and machine-joins. Runs on drafts too —
+      # this is what the maintainer's gate decision reads.
+      - run: ./dev spec-check
+      # Drift gate: at PR-READY only, the specs this PR touches must be
+      # honored by the generated API surface (codemap-sync proves committed
+      # signatures == code; this proves signatures == promise). A draft is
+      # still implementing its spec — drift there is expected, not an error.
+      - name: Spec drift (PR-ready only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+        run: ./dev spec-drift --pr origin/${{ github.base_ref }}
 
   lint:
     name: hlint (dialect gate)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,24 @@ on:
 
 jobs:
   claude:
+    # MAINTAINER-ONLY (pipeline Phase 5): this workflow is the pipeline's
+    # continue signal — a maintainer comment (e.g. "@claude continue") on a
+    # parked draft PR is what authorizes resuming past the spec gate. The
+    # author-association check makes that signal unforgeable: comments from
+    # anyone who is not an org OWNER/MEMBER are ignored entirely (which also
+    # closes the standing hole of any passer-by invoking the action).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      ) && (
+        (github.event_name == 'issue_comment' && contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(fromJSON('["OWNER", "MEMBER"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -1,0 +1,70 @@
+# Nightly benchmarks (pipeline Phase 5, task 9) — NON-BLOCKING by design:
+# schedule + manual dispatch only, never wired to pull_request. A budget
+# breach fails this run, and that failure is the notification (next-morning
+# fix task); PR-time perf assurance is the design review, not a benchmark.
+#
+# Telemetry: the uploaded bench-results artifact is the run's evidence
+# (telemetry/runs.jsonl stays pipeline-only by doctrine); the weekly review
+# reads the artifact trend and owns budget calibration
+# (telemetry/bench-budgets.json).
+name: nightly-bench
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch: # the human-tool parity path: run it on demand
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/determinate-nix-action@v3.21.2
+        with:
+          extra-conf: |
+            accept-flake-config = true
+            extra-substituters = https://cache.iog.io https://neohaskell.cachix.org
+            extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= neohaskell.cachix.org-1:mo2cLaGbwqbrxs9xhqKK8jeNsn3osi7t6XoAmxSZssc=
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      # Same cache key family as test.yml's build job — warm restores keep the
+      # nightly build cost near-zero on quiet days
+      - uses: actions/cache@v6
+        with:
+          path: dist-newstyle
+          key: ${{ runner.os }}-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
+          restore-keys: |
+            ${{ runner.os }}-cabal-
+      - name: Start PostgreSQL
+        run: |
+          docker run -d --name neohaskell_postgres \
+            -e POSTGRES_USER=neohaskell \
+            -e POSTGRES_PASSWORD=neohaskell \
+            -e POSTGRES_DB=neohaskell \
+            -p 5432:5432 \
+            postgres:16-alpine \
+            postgres -c max_connections=200
+          for i in $(seq 1 30); do
+            pg_isready -h 127.0.0.1 -U neohaskell && break || sleep 1
+          done
+          if ! pg_isready -h 127.0.0.1 -U neohaskell; then
+            echo "::error::PostgreSQL failed to start within 30 seconds"
+            exit 1
+          fi
+        env:
+          PGPASSWORD: neohaskell
+      - name: Run benchmark suites against budgets
+        run: LOG_LEVEL=Warn POSTGRES_AVAILABLE=true ./dev bench
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: bench-results-${{ github.run_id }}
+          path: .bench-results.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/nightly-bench.yml
+++ b/.github/workflows/nightly-bench.yml
@@ -26,16 +26,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           persist-credentials: false
-      - uses: DeterminateSystems/determinate-nix-action@v3.21.2
+      - uses: DeterminateSystems/determinate-nix-action@629b284231c2a82554b724e357e47fc6020833c8 # v3.21.2
         with:
           extra-conf: |
             accept-flake-config = true
             extra-substituters = https://cache.iog.io https://neohaskell.cachix.org
             extra-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= neohaskell.cachix.org-1:mo2cLaGbwqbrxs9xhqKK8jeNsn3osi7t6XoAmxSZssc=
-      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
       # Same cache key family as test.yml's build job — warm restores keep the
       # nightly build cost near-zero on quiet days
-      - uses: actions/cache@v6
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: dist-newstyle
           key: ${{ runner.os }}-cabal-${{ hashFiles('**/*.cabal', 'cabal.project') }}
@@ -61,7 +61,7 @@ jobs:
           PGPASSWORD: neohaskell
       - name: Run benchmark suites against budgets
         run: LOG_LEVEL=Warn POSTGRES_AVAILABLE=true ./dev bench
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: bench-results-${{ github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    # ready_for_review is NOT a default activity type — without it, flipping
+    # a draft to ready would never re-trigger the suite the guard skipped
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "core/**"
       - "testbed/**"
@@ -25,7 +28,15 @@ permissions:
   contents: read
 
 jobs:
+  # DRAFT-PR CI GUARD (pipeline Phase 5, task 3): a draft PR is a parked spec
+  # awaiting the maintainer's gate decision — burning ~1h of build+test on it
+  # is waste. The heavy jobs skip on drafts (dependents skip transitively);
+  # ci-gate accepts the skips only while the PR stays a draft. Marking the PR
+  # ready-for-review re-triggers the full matrix. checks.yml (doctor, codemap,
+  # lint, spec) still runs on drafts — seconds, and it is what validates the
+  # spec itself.
   build:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -95,6 +106,7 @@ jobs:
   # (build-free: doctest interprets sources against the dev-shell GHC's
   # package DB, so no dist-newstyle artifact is needed).
   doctest:
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -265,6 +277,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all tests passed
+        env:
+          IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
         run: |
           results=(
             "${{ needs.doctest.result }}"
@@ -275,6 +289,11 @@ jobs:
             "${{ needs.test-hurl.result }}"
           )
           for r in "${results[@]}"; do
+            # skipped is acceptable ONLY under the draft-PR guard — a parked
+            # spec hasn't earned a green gate, it just hasn't burned CI yet
+            if [[ "$r" == "skipped" && "$IS_DRAFT" == "true" ]]; then
+              continue
+            fi
             if [[ "$r" != "success" ]]; then
               echo "::error::Test job failed with result: $r"
               exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ __pycache__/
 # Phase 4: doctest gate — scripts/run-doctest writes + removes these; a
 # stray one would silently reconfigure every later ghci/ghcid session
 .ghc.environment.*
+
+# Phase 5: nightly bench evidence (uploaded as a CI artifact, never committed)
+/.bench-results.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,11 +79,11 @@ Any request that should end in a PR runs the `neohaskell-pipeline` skill. The sh
 
 - **Spec first**: `docs/changes/NNN-slug.md` from `TEMPLATE.md` — promised API diff (signatures vocabulary), `touches:` capability IDs, criteria C1..Cn each naming its proving test + level (`unit|integration|acceptance`). Bugs: C1 = the failing repro, committed red. Validate: `./dev spec-check` (CI: checks.yml `spec` job).
 - **Gate 1 = draft PR** (spec only; heavy CI skipped on drafts). Continue signal = maintainer `@claude` comment (claude.yml ignores non-maintainers). Record it: `./dev pipeline approve spec --by <who>` — advancing without it is refused.
-- **Resume contract**: `.pipeline/state.json` via `./dev pipeline` (init/status/advance/park/resume). Resume never re-plans; plan wrong → park (`wrong-localization`) + fix the asset.
-- **Risk-tiered design reviews** (post-approval, pre-implementation): `./dev spec-check --plan <spec>` routes to `neohaskell-security-design-review` / `neohaskell-performance-design-review` when `touches:` hits risk-tagged capabilities; review records are committed next to the spec.
+- **Resume contract**: `.pipeline/state.json` via `./dev pipeline` (init/status/advance/set/approve/park/resume/validate). Resume never re-plans; plan wrong → park (`wrong-localization`) + fix the asset.
+- **Risk-tiered design reviews** (post-approval, pre-implementation): `./dev spec-check --plan <spec>` routes to `neohaskell-security-design-review` / `neohaskell-performance-design-review` when `touches:` hits risk-tagged capabilities; review records (`NNN-slug.<kind>-review.md`) are committed next to the spec, and their presence is gated at PR-ready by `./dev spec-check --reviews-pr`.
 - **Verification order**: criteria tests red → implement → green at declared levels → test-impact suites (from `--plan`) → `./dev lint` + `./dev spec-drift <spec>` → full suite once at PR-ready.
 - **Failure policy**: per-stage time-boxes (skill has the table) → retry once → escalate tier → `./dev pipeline park --label <taxonomy>` + structured report. A parked report beats a wrong PR.
-- **Expectation guard** (`.claude/hooks/expectation-guard.py`): removing/rewording an existing test expectation is blocked without the maintainer marker `.pipeline/allow-expectation-edits`. Adding tests never needs it.
+- **Expectation guard** (`.claude/hooks/expectation-guard.py`): removing/rewording an existing test expectation is blocked twice — locally by the hook (maintainer marker `.pipeline/allow-expectation-edits`) and in CI by the `expectations` census job (maintainer `expectations-approved` PR label, which the agent can't self-apply). Adding tests never needs either.
 - **Benchmarks**: nightly only (`./dev bench` vs `telemetry/bench-budgets.json`, nightly-bench.yml) — never PR-blocking.
 
 ## Dialect enforcement (Phase 2, live since 2026-07-07)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,19 @@ Training-data APIs don't exist here. Resolve symbols at **plan time** into a `us
 - `codemap/phrasebook.md` — doctest-verified usage patterns (gate: test.yml `doctest` job; thin coverage = the doc backlog, ratcheted via `undocumented_doctest_modules`)
 - GHC "not in scope" in `./dev check` output = invented API — resolve via `./dev api`; pipeline runs record per-stage `invented_api_events` (telemetry schema v2)
 
+## Change flow (Phase 5) — spec-gated, two human touchpoints
+
+Any request that should end in a PR runs the `neohaskell-pipeline` skill. The shape (ADR-0067):
+
+- **Spec first**: `docs/changes/NNN-slug.md` from `TEMPLATE.md` — promised API diff (signatures vocabulary), `touches:` capability IDs, criteria C1..Cn each naming its proving test + level (`unit|integration|acceptance`). Bugs: C1 = the failing repro, committed red. Validate: `./dev spec-check` (CI: checks.yml `spec` job).
+- **Gate 1 = draft PR** (spec only; heavy CI skipped on drafts). Continue signal = maintainer `@claude` comment (claude.yml ignores non-maintainers). Record it: `./dev pipeline approve spec --by <who>` — advancing without it is refused.
+- **Resume contract**: `.pipeline/state.json` via `./dev pipeline` (init/status/advance/park/resume). Resume never re-plans; plan wrong → park (`wrong-localization`) + fix the asset.
+- **Risk-tiered design reviews** (post-approval, pre-implementation): `./dev spec-check --plan <spec>` routes to `neohaskell-security-design-review` / `neohaskell-performance-design-review` when `touches:` hits risk-tagged capabilities; review records are committed next to the spec.
+- **Verification order**: criteria tests red → implement → green at declared levels → test-impact suites (from `--plan`) → `./dev lint` + `./dev spec-drift <spec>` → full suite once at PR-ready.
+- **Failure policy**: per-stage time-boxes (skill has the table) → retry once → escalate tier → `./dev pipeline park --label <taxonomy>` + structured report. A parked report beats a wrong PR.
+- **Expectation guard** (`.claude/hooks/expectation-guard.py`): removing/rewording an existing test expectation is blocked without the maintainer marker `.pipeline/allow-expectation-edits`. Adding tests never needs it.
+- **Benchmarks**: nightly only (`./dev bench` vs `telemetry/bench-budgets.json`, nightly-bench.yml) — never PR-blocking.
+
 ## Dialect enforcement (Phase 2, live since 2026-07-07)
 
 Three layers, in feedback order:

--- a/dev
+++ b/dev
@@ -34,12 +34,13 @@ usage: ./dev <verb> [args]
   api <query>           search the NeoHaskell API surface — by type
                           ("Text -> Int") or by name (toInt)
   spec-check [files]    validate contract-delta specs in docs/changes/
-                          (--plan <spec> prints review + test-impact joins)
+                          (--plan <spec> prints review + test-impact joins;
+                          --reviews-pr [base] gates design-review records)
   spec-drift <spec|--pr>  verify the generated API surface honors a spec's
                           promised contract delta (PR-ready gate)
   pipeline <cmd>        pipeline run state (.pipeline/state.json): init,
-                          status, advance, approve, park, resume — the
-                          resume-never-replans contract
+                          status, advance, set, approve, park, resume,
+                          validate — the resume-never-replans contract
   bench                 run the perf suites against telemetry/bench-budgets.json
                           (nightly in CI; needs POSTGRES_AVAILABLE=true for
                           the Postgres entries)

--- a/dev
+++ b/dev
@@ -33,6 +33,16 @@ usage: ./dev <verb> [args]
   where-defined <sym>   symbol definition site, capability-tagged
   api <query>           search the NeoHaskell API surface — by type
                           ("Text -> Int") or by name (toInt)
+  spec-check [files]    validate contract-delta specs in docs/changes/
+                          (--plan <spec> prints review + test-impact joins)
+  spec-drift <spec|--pr>  verify the generated API surface honors a spec's
+                          promised contract delta (PR-ready gate)
+  pipeline <cmd>        pipeline run state (.pipeline/state.json): init,
+                          status, advance, approve, park, resume — the
+                          resume-never-replans contract
+  bench                 run the perf suites against telemetry/bench-budgets.json
+                          (nightly in CI; needs POSTGRES_AVAILABLE=true for
+                          the Postgres entries)
   doctor                harness self-check: every script has a verb or a
                           reasoned exemption; no dangling verbs (CI-enforced)
   exec <cmd> [args]     run any command with the pinned toolchain
@@ -59,6 +69,10 @@ case "${VERB}" in
   who-calls) exec scripts/who-calls "$@" ;;
   where-defined) exec scripts/where-defined "$@" ;;
   api)      exec scripts/api "$@" ;;
+  spec-check) exec scripts/spec-check "$@" ;;
+  spec-drift) exec scripts/spec-drift "$@" ;;
+  pipeline) exec scripts/pipeline-state "$@" ;;
+  bench)    exec scripts/bench "$@" ;;
   doctor)   exec scripts/doctor "$@" ;;
   exec)     exec scripts/with-toolchain "$@" ;;
   ""|help|-h|--help) usage ;;

--- a/docs/changes/TEMPLATE.md
+++ b/docs/changes/TEMPLATE.md
@@ -1,0 +1,56 @@
+# Change NNN: <imperative title>
+
+<!-- This template is ITSELF a valid spec instance: CI validates it with
+     `./dev spec-check` (checks.yml `spec` job), so the template can never
+     drift from the validator. Copy it to docs/changes/NNN-slug.md (next
+     3-digit number) as the FIRST commit of a draft PR — the spec is the
+     contract the maintainer approves before implementation starts. -->
+
+One paragraph of intent: what the requester asked for, in their vocabulary.
+
+```yaml spec
+issue: adhoc:example            # issue#NNN or adhoc:<slug>
+kind: feature                   # feature | bug | refactor
+touches: [core-primitives]      # capability IDs from codemap/capabilities.yaml (closed list)
+breaking: false                 # MUST be true if the contract delta has any `-` line
+new-dependency: false           # any new build-depends / flake input
+new-capability: false           # this change adds a row to codemap/capabilities.yaml
+new-extension-point: false      # this change adds a row to codemap/extension-points.yaml
+```
+
+## Contract delta
+
+The promised public-API diff, in `codemap/signatures/` vocabulary:
+`<+|-> <Module>: <signature line>`. At PR-ready, `./dev spec-drift` verifies
+the regenerated signatures honor every line. Internal-only changes promise an
+empty block — that is a first-class spec, not a degenerate one.
+
+```diff signatures
++ Text: exampleNewFunction :: Text -> Text
+```
+
+## Criteria
+
+Every numbered criterion names the test that proves it and declares its level.
+A behavior that crosses a real boundary (filesystem, Postgres, HTTP) must
+declare `integration` or `acceptance` — a mocked unit test cannot satisfy it.
+For `kind: bug`, C1 is the failing reproduction test, committed red in the
+draft PR: the repro **is** the spec.
+
+| ID | Behavior | Proving test | Level |
+|----|----------|--------------|-------|
+| C1 | example: slugifies unicode titles | `TextSpec` "slugifies unicode" | unit |
+
+## User impact
+
+Breaking? Testbed effect? Migration note? "None" is an acceptable answer;
+silence is not.
+
+## ADR
+
+Not required — no trigger (breaking / new-dependency / new-capability /
+new-extension-point all false).
+
+<!-- When any trigger flag is true, this section MUST link the decision,
+     e.g. [ADR-0067](../decisions/0067-slug.md) — the ADR is part of the
+     spec the maintainer reviews at the gate, and lands with the merge. -->

--- a/docs/changes/TEMPLATE.md
+++ b/docs/changes/TEMPLATE.md
@@ -1,10 +1,11 @@
 # Change NNN: <imperative title>
 
 <!-- This template is ITSELF a valid spec instance: CI validates it with
-     `./dev spec-check` (checks.yml `spec` job), so the template can never
-     drift from the validator. Copy it to docs/changes/NNN-slug.md (next
-     3-digit number) as the FIRST commit of a draft PR — the spec is the
-     contract the maintainer approves before implementation starts. -->
+     `./dev spec-check` (checks.yml `spec` job), so its machine-read parts
+     (header keys, fence infos, `## section` names, criteria cells) can't drift
+     from the validator. Copy it to docs/changes/NNN-slug.md (next 3-digit
+     number) as the FIRST commit of a draft PR — the spec is the contract the
+     maintainer approves before implementation starts. -->
 
 One paragraph of intent: what the requester asked for, in their vocabulary.
 
@@ -52,5 +53,5 @@ Not required — no trigger (breaking / new-dependency / new-capability /
 new-extension-point all false).
 
 <!-- When any trigger flag is true, this section MUST link the decision,
-     e.g. [ADR-0067](../decisions/0067-slug.md) — the ADR is part of the
+     e.g. [ADR-00NN](../decisions/00NN-slug.md) — the ADR is part of the
      spec the maintainer reviews at the gate, and lands with the merge. -->

--- a/docs/decisions/0067-contract-delta-spec-gate.md
+++ b/docs/decisions/0067-contract-delta-spec-gate.md
@@ -54,7 +54,10 @@ its proving test and declaring `unit|integration|acceptance`).
 
 Honesty is cross-checked, not trusted: a `-` line in the delta forces
 `breaking: true`; trigger flags force a linked ADR; `TEMPLATE.md` is itself
-a validated instance so template and validator cannot drift.
+a validated instance, so the template's machine-read parts (header keys, fence
+infos, `## section` names, criteria cells) cannot drift from the validator.
+Design-review records (`*-review.md`) share the directory but are not specs —
+both validators skip them.
 
 ### 2. The gate is a draft PR; the continue signal is maintainer-only
 
@@ -87,20 +90,29 @@ implementing its spec, drift there is expected.
 `spec-check --plan` joins `touches:` with capability risk tags: intersecting
 `security-sensitive`/`perf-sensitive` routes the run through the
 corresponding design-review skill *after spec approval, before
-implementation*; review records are committed next to the spec (the
-compliance audit trail). Untagged specs skip reviews entirely. Perf
-*measurement* is `./dev bench` against `telemetry/bench-budgets.json`,
-nightly and never PR-blocking; budgets start null (calibration) and are set
-from observed medians by the weekly review.
+implementation*; review records are committed next to the spec as
+`NNN-slug.<kind>-review.md` (the compliance audit trail). Untagged specs skip
+reviews entirely. That the record exists when routing fired is enforced at
+PR-ready by `spec-check --reviews-pr` (checks.yml `spec` job), so the audit
+artifact is gated, not merely prosed. Perf *measurement* is `./dev bench`
+against `telemetry/bench-budgets.json`, nightly and never PR-blocking; budgets
+start null (calibration) and are set from observed medians by the weekly review.
 
-### 6. Expectations are protected mechanically
+### 6. Expectations are protected in two layers
 
-A PreToolUse hook (`expectation-guard.py`, same self-test contract as the
-dialect guard) blocks edits that remove or reword existing test expectation
-lines unless `.pipeline/allow-expectation-edits` (a maintainer-authorized,
-never-committed marker) exists. There is deliberately no inline escape
-hatch: changing recorded expectations is exactly the action that must pass
-through a human.
+Changing recorded test expectations is exactly the action that must pass
+through a human, so it is guarded twice. **Locally**, a PreToolUse hook
+(`expectation-guard.py`, same self-test contract as the dialect guard) is the
+fast teacher: it blocks edits that remove or reword existing expectation lines
+unless the maintainer-authored, never-committed marker
+`.pipeline/allow-expectation-edits` exists (no inline escape hatch), and it
+fails loud-open on unparseable input rather than silently disabling itself.
+**In CI** — the enforced backstop — the `expectations` job census-diffs the
+committed test files against the merge base and blocks a net-removed/reworded
+expectation unless a maintainer applied the `expectations-approved` PR label.
+Operating on the committed result covers the rename / non-test-path /
+Bash-mutation cases the local hook's path+payload matcher cannot, and the label
+— unlike the local marker — is not agent-writable.
 
 ## Consequences
 

--- a/docs/decisions/0067-contract-delta-spec-gate.md
+++ b/docs/decisions/0067-contract-delta-spec-gate.md
@@ -1,0 +1,140 @@
+# ADR-0067: Contract-delta spec gate and resumable draft-PR flow
+
+> Part of #715 — pipeline plan Phase 5 (spec gate + verification architecture).
+
+## Status
+
+Proposed
+
+## Context
+
+### Current State
+
+Phases 0–4 built the generation substrate: a measured fast inner loop, a
+three-layer dialect gate, lookup-based localization (`codemap/`), and API
+knowledge delivery (`./dev api`, hot card, phrasebook). What was missing is
+the *shape of a run*: baseline PRs took 2–3 hours and were wrong because the
+first human checkpoint was a finished (wrong) diff. There was no mechanical
+definition of "what this change promises", no cheap point for the maintainer
+to redirect work, and no way to resume a half-done run without re-planning
+(and re-diverging).
+
+### Design Goals
+
+1. **Exactly two human gates** — spec approval and PR review; every other
+   checkpoint is mechanical (Nick's time is the scarce resource).
+2. **The cheap gate comes first** — the maintainer approves a one-page
+   contract before implementation exists, not a 40-file diff after.
+3. **Machine-joinable specs** — the spec must mechanically derive the
+   test-impact set, the design-review routing, and the drift check; prose
+   promises rot, joins don't.
+4. **Resume never re-plans** — a continued run picks up its recorded plan
+   verbatim; divergence is parked visibly, never silently re-derived.
+
+### GitHub Issue
+
+- [#715: Continuous generation pipeline](https://github.com/neohaskell/NeoHaskell/issues/715)
+
+## Decision
+
+### 1. The spec is a contract delta, validated as data
+
+`docs/changes/NNN-slug.md`, validated by `./dev spec-check` (CI: checks.yml
+`spec` job). Machine-readable parts: a `yaml spec` header (`kind`, `touches:`
+capability IDs from the closed ontology, ADR-trigger flags), a
+`diff signatures` block promising the public-API delta in
+`codemap/signatures/` vocabulary, and a criteria table (C1…Cn, each naming
+its proving test and declaring `unit|integration|acceptance`).
+
+| Candidate | Verdict | Rationale |
+|-----------|---------|-----------|
+| Free-form design doc | Rejected | not machine-joinable; rots; review cost scales with prose |
+| Full event-model spec | Rejected | event models are for user apps (locked decision); internal changes are API/behavior contract deltas |
+| Contract delta + criteria table | **Chosen** | joins mechanically to capabilities (reviews, test impact) and signatures (drift) |
+
+Honesty is cross-checked, not trusted: a `-` line in the delta forces
+`breaking: true`; trigger flags force a linked ADR; `TEMPLATE.md` is itself
+a validated instance so template and validator cannot drift.
+
+### 2. The gate is a draft PR; the continue signal is maintainer-only
+
+The pipeline opens a draft PR containing only the spec (+ ADR, + red repro
+test for bugs). Draft PRs run only the seconds-cheap checks (doctor, codemap,
+lint, spec-check); the heavy build/test matrix is skipped until the PR
+leaves draft (`ready_for_review` re-triggers it). The continue signal is a
+maintainer `@claude` comment — `claude.yml` enforces an author-association
+allowlist (OWNER/MEMBER), which also closes the standing anyone-can-invoke
+hole.
+
+### 3. Resume state is a validated local contract
+
+`.pipeline/state.json` (gitignored), manipulated only via `./dev pipeline`
+(init/status/advance/set/approve/park/resume; schema-validated on every
+save). Stage names are the telemetry schema v2 canon. Advancing past `spec`
+without a recorded approval is mechanically refused. Parking requires a
+label from the closed failure taxonomy.
+
+### 4. Drift is checked at PR-ready, against the gated surface
+
+`./dev spec-drift` verifies every promised `+` line exists in (and every
+`-` line is absent from) `codemap/signatures/*.txt`. Because codemap-sync
+(test.yml) proves committed signatures == code, checking the committed files
+is checking the code. Runs in CI only for non-draft PRs — a draft is still
+implementing its spec, drift there is expected.
+
+### 5. Reviews are risk-tiered and design-time; measurement is nightly
+
+`spec-check --plan` joins `touches:` with capability risk tags: intersecting
+`security-sensitive`/`perf-sensitive` routes the run through the
+corresponding design-review skill *after spec approval, before
+implementation*; review records are committed next to the spec (the
+compliance audit trail). Untagged specs skip reviews entirely. Perf
+*measurement* is `./dev bench` against `telemetry/bench-budgets.json`,
+nightly and never PR-blocking; budgets start null (calibration) and are set
+from observed medians by the weekly review.
+
+### 6. Expectations are protected mechanically
+
+A PreToolUse hook (`expectation-guard.py`, same self-test contract as the
+dialect guard) blocks edits that remove or reword existing test expectation
+lines unless `.pipeline/allow-expectation-edits` (a maintainer-authorized,
+never-committed marker) exists. There is deliberately no inline escape
+hatch: changing recorded expectations is exactly the action that must pass
+through a human.
+
+## Consequences
+
+### Positive
+
+- The maintainer redirects wrong work at the one-page stage, in minutes.
+- Spec, reviews, tests, and drift check all join through the same two gated
+  artifacts (capabilities.yaml, signatures) — no new vocabulary to rot.
+- Parked runs carry labeled causes; every failure is trend-measurable.
+
+### Negative
+
+- Every pipeline change now pays the spec-writing overhead, even small ones
+  (mitigated: empty contract delta is first-class; bug specs are one red test).
+- Draft PRs get no heavy CI signal until ready — a spec whose implementation
+  is doomed for build reasons is discovered later than it would be with
+  always-on CI (accepted: that is what the fast local loop is for).
+
+### Risks
+
+- `author_association` values can surprise (org privacy settings can report
+  MEMBER as NONE) — the gate would then ignore a legitimate maintainer.
+- Stage time-boxes are guesses until telemetry accumulates.
+
+### Mitigations
+
+- The association check is observable in the workflow run log; if Nick's
+  comments are ignored, widen the allowlist deliberately (one-line diff).
+- Time-boxes live in the pipeline skill and are recalibrated at the weekly
+  telemetry review (Phase 6).
+
+## References
+
+- [#715](https://github.com/neohaskell/NeoHaskell/issues/715)
+- [Pipeline plan — Phase 5](../plans/2026-07-07-continuous-generation-pipeline-plan.md)
+- [ADR-0066: Two-database API search](0066-two-database-api-search.md)
+- [telemetry/SCHEMA.md](../../telemetry/SCHEMA.md)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -75,6 +75,8 @@ ADRs document significant architectural decisions made during the development of
 | [0063](0063-per-stream-subscription-connection-release.md) | Release Per-Stream Subscription Connections on Unsubscribe | Proposed |
 | [0064](0064-optional-sslmode-tls-hardening.md) | Optional `sslmode` TLS Hardening for Postgres Connections | Proposed |
 | [0065](0065-acs-email-integration.md) | Azure Communication Services Email Integration | Proposed |
+| [0066](0066-two-database-api-search.md) | Two-database API search (`./dev api`) | Accepted |
+| [0067](0067-contract-delta-spec-gate.md) | Contract-delta spec gate and resumable draft-PR flow | Proposed |
 
 ## Creating New ADRs
 

--- a/scripts/bench
+++ b/scripts/bench
@@ -43,15 +43,20 @@ RESULTS = ROOT / ".bench-results.json"
 SUMMARY = re.compile(r"(\d+) examples?, \d+ failures?")
 
 
-def run_entry(entry):
+def run_entry(entry, timeout=1800):
     # one --test-option per token: no quoting/splitting layer to get wrong,
-    # and match patterns with spaces stay intact
+    # and match patterns with spaces stay intact. Per-entry timeout so one
+    # hung suite yields a recorded failure and the remaining entries still
+    # run, instead of the job-level timeout killing the whole night's data.
     cmd = [str(ROOT / "scripts" / "with-toolchain"), "cabal", "test", entry["suite"],
            "--test-option=--match", f"--test-option={entry['match']}"]
     start = time.monotonic()
-    proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
-    elapsed = round(time.monotonic() - start, 1)
-    return elapsed, proc
+    try:
+        proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True,
+                              timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return round(time.monotonic() - start, 1), None
+    return round(time.monotonic() - start, 1), proc
 
 
 def examples_run(proc):
@@ -73,6 +78,13 @@ def main():
         print(f"bench: running {name} ({entry['suite']} --match \"{entry['match']}\")…")
         elapsed, proc = run_entry(entry)
         budget = entry.get("budget_s")
+
+        if proc is None:
+            print(f"bench: FAIL {name} — timed out after {elapsed}s; "
+                  "continuing with the remaining entries", file=sys.stderr)
+            failures.append(name)
+            results.append({"name": name, "status": "timeout", "elapsed_s": elapsed})
+            continue
 
         if proc.returncode != 0:
             print(f"bench: FAIL {name} — suite failed (exit {proc.returncode}); "

--- a/scripts/bench
+++ b/scripts/bench
@@ -26,6 +26,7 @@ Run: ./dev bench    CI: .github/workflows/nightly-bench.yml (schedule + manual)
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -36,14 +37,26 @@ ROOT = Path(__file__).resolve().parent.parent
 BUDGETS = ROOT / "telemetry" / "bench-budgets.json"
 RESULTS = ROOT / ".bench-results.json"
 
+# hspec summary: "N examples, M failures" — 0 examples means the match hit
+# nothing and the "timing" is just build overhead (vacuous, must fail loudly;
+# same protection scripts/test-match has)
+SUMMARY = re.compile(r"(\d+) examples?, \d+ failures?")
+
 
 def run_entry(entry):
+    # one --test-option per token: no quoting/splitting layer to get wrong,
+    # and match patterns with spaces stay intact
     cmd = [str(ROOT / "scripts" / "with-toolchain"), "cabal", "test", entry["suite"],
-           "--test-options", f'--match "{entry["match"]}"']
+           "--test-option=--match", f"--test-option={entry['match']}"]
     start = time.monotonic()
     proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
     elapsed = round(time.monotonic() - start, 1)
     return elapsed, proc
+
+
+def examples_run(proc):
+    m = SUMMARY.search(proc.stdout) or SUMMARY.search(proc.stderr)
+    return int(m.group(1)) if m else None
 
 
 def main():
@@ -65,8 +78,19 @@ def main():
             print(f"bench: FAIL {name} — suite failed (exit {proc.returncode}); "
                   "timing is meaningless on a red suite", file=sys.stderr)
             print(proc.stdout[-2000:], file=sys.stderr)
+            print(proc.stderr[-2000:], file=sys.stderr)
             failures.append(name)
             results.append({"name": name, "status": "suite-failed", "elapsed_s": elapsed})
+            continue
+
+        examples = examples_run(proc)
+        if not examples:
+            print(f"bench: FAIL {name} — match \"{entry['match']}\" ran "
+                  f"{'no summary-reporting' if examples is None else '0'} examples; "
+                  "the measurement is vacuous (typo'd pattern or renamed suite?)",
+                  file=sys.stderr)
+            failures.append(name)
+            results.append({"name": name, "status": "vacuous", "elapsed_s": elapsed})
             continue
 
         status = "calibration" if budget is None else ("breach" if elapsed > budget else "ok")
@@ -76,8 +100,8 @@ def main():
         else:
             budget_txt = f"budget {budget}s" if budget is not None else "calibrating (no budget yet)"
             print(f"bench: {name} — {elapsed}s ({budget_txt})")
-        results.append({"name": name, "status": status,
-                        "elapsed_s": elapsed, "budget_s": budget})
+        results.append({"name": name, "status": status, "elapsed_s": elapsed,
+                        "budget_s": budget, "examples": examples})
 
     RESULTS.write_text(json.dumps({
         "at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),

--- a/scripts/bench
+++ b/scripts/bench
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Nightly benchmark harness (pipeline Phase 5, task 9) — non-blocking by design.
+
+Times the perf-tagged suites (seed: the EventStore volume/magnitude suites,
+`core/testlib/Test/Service/EventStore/`) against the budgets committed in
+telemetry/bench-budgets.json. Runs NIGHTLY (nightly-bench.yml) and on demand
+(`./dev bench`) — never per-PR: per-PR perf assurance is the risk-tiered
+design review (spec-check --plan routes it); this harness is the measurement
+that catches what review reasoning missed.
+
+Behavior per entry:
+  budget_s: null  -> calibration mode: measure, record, never fail
+  budget_s: N     -> measured > N = breach -> exit 1 (in the nightly workflow
+                     that failure IS the notification: a next-morning fix
+                     task, never a PR blocker)
+  requires: postgres and POSTGRES_AVAILABLE != true -> skipped, with a warning
+
+Suites run COMPILED via `cabal test` (default project, -O1) — the dev-flavor
+repl runner (./dev test) is interpreted and would time the interpreter, not
+the code. Results land in .bench-results.json (gitignored; the workflow
+uploads it as the run's evidence artifact — telemetry/runs.jsonl stays
+pipeline-only by doctrine).
+
+Run: ./dev bench    CI: .github/workflows/nightly-bench.yml (schedule + manual)
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BUDGETS = ROOT / "telemetry" / "bench-budgets.json"
+RESULTS = ROOT / ".bench-results.json"
+
+
+def run_entry(entry):
+    cmd = [str(ROOT / "scripts" / "with-toolchain"), "cabal", "test", entry["suite"],
+           "--test-options", f'--match "{entry["match"]}"']
+    start = time.monotonic()
+    proc = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True)
+    elapsed = round(time.monotonic() - start, 1)
+    return elapsed, proc
+
+
+def main():
+    config = json.loads(BUDGETS.read_text())
+    results, breaches, failures = [], [], []
+
+    for entry in config["entries"]:
+        name = entry["name"]
+        if entry.get("requires") == "postgres" and os.environ.get("POSTGRES_AVAILABLE") != "true":
+            print(f"bench: SKIP {name} — requires postgres (set POSTGRES_AVAILABLE=true)")
+            results.append({"name": name, "status": "skipped"})
+            continue
+
+        print(f"bench: running {name} ({entry['suite']} --match \"{entry['match']}\")…")
+        elapsed, proc = run_entry(entry)
+        budget = entry.get("budget_s")
+
+        if proc.returncode != 0:
+            print(f"bench: FAIL {name} — suite failed (exit {proc.returncode}); "
+                  "timing is meaningless on a red suite", file=sys.stderr)
+            print(proc.stdout[-2000:], file=sys.stderr)
+            failures.append(name)
+            results.append({"name": name, "status": "suite-failed", "elapsed_s": elapsed})
+            continue
+
+        status = "calibration" if budget is None else ("breach" if elapsed > budget else "ok")
+        if status == "breach":
+            print(f"bench: BREACH {name} — {elapsed}s > budget {budget}s", file=sys.stderr)
+            breaches.append(name)
+        else:
+            budget_txt = f"budget {budget}s" if budget is not None else "calibrating (no budget yet)"
+            print(f"bench: {name} — {elapsed}s ({budget_txt})")
+        results.append({"name": name, "status": status,
+                        "elapsed_s": elapsed, "budget_s": budget})
+
+    RESULTS.write_text(json.dumps({
+        "at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "mode": config["mode"],
+        "results": results,
+    }, indent=2) + "\n")
+    print(f"bench: results written to {RESULTS.name}")
+
+    if failures:
+        return 2
+    if breaches:
+        print(f"bench: {len(breaches)} budget breach(es) — this is the notification; "
+              "file the fix task, do not block PRs on it", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -71,11 +71,20 @@ if [ -d .claude/skills ]; then
   done < <(grep -rhoE '\./dev [a-z-]+' .claude/skills/*/SKILL.md 2>/dev/null | sort -u)
 fi
 
-# 5. Dialect-guard self-test: every hook rule must have blocking AND passing
-#    cases in dialect-guard-cases.json (a rule without cases fails here).
+# 5. Hook self-tests: every hook rule/scenario must have blocking AND passing
+#    cases in its committed cases file (a rule without cases fails here).
 if [ -f .claude/hooks/dialect-guard.py ]; then
   python3 .claude/hooks/dialect-guard.py --self-test || fail=1
 fi
+if [ -f .claude/hooks/expectation-guard.py ]; then
+  python3 .claude/hooks/expectation-guard.py --self-test || fail=1
+fi
+
+# 5b. Phase 5 validator self-tests (spec gate + resume contract): fixture
+#     mutations must keep failing for the right reasons — a validator that
+#     stops rejecting is a gate that silently opened.
+scripts/spec-check --self-test || fail=1
+scripts/pipeline-state --self-test || fail=1
 
 # 6. invented-api counter self-test (Phase 4): ./dev check's counter is
 #    anchored to GHC error text + error-index codes; this fixture runs the

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -62,16 +62,16 @@ for f in scripts/*; do
   fi
 done
 
-# 4. Skills are agent-visible docs (governing rule: no doc without a gate) —
-#    every `./dev <verb>` a SKILL.md references must actually be registered.
-if [ -d .claude/skills ]; then
-  while IFS= read -r ref; do
-    verb=$(echo "${ref}" | sed 's|.*\./dev ||' | awk '{print $1}')
-    if ! grep -qE "^\s*${verb}\)" dev; then
-      err "a SKILL.md references './dev ${verb}' but that verb is not registered in ./dev"
-    fi
-  done < <(grep -rhoE '\./dev [a-z-]+' .claude/skills/*/SKILL.md 2>/dev/null | sort -u)
-fi
+# 4. Agent-visible docs (governing rule: no doc without a gate) — every
+#    `./dev <verb>` referenced in a SKILL.md, AGENTS.md, or CLAUDE.md must
+#    actually be registered, so a verb rename can't make the most-read docs
+#    lie silently (AGENTS.md is loaded into every session).
+while IFS= read -r ref; do
+  verb=$(echo "${ref}" | sed 's|.*\./dev ||' | awk '{print $1}')
+  if ! grep -qE "^\s*${verb}\)" dev; then
+    err "an agent-visible doc references './dev ${verb}' but that verb is not registered in ./dev"
+  fi
+done < <(grep -rhoE '\./dev [a-z-]+' .claude/skills/*/SKILL.md AGENTS.md CLAUDE.md 2>/dev/null | sort -u)
 
 # 5. Hook self-tests: every hook rule/scenario must have blocking AND passing
 #    cases in its committed cases file (a rule without cases fails here).
@@ -86,6 +86,7 @@ fi
 #     mutations must keep failing for the right reasons — a validator that
 #     stops rejecting is a gate that silently opened.
 scripts/spec-check --self-test || fail=1
+scripts/spec-drift --self-test || fail=1
 scripts/pipeline-state --self-test || fail=1
 
 # 6. invented-api counter self-test (Phase 4): ./dev check's counter is

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -23,6 +23,7 @@ EXEMPT_NAMES=(
   "install.sh:end-user installer (curl-piped); not a repo dev tool"
   "build-hoogle-dbs:internal plumbing — invoked by ./dev api and ./dev codemap, not a user verb"
   "toolchain-fp:internal plumbing — fingerprint for with-toolchain fast path + flake shellHook"
+  "speclib.py:shared parsing module imported by spec-check and spec-drift — never executed"
 )
 
 fail=0
@@ -43,6 +44,7 @@ done
 
 # 2. Unregistered scripts + 3. stale exemptions.
 for f in scripts/*; do
+  [ -f "${f}" ] || continue  # stray dirs (e.g. a __pycache__) are not scripts
   name=$(basename "${f}")
   # (no special case for doctor itself — it must be registered like anything else)
   exempt_reason=""

--- a/scripts/pipeline-state
+++ b/scripts/pipeline-state
@@ -184,6 +184,11 @@ def cmd_set(args, state_dir):
     s = load(state_dir)
     node, *rest = args.key.split(".")
     if node == "plan":
+        if not rest:
+            print("pipeline-state: use `set plan.<field>` not `set plan` — a "
+                  "wholesale replacement would silently drop the other plan "
+                  "fields", file=sys.stderr)
+            return 2
         if s["stage"] not in PLAN_WRITABLE_STAGES:
             print(f"pipeline-state: refusing `set {args.key}` at stage `{s['stage']}` "
                   "— the plan is binding after planning; if it is wrong, `park "
@@ -283,6 +288,8 @@ def self_test():
         # or re-plan after planning
         run("set-stage-denied", lambda: cmd_set(
             argparse.Namespace(key="stage", value="ci"), d), 2)
+        run("set-bare-plan-denied", lambda: cmd_set(
+            argparse.Namespace(key="plan", value='{"touches":[]}'), d), 2)
         run("set-approvals-denied", lambda: cmd_set(
             argparse.Namespace(key="approvals.pr", value='{"by":"x"}'), d), 2)
         run("approve-wrong-stage", lambda: cmd_approve(

--- a/scripts/pipeline-state
+++ b/scripts/pipeline-state
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Pipeline run state — the binding resume contract (Phase 5, task 2).
+
+`.pipeline/state.json` (local, gitignored) is what makes the draft-PR gate
+resumable: it records the run's plan (resolved capability IDs, file paths,
+symbols), the current stage, and the approvals received. **Resume never
+re-plans** — a run continued after the maintainer's signal picks up the
+recorded plan verbatim; if the plan is wrong, the run is parked and re-entered
+from the top, visibly.
+
+Stage names are the telemetry schema v2 canonical list (telemetry/SCHEMA.md)
+— one vocabulary across state, telemetry lines, and the pipeline skill.
+
+Commands:
+  init --run-id ID --request REF [--branch B]   start a run (refuses to clobber)
+  status                                        human-readable summary
+  advance                                       move to the next stage
+  set KEY VALUE                                 dotted path; VALUE parsed as JSON,
+                                                falling back to string
+  approve STAGE --by WHO [--via HOW]            record a human approval
+  park --label LABEL [--note NOTE]              park with a taxonomy label
+  resume                                        clear parked (plan is kept — the contract)
+  validate                                      schema check (also runs on save)
+  --self-test                                   full lifecycle in a temp dir (doctor/CI)
+
+Run: ./dev pipeline <command>
+"""
+
+import argparse
+import json
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE_DIR = ROOT / ".pipeline"
+
+# telemetry/SCHEMA.md stage enum, in pipeline order. Changing it there means
+# changing it here in the same PR (both quote schema v2).
+STAGES = ["intake", "localize", "spec", "design-review", "plan",
+          "test-writing", "implement", "verify", "pr", "ci"]
+
+# telemetry/SCHEMA.md failure-label taxonomy v1 (closed).
+LABELS = {"wrong-intent", "wrong-localization", "dialect-violation", "invented-api",
+          "test-failure", "spec-drift", "flaky-infra", "timeout",
+          "human-rejected-spec", "human-rejected-pr", "other"}
+
+
+def now():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def state_file(state_dir):
+    return state_dir / "state.json"
+
+
+def validate(state):
+    errs = []
+    for key in ("schema", "run_id", "request_ref", "stage", "parked", "plan",
+                "approvals", "history"):
+        if key not in state:
+            errs.append(f"missing key `{key}`")
+    if errs:
+        return errs
+    if state["stage"] not in STAGES:
+        errs.append(f"stage `{state['stage']}` not in {STAGES}")
+    if not isinstance(state["parked"], bool):
+        errs.append("`parked` must be a bool")
+    if state["parked"] and state.get("park", {}).get("label") not in LABELS:
+        errs.append(f"parked runs need a `park.label` from the taxonomy {sorted(LABELS)}")
+    plan = state["plan"]
+    for key in ("touches", "files", "uses"):
+        if not isinstance(plan.get(key), list):
+            errs.append(f"`plan.{key}` must be a list")
+    return errs
+
+
+def load(state_dir):
+    f = state_file(state_dir)
+    if not f.exists():
+        print(f"pipeline-state: no run in progress ({f} missing) — use `init`", file=sys.stderr)
+        sys.exit(2)
+    state = json.loads(f.read_text())
+    errs = validate(state)
+    if errs:
+        for e in errs:
+            print(f"pipeline-state: INVALID state — {e}", file=sys.stderr)
+        sys.exit(1)
+    return state
+
+
+def save(state_dir, state):
+    errs = validate(state)
+    if errs:
+        for e in errs:
+            print(f"pipeline-state: refusing to save invalid state — {e}", file=sys.stderr)
+        sys.exit(1)
+    state_dir.mkdir(exist_ok=True)
+    state_file(state_dir).write_text(json.dumps(state, indent=2) + "\n")
+
+
+def cmd_init(args, state_dir):
+    f = state_file(state_dir)
+    if f.exists() and not args.force:
+        print(f"pipeline-state: {f} exists — finish or park the current run first "
+              "(or --force to discard it)", file=sys.stderr)
+        return 2
+    state = {
+        "schema": 1,
+        "run_id": args.run_id,
+        "request_ref": args.request,
+        "branch": args.branch,
+        "stage": "intake",
+        "parked": False,
+        "park": None,
+        "spec_path": None,
+        "pr_number": None,
+        "plan": {"touches": [], "files": [], "uses": []},
+        "approvals": {},
+        "history": [{"stage": "intake", "entered": now()}],
+    }
+    save(state_dir, state)
+    print(f"pipeline-state: run {args.run_id} started at stage `intake`")
+    return 0
+
+
+def cmd_status(state_dir):
+    s = load(state_dir)
+    parked = f" [PARKED: {s['park']['label']}]" if s["parked"] else ""
+    print(f"run {s['run_id']} ({s['request_ref']})  stage: {s['stage']}{parked}")
+    print(f"  branch: {s.get('branch')}  spec: {s.get('spec_path')}  PR: {s.get('pr_number')}")
+    print(f"  plan: {len(s['plan']['touches'])} capabilities, "
+          f"{len(s['plan']['files'])} files, {len(s['plan']['uses'])} symbols")
+    if s["approvals"]:
+        for stage, a in s["approvals"].items():
+            print(f"  approved {stage}: by {a['by']} via {a.get('via', '?')} at {a['at']}")
+    print(f"  history: {' -> '.join(h['stage'] for h in s['history'])}")
+    return 0
+
+
+def cmd_advance(state_dir):
+    s = load(state_dir)
+    if s["parked"]:
+        print("pipeline-state: run is parked — `resume` first", file=sys.stderr)
+        return 1
+    i = STAGES.index(s["stage"])
+    if i + 1 >= len(STAGES):
+        print(f"pipeline-state: already at final stage `{s['stage']}`", file=sys.stderr)
+        return 1
+    if STAGES[i + 1] == "design-review" and "spec" not in s["approvals"]:
+        print("pipeline-state: cannot advance past `spec` without a recorded spec "
+              "approval (`approve spec --by …`) — the gate is the contract", file=sys.stderr)
+        return 1
+    s["stage"] = STAGES[i + 1]
+    s["history"].append({"stage": s["stage"], "entered": now()})
+    save(state_dir, s)
+    print(f"pipeline-state: -> {s['stage']}")
+    return 0
+
+
+def cmd_set(args, state_dir):
+    s = load(state_dir)
+    try:
+        value = json.loads(args.value)
+    except json.JSONDecodeError:
+        value = args.value
+    node, *rest = args.key.split(".")
+    target = s
+    while rest:
+        target = target[node]
+        node, *rest = rest
+    target[node] = value
+    save(state_dir, s)
+    print(f"pipeline-state: {args.key} = {json.dumps(value)}")
+    return 0
+
+
+def cmd_approve(args, state_dir):
+    s = load(state_dir)
+    s["approvals"][args.stage] = {"by": args.by, "via": args.via, "at": now()}
+    save(state_dir, s)
+    print(f"pipeline-state: `{args.stage}` approved by {args.by} via {args.via}")
+    return 0
+
+
+def cmd_park(args, state_dir):
+    if args.label not in LABELS:
+        print(f"pipeline-state: label `{args.label}` not in the closed taxonomy "
+              f"{sorted(LABELS)}", file=sys.stderr)
+        return 2
+    s = load(state_dir)
+    s["parked"] = True
+    s["park"] = {"label": args.label, "note": args.note, "at": now()}
+    save(state_dir, s)
+    print(f"pipeline-state: parked at `{s['stage']}` ({args.label})")
+    return 0
+
+
+def cmd_resume(state_dir):
+    s = load(state_dir)
+    if not s["parked"]:
+        print("pipeline-state: run is not parked", file=sys.stderr)
+        return 1
+    s["parked"], s["park"] = False, None
+    save(state_dir, s)
+    print(f"pipeline-state: resumed at `{s['stage']}` — plan is binding, no re-planning")
+    return 0
+
+
+def self_test():
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp)
+        fails = 0
+
+        def run(label, fn, want):
+            nonlocal fails
+            got = fn()
+            if got != want:
+                print(f"self-test FAIL {label}: exit {got}, want {want}")
+                fails += 1
+
+        ns = argparse.Namespace(run_id="t-001", request="issue#0", branch="b", force=False)
+        run("init", lambda: cmd_init(ns, d), 0)
+        run("init-refuses-clobber", lambda: cmd_init(ns, d), 2)
+        run("advance-to-localize", lambda: cmd_advance(d), 0)
+        run("advance-to-spec", lambda: cmd_advance(d), 0)
+        run("gate-blocks-unapproved", lambda: cmd_advance(d), 1)
+        run("approve-spec", lambda: cmd_approve(
+            argparse.Namespace(stage="spec", by="nick", via="pr-comment"), d), 0)
+        run("advance-past-gate", lambda: cmd_advance(d), 0)
+        run("park-bad-label", lambda: cmd_park(
+            argparse.Namespace(label="vibes", note=""), d), 2)
+        run("park", lambda: cmd_park(
+            argparse.Namespace(label="timeout", note="stage budget"), d), 0)
+        run("advance-while-parked", lambda: cmd_advance(d), 1)
+        run("resume", lambda: cmd_resume(d), 0)
+        run("set-pr", lambda: cmd_set(argparse.Namespace(key="pr_number", value="721"), d), 0)
+        run("set-plan", lambda: cmd_set(argparse.Namespace(
+            key="plan.touches", value='["auth"]'), d), 0)
+        state = json.loads(state_file(d).read_text())
+        if state["pr_number"] != 721 or state["plan"]["touches"] != ["auth"]:
+            print(f"self-test FAIL set: {state['pr_number']}, {state['plan']['touches']}")
+            fails += 1
+
+        if fails == 0:
+            print("pipeline-state self-test: OK — lifecycle, gate, park taxonomy covered")
+        return 1 if fails else 0
+
+
+def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        return self_test()
+
+    p = argparse.ArgumentParser(prog="pipeline-state")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    pi = sub.add_parser("init")
+    pi.add_argument("--run-id", required=True)
+    pi.add_argument("--request", required=True)
+    pi.add_argument("--branch", default=None)
+    pi.add_argument("--force", action="store_true")
+    sub.add_parser("status")
+    sub.add_parser("advance")
+    ps = sub.add_parser("set")
+    ps.add_argument("key")
+    ps.add_argument("value")
+    pa = sub.add_parser("approve")
+    pa.add_argument("stage")
+    pa.add_argument("--by", required=True)
+    pa.add_argument("--via", default="pr-comment")
+    pp = sub.add_parser("park")
+    pp.add_argument("--label", required=True)
+    pp.add_argument("--note", default="")
+    sub.add_parser("resume")
+    sub.add_parser("validate")
+    args = p.parse_args()
+
+    if args.cmd == "init":
+        return cmd_init(args, STATE_DIR)
+    if args.cmd == "status":
+        return cmd_status(STATE_DIR)
+    if args.cmd == "advance":
+        return cmd_advance(STATE_DIR)
+    if args.cmd == "set":
+        return cmd_set(args, STATE_DIR)
+    if args.cmd == "approve":
+        return cmd_approve(args, STATE_DIR)
+    if args.cmd == "park":
+        return cmd_park(args, STATE_DIR)
+    if args.cmd == "resume":
+        return cmd_resume(STATE_DIR)
+    if args.cmd == "validate":
+        load(STATE_DIR)
+        print("pipeline-state: valid")
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pipeline-state
+++ b/scripts/pipeline-state
@@ -15,8 +15,12 @@ Commands:
   init --run-id ID --request REF [--branch B]   start a run (refuses to clobber)
   status                                        human-readable summary
   advance                                       move to the next stage
-  set KEY VALUE                                 dotted path; VALUE parsed as JSON,
-                                                falling back to string
+  set KEY VALUE                                 data keys only (spec_path,
+                                                pr_number, branch, plan.* while
+                                                planning); VALUE parsed as JSON,
+                                                falling back to string. Lifecycle
+                                                state only moves via the gate
+                                                commands below.
   approve STAGE --by WHO [--via HOW]            record a human approval
   park --label LABEL [--note NOTE]              park with a taxonomy label
   resume                                        clear parked (plan is kept — the contract)
@@ -63,15 +67,23 @@ def validate(state):
             errs.append(f"missing key `{key}`")
     if errs:
         return errs
+    # container shapes first — a scalar smuggled into park/plan/approvals must
+    # be a clean validation failure, not an AttributeError mid-save
+    for key, want in (("plan", dict), ("approvals", dict), ("history", list)):
+        if not isinstance(state[key], want):
+            errs.append(f"`{key}` must be a {want.__name__}")
+    if state.get("park") is not None and not isinstance(state["park"], dict):
+        errs.append("`park` must be null or an object")
+    if errs:
+        return errs
     if state["stage"] not in STAGES:
         errs.append(f"stage `{state['stage']}` not in {STAGES}")
     if not isinstance(state["parked"], bool):
         errs.append("`parked` must be a bool")
-    if state["parked"] and state.get("park", {}).get("label") not in LABELS:
+    if state["parked"] and (state["park"] or {}).get("label") not in LABELS:
         errs.append(f"parked runs need a `park.label` from the taxonomy {sorted(LABELS)}")
-    plan = state["plan"]
     for key in ("touches", "files", "uses"):
-        if not isinstance(plan.get(key), list):
+        if not isinstance(state["plan"].get(key), list):
             errs.append(f"`plan.{key}` must be a list")
     return errs
 
@@ -159,13 +171,33 @@ def cmd_advance(state_dir):
     return 0
 
 
+# `set` is for run DATA only. Lifecycle state moves through its dedicated,
+# gate-checking commands (advance/approve/park/resume) — allowing `set stage`
+# would let a run fast-forward past the spec gate silently.
+SETTABLE = {"spec_path", "pr_number", "branch"}
+# The plan is written during planning and BINDING afterwards (resume never
+# re-plans): plan.* writes are refused once the run passes `plan`.
+PLAN_WRITABLE_STAGES = {"intake", "localize", "spec", "design-review", "plan"}
+
+
 def cmd_set(args, state_dir):
     s = load(state_dir)
+    node, *rest = args.key.split(".")
+    if node == "plan":
+        if s["stage"] not in PLAN_WRITABLE_STAGES:
+            print(f"pipeline-state: refusing `set {args.key}` at stage `{s['stage']}` "
+                  "— the plan is binding after planning; if it is wrong, `park "
+                  "--label wrong-localization` and re-enter", file=sys.stderr)
+            return 2
+    elif node not in SETTABLE:
+        print(f"pipeline-state: `{node}` is not settable — lifecycle state moves via "
+              "advance/approve/park/resume; settable data keys: "
+              f"{sorted(SETTABLE)} + plan.*", file=sys.stderr)
+        return 2
     try:
         value = json.loads(args.value)
     except json.JSONDecodeError:
         value = args.value
-    node, *rest = args.key.split(".")
     target = s
     while rest:
         target = target[node]
@@ -178,6 +210,11 @@ def cmd_set(args, state_dir):
 
 def cmd_approve(args, state_dir):
     s = load(state_dir)
+    if s["stage"] != args.stage:
+        print(f"pipeline-state: cannot approve `{args.stage}` while the run is at "
+              f"`{s['stage']}` — approvals are recorded at the gate, not pre-seeded",
+              file=sys.stderr)
+        return 1
     s["approvals"][args.stage] = {"by": args.by, "via": args.via, "at": now()}
     save(state_dir, s)
     print(f"pipeline-state: `{args.stage}` approved by {args.by} via {args.via}")
@@ -242,6 +279,18 @@ def self_test():
         if state["pr_number"] != 721 or state["plan"]["touches"] != ["auth"]:
             print(f"self-test FAIL set: {state['pr_number']}, {state['plan']['touches']}")
             fails += 1
+        # lifecycle is sealed: `set` must not move stages, pre-seed approvals,
+        # or re-plan after planning
+        run("set-stage-denied", lambda: cmd_set(
+            argparse.Namespace(key="stage", value="ci"), d), 2)
+        run("set-approvals-denied", lambda: cmd_set(
+            argparse.Namespace(key="approvals.pr", value='{"by":"x"}'), d), 2)
+        run("approve-wrong-stage", lambda: cmd_approve(
+            argparse.Namespace(stage="spec", by="nick", via="pr-comment"), d), 1)
+        run("advance-to-plan", lambda: cmd_advance(d), 0)
+        run("advance-to-test-writing", lambda: cmd_advance(d), 0)
+        run("replan-after-plan-denied", lambda: cmd_set(
+            argparse.Namespace(key="plan.touches", value='["json"]'), d), 2)
 
         if fails == 0:
             print("pipeline-state self-test: OK — lifecycle, gate, park taxonomy covered")

--- a/scripts/pipeline-state
+++ b/scripts/pipeline-state
@@ -50,6 +50,11 @@ LABELS = {"wrong-intent", "wrong-localization", "dialect-violation", "invented-a
           "test-failure", "spec-drift", "flaky-infra", "timeout",
           "human-rejected-spec", "human-rejected-pr", "other"}
 
+# The plan sub-fields `set plan.<field>` may write — also what validate checks.
+# The plan is the binding resume contract: an unlisted field is a typo, not a
+# new key, so it is rejected rather than silently stored.
+PLAN_FIELDS = ("touches", "files", "uses")
+
 
 def now():
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -82,7 +87,7 @@ def validate(state):
         errs.append("`parked` must be a bool")
     if state["parked"] and (state["park"] or {}).get("label") not in LABELS:
         errs.append(f"parked runs need a `park.label` from the taxonomy {sorted(LABELS)}")
-    for key in ("touches", "files", "uses"):
+    for key in PLAN_FIELDS:
         if not isinstance(state["plan"].get(key), list):
             errs.append(f"`plan.{key}` must be a list")
     return errs
@@ -93,7 +98,15 @@ def load(state_dir):
     if not f.exists():
         print(f"pipeline-state: no run in progress ({f} missing) — use `init`", file=sys.stderr)
         sys.exit(2)
-    state = json.loads(f.read_text())
+    try:
+        state = json.loads(f.read_text())
+    except json.JSONDecodeError:
+        # a truncated/partial write must not traceback — the resume contract's
+        # own storage failing should give an actionable message, not a stack
+        print(f"pipeline-state: {f} is corrupt (truncated/partial write?) — delete it "
+              "and `init` a fresh run; resume from the recorded stage is lost, so "
+              "re-localize", file=sys.stderr)
+        sys.exit(1)
     errs = validate(state)
     if errs:
         for e in errs:
@@ -109,7 +122,13 @@ def save(state_dir, state):
             print(f"pipeline-state: refusing to save invalid state — {e}", file=sys.stderr)
         sys.exit(1)
     state_dir.mkdir(exist_ok=True)
-    state_file(state_dir).write_text(json.dumps(state, indent=2) + "\n")
+    # write-to-temp then atomic replace: an interrupted write (crash, Ctrl-C,
+    # full disk) can leave a stray state.json.tmp but never a truncated
+    # state.json — the binding resume contract stays readable
+    f = state_file(state_dir)
+    tmp = f.with_name(f.name + ".tmp")
+    tmp.write_text(json.dumps(state, indent=2) + "\n")
+    tmp.replace(f)
 
 
 def cmd_init(args, state_dir):
@@ -182,19 +201,29 @@ PLAN_WRITABLE_STAGES = {"intake", "localize", "spec", "design-review", "plan"}
 
 def cmd_set(args, state_dir):
     s = load(state_dir)
-    node, *rest = args.key.split(".")
+    # Validate key depth/shape up front — a typo in the plan sub-field
+    # (`plan.touchs`) or an over-deep key (`plan.a.b`, `spec_path.x`) must be a
+    # clean exit-2 rejection, never a silently-stored junk key or a raw
+    # KeyError traceback. The plan is read back verbatim on resume.
+    parts = args.key.split(".")
+    node = parts[0]
     if node == "plan":
-        if not rest:
-            print("pipeline-state: use `set plan.<field>` not `set plan` — a "
-                  "wholesale replacement would silently drop the other plan "
-                  "fields", file=sys.stderr)
+        if len(parts) != 2 or parts[1] not in PLAN_FIELDS:
+            print(f"pipeline-state: `set {args.key}` — plan writes are "
+                  f"`set plan.<field>` with <field> in {sorted(PLAN_FIELDS)}",
+                  file=sys.stderr)
             return 2
         if s["stage"] not in PLAN_WRITABLE_STAGES:
             print(f"pipeline-state: refusing `set {args.key}` at stage `{s['stage']}` "
                   "— the plan is binding after planning; if it is wrong, `park "
                   "--label wrong-localization` and re-enter", file=sys.stderr)
             return 2
-    elif node not in SETTABLE:
+    elif node in SETTABLE:
+        if len(parts) != 1:
+            print(f"pipeline-state: `{node}` is a scalar key — `set {node}` takes "
+                  "no sub-field", file=sys.stderr)
+            return 2
+    else:
         print(f"pipeline-state: `{node}` is not settable — lifecycle state moves via "
               "advance/approve/park/resume; settable data keys: "
               f"{sorted(SETTABLE)} + plan.*", file=sys.stderr)
@@ -203,11 +232,10 @@ def cmd_set(args, state_dir):
         value = json.loads(args.value)
     except json.JSONDecodeError:
         value = args.value
-    target = s
-    while rest:
-        target = target[node]
-        node, *rest = rest
-    target[node] = value
+    if node == "plan":
+        s["plan"][parts[1]] = value
+    else:
+        s[node] = value
     save(state_dir, s)
     print(f"pipeline-state: {args.key} = {json.dumps(value)}")
     return 0
@@ -292,6 +320,13 @@ def self_test():
             argparse.Namespace(key="plan", value='{"touches":[]}'), d), 2)
         run("set-approvals-denied", lambda: cmd_set(
             argparse.Namespace(key="approvals.pr", value='{"by":"x"}'), d), 2)
+        # Fix 5: plan-field typos and over-deep keys are rejected, not stored
+        run("set-plan-bad-field", lambda: cmd_set(
+            argparse.Namespace(key="plan.touchs", value='["auth"]'), d), 2)
+        run("set-plan-deep-key", lambda: cmd_set(
+            argparse.Namespace(key="plan.a.b", value='"x"'), d), 2)
+        run("set-scalar-deep-key", lambda: cmd_set(
+            argparse.Namespace(key="spec_path.x", value='"y"'), d), 2)
         run("approve-wrong-stage", lambda: cmd_approve(
             argparse.Namespace(stage="spec", by="nick", via="pr-comment"), d), 1)
         run("advance-to-plan", lambda: cmd_advance(d), 0)
@@ -299,8 +334,21 @@ def self_test():
         run("replan-after-plan-denied", lambda: cmd_set(
             argparse.Namespace(key="plan.touches", value='["json"]'), d), 2)
 
+        # Fix 6: a truncated state file exits cleanly (exit 1), never tracebacks.
+        # Runs last — it clobbers the valid state file on purpose.
+        state_file(d).write_text('{"schema": 1, "run_i')
+        try:
+            load(d)
+            code = 0
+        except SystemExit as e:
+            code = e.code
+        if code != 1:
+            print(f"self-test FAIL corrupt-state: load() exit {code}, want 1")
+            fails += 1
+
         if fails == 0:
-            print("pipeline-state self-test: OK — lifecycle, gate, park taxonomy covered")
+            print("pipeline-state self-test: OK — lifecycle, gate, park taxonomy, "
+                  "plan-field guard, corrupt-file recovery covered")
         return 1 if fails else 0
 
 

--- a/scripts/spec-check
+++ b/scripts/spec-check
@@ -3,7 +3,11 @@
 
 Validates docs/changes/*.md — the spec a draft PR opens with and the
 maintainer approves at the gate. The template (docs/changes/TEMPLATE.md) is
-itself a validated instance, so template and validator cannot drift.
+itself a validated instance, so the template's machine-read parts (header
+keys, fence infos, `## section` names, criteria cells) cannot drift from the
+validator. (The criteria table's column *labels* are documentation — parsed
+positionally, not asserted; design-review records, `*-review.md`, are not
+specs and are skipped.)
 
 Checks (all mechanical — a spec that passes is machine-joinable):
   1. filename: NNN-slug.md (3-digit, kebab), TEMPLATE.md exempt
@@ -25,6 +29,9 @@ Modes:
   spec-check --plan FILE      emit the mechanical joins as JSON:
                               required design reviews (touches x risk tags)
                               + test-impact globs (touches x tests:)
+  spec-check --reviews-pr [BASE]  PR-ready gate: every design review a changed
+                              spec routes must have its committed record
+                              (NNN-slug.<kind>-review.md, backlinking the spec)
   spec-check --self-test      embedded fixture + mutation coverage (doctor/CI)
 
 Run: ./dev spec-check    CI: .github/workflows/checks.yml `spec` job
@@ -50,6 +57,13 @@ FILENAME = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*\.md$")
 CRITERION_ID = re.compile(r"^C(\d+)$")
 ADR_LINK = re.compile(r"decisions/\d{4}-[a-z0-9-]+\.md")
 TRIGGER_FLAGS = ("breaking", "new-dependency", "new-capability", "new-extension-point")
+
+
+def is_spec_file(name):
+    """A validatable spec in docs/changes/: excludes the README index and
+    design-review records (`*-review.md`). TEMPLATE.md IS a validated instance,
+    so it stays in."""
+    return name != "README.md" and not speclib.is_review_record(name)
 
 
 def load_capabilities():
@@ -168,14 +182,22 @@ def check_spec(text, name, caps):
         rows = []
         for line in crit.splitlines():
             cells = [c.strip() for c in line.strip().strip("|").split("|")]
-            if len(cells) >= 4 and CRITERION_ID.match(cells[0]):
+            # recognize a criterion by its ID cell regardless of width, so a
+            # row missing the Level column reports the real problem instead of
+            # silently vanishing into "no criteria rows"
+            if cells and CRITERION_ID.match(cells[0]):
                 rows.append(cells)
         if not rows:
             errs.append(f"{name}: criteria table needs at least one `| Cn | … |` row")
         for i, cells in enumerate(rows, start=1):
-            cid, _behavior, test, level = cells[0], cells[1], cells[2], cells[3]
+            cid = cells[0]
             if int(CRITERION_ID.match(cid).group(1)) != i:
                 errs.append(f"{name}: criteria IDs must be sequential — row {i} is `{cid}`")
+            if len(cells) < 4:
+                errs.append(f"{name}: {cid} row needs 4 columns "
+                            "(ID|Behavior|Proving test|Level)")
+                continue
+            _behavior, test, level = cells[1], cells[2], cells[3]
             if not test or test == "—":
                 errs.append(f"{name}: {cid} names no proving test")
             if level not in LEVELS:
@@ -209,6 +231,58 @@ def plan_joins(text, caps):
         reviews.append("perf")
     globs = sorted({g for t in touches for g in caps[t]["tests"]})
     return {"touches": touches, "design_reviews": reviews, "test_impact_globs": globs}
+
+
+def review_obligations(text, spec_name, caps):
+    """(kind, record filename) pairs a spec's routing requires — one per entry
+    in plan_joins' `design_reviews`; empty when routing is empty."""
+    reviews = plan_joins(text, caps)["design_reviews"]
+    return [(r, speclib.review_record_name(spec_name, r)) for r in reviews]
+
+
+def missing_review_records(spec_name, spec_text, caps, record_exists, record_text):
+    """Pure gate core: given callbacks to test a record's existence and read
+    its text, return [error strings] for missing or non-backlinking records.
+    Callback-driven so the gate is testable without a git checkout."""
+    errs = []
+    for kind, record_name in review_obligations(spec_text, spec_name, caps):
+        if not record_exists(record_name):
+            errs.append(f"{spec_name}: routes a `{kind}` design review but its record "
+                        f"`{record_name}` is missing — run the neohaskell-{kind}"
+                        "-design-review skill and commit the record next to the spec")
+        elif spec_name not in record_text(record_name):
+            errs.append(f"{record_name}: does not backlink its spec `{spec_name}` "
+                        "(the record must name the spec it reviews)")
+    return errs
+
+
+def reviews_pr(base, caps):
+    """PR-ready review-record gate over the specs this branch changed vs `base`.
+    Returns an exit code (0 honored, 1 missing/unlinked, 2 bad base)."""
+    try:
+        specs = speclib.changed_specs(ROOT, base)
+    except speclib.GitDiffError as e:
+        print(f"spec-check: git diff against `{base}` failed — bad base ref? ({e})",
+              file=sys.stderr)
+        return 2
+    specs = [p for p in specs if is_spec_file(p.name) and p.name != "TEMPLATE.md"]
+    if not specs:
+        print(f"spec-check: no specs changed vs {base} — no review records to check")
+        return 0
+    errs = []
+    for spec in specs:
+        if not spec.exists():
+            continue  # spec deleted on the branch — nothing to require
+        errs += missing_review_records(
+            spec.name, spec.read_text(), caps,
+            record_exists=lambda n, d=spec.parent: (d / n).exists(),
+            record_text=lambda n, d=spec.parent: (d / n).read_text() if (d / n).exists() else "")
+    for e in errs:
+        print(f"spec-check: FAIL — {e}", file=sys.stderr)
+    if errs:
+        return 1
+    print(f"spec-check: OK — design-review records present for {len(specs)} changed spec(s)")
+    return 0
 
 
 # ── self-test ────────────────────────────────────────────────────────────────
@@ -292,6 +366,11 @@ def self_test():
            VALID_FIXTURE.replace("## User impact\n\nNone.\n", "## User impact\n\n"),
            "User impact")
 
+    expect("short-criteria-row",
+           VALID_FIXTURE.replace("| C1 | slugifies | `TextSpec` \"slugifies\" | unit |",
+                                 "| C1 | slugifies | `TextSpec` \"slugifies\" |"),
+           "row needs 4 columns")
+
     joins = plan_joins(
         VALID_FIXTURE.replace("[core-primitives]", "[auth, concurrency]"), caps)
     if joins["design_reviews"] != ["security", "perf"]:
@@ -301,8 +380,39 @@ def self_test():
         print("self-test FAIL plan-joins: expected test globs for auth+concurrency")
         fails += 1
 
+    # Fix 1: is_spec_file excludes README + review records, keeps specs + template
+    for nm, want in (("067-x.md", True), ("TEMPLATE.md", True),
+                     ("README.md", False), ("067-x.security-review.md", False)):
+        if is_spec_file(nm) is not want:
+            print(f"self-test FAIL is_spec_file({nm}): want {want}")
+            fails += 1
+
+    # Fix 2: review-record obligations + the missing/backlink gate (pure, no git)
+    auth_spec = VALID_FIXTURE.replace("[core-primitives]", "[auth]")
+    if [n for _, n in review_obligations(auth_spec, "067-x.md", caps)] != \
+            ["067-x.security-review.md"]:
+        print("self-test FAIL review-obligations: [auth] should owe the security record")
+        fails += 1
+    if review_obligations(VALID_FIXTURE, "001-x.md", caps):
+        print("self-test FAIL review-obligations: untagged spec owes nothing")
+        fails += 1
+    if not missing_review_records("067-x.md", auth_spec, caps,
+                                  lambda n: False, lambda n: ""):
+        print("self-test FAIL review-gate: absent record must error")
+        fails += 1
+    if missing_review_records("067-x.md", auth_spec, caps,
+                              lambda n: n == "067-x.security-review.md",
+                              lambda n: "Spec: docs/changes/067-x.md"):
+        print("self-test FAIL review-gate: present backlinked record must pass")
+        fails += 1
+    if not missing_review_records("067-x.md", auth_spec, caps,
+                                  lambda n: True, lambda n: "no reference"):
+        print("self-test FAIL review-gate: record without a backlink must error")
+        fails += 1
+
     if fails == 0:
-        print("spec-check self-test: OK — fixture mutations, header parsing, plan joins covered")
+        print("spec-check self-test: OK — fixture mutations, header parsing, "
+              "plan joins, spec-file filter, review-record gate covered")
     return 1 if fails else 0
 
 
@@ -317,14 +427,28 @@ def main():
         if len(args) != 2:
             print("usage: spec-check --plan <spec-file>", file=sys.stderr)
             return 2
-        print(json.dumps(plan_joins(Path(args[1]).read_text(), caps), indent=2))
+        spec = Path(args[1])
+        if not spec.exists():
+            print(f"spec-check: no such spec {spec}", file=sys.stderr)
+            return 2
+        print(json.dumps(plan_joins(spec.read_text(), caps), indent=2))
         return 0
 
-    files = [Path(a) for a in args] if args else sorted(
-        p for p in CHANGES.glob("*.md") if p.name != "README.md")
+    if args and args[0] == "--reviews-pr":
+        base = args[1] if len(args) > 1 else "origin/main"
+        return reviews_pr(base, caps)
+
+    files = [Path(a) for a in args] if args else sorted(CHANGES.glob("*.md"))
+    files = [p for p in files if is_spec_file(p.name)]
     if not files:
         print("spec-check: no specs to validate")
         return 0
+
+    missing = [p for p in files if not p.exists()]
+    if missing:
+        for p in missing:
+            print(f"spec-check: no such spec {p}", file=sys.stderr)
+        return 2
 
     errors = []
     for path in files:

--- a/scripts/spec-check
+++ b/scripts/spec-check
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Contract-delta spec validator (pipeline Phase 5).
+
+Validates docs/changes/*.md — the spec a draft PR opens with and the
+maintainer approves at the gate. The template (docs/changes/TEMPLATE.md) is
+itself a validated instance, so template and validator cannot drift.
+
+Checks (all mechanical — a spec that passes is machine-joinable):
+  1. filename: NNN-slug.md (3-digit, kebab), TEMPLATE.md exempt
+  2. the ```yaml spec``` header block parses; `kind` in the closed enum;
+     `touches` non-empty and every ID exists in codemap/capabilities.yaml
+     (the closed localization ontology — the mechanical join for test-impact
+     and design-review routing)
+  3. the ```diff signatures``` contract-delta block exists; every non-empty
+     line is `<+|-> <Module>: <entry>` in codemap/signatures vocabulary
+  4. honesty cross-check: any `-` line forces `breaking: true`
+  5. criteria table: >=1 row, IDs sequential C1..Cn, proving test non-empty,
+     level in {unit, integration, acceptance}
+  6. `## User impact` section present and non-empty
+  7. ADR trigger: breaking / new-dependency / new-capability /
+     new-extension-point -> the `## ADR` section must link docs/decisions/
+
+Modes:
+  spec-check [files…]         validate (default: all docs/changes/*.md)
+  spec-check --plan FILE      emit the mechanical joins as JSON:
+                              required design reviews (touches x risk tags)
+                              + test-impact globs (touches x tests:)
+  spec-check --self-test      embedded fixture + mutation coverage (doctor/CI)
+
+Run: ./dev spec-check    CI: .github/workflows/checks.yml `spec` job
+(python3 stdlib only — capabilities.yaml is regex-scanned, no pyyaml)
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGES = ROOT / "docs" / "changes"
+CAPABILITIES = ROOT / "codemap" / "capabilities.yaml"
+
+KINDS = {"feature", "bug", "refactor"}
+LEVELS = {"unit", "integration", "acceptance"}
+FILENAME = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*\.md$")
+DELTA_LINE = re.compile(r"^([+-])\s+([A-Za-z][\w.]*):\s+(.+)$")
+CRITERION_ID = re.compile(r"^C(\d+)$")
+ADR_LINK = re.compile(r"decisions/\d{4}-[a-z0-9-]+\.md")
+TRIGGER_FLAGS = ("breaking", "new-dependency", "new-capability", "new-extension-point")
+
+
+def load_capabilities():
+    """Regex-scan capabilities.yaml: id -> {risk tags, test globs}.
+    Line-based on purpose — the file is CI-gated by codemap/check.py, so the
+    shapes scanned here are stable."""
+    caps, current = {}, None
+    for line in CAPABILITIES.read_text().splitlines():
+        m = re.match(r"^\s*-\s+id:\s+(\S+)", line)
+        if m:
+            current = m.group(1)
+            caps[current] = {"security": False, "perf": False, "tests": []}
+            continue
+        if current is None:
+            continue
+        if re.match(r"^\s*security-sensitive:\s*true", line):
+            caps[current]["security"] = True
+        elif re.match(r"^\s*perf-sensitive:\s*true", line):
+            caps[current]["perf"] = True
+        else:
+            m = re.match(r"^\s*tests:\s*\[(.*)\]", line)
+            if m:
+                caps[current]["tests"] = [g.strip() for g in m.group(1).split(",") if g.strip()]
+    return caps
+
+
+def fenced_block(text, info):
+    """Content of the ```<info>``` fence, or None."""
+    m = re.search(rf"```{re.escape(info)}\n(.*?)```", text, re.DOTALL)
+    return m.group(1) if m else None
+
+
+def section(text, title):
+    """Body of a `## title` section, or None."""
+    m = re.search(rf"^## {re.escape(title)}\n(.*?)(?=^## |\Z)", text, re.DOTALL | re.MULTILINE)
+    return m.group(1) if m else None
+
+
+def parse_header(block):
+    """The ```yaml spec``` block is a flat known-shape mapping — parsed
+    line-based (stdlib only). Returns (dict, [errors])."""
+    header, errs = {}, []
+    for raw in block.splitlines():
+        line = raw.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        m = re.match(r"^([a-z-]+):\s*(.+)$", line)
+        if not m:
+            errs.append(f"header: unparseable line `{raw.strip()}`")
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if key == "touches":
+            lm = re.match(r"^\[(.*)\]$", val)
+            if not lm:
+                errs.append("header: `touches` must be a [flow, list]")
+                continue
+            header[key] = [t.strip() for t in lm.group(1).split(",") if t.strip()]
+        elif val in ("true", "false"):
+            header[key] = val == "true"
+        else:
+            header[key] = val
+    return header, errs
+
+
+def check_spec(text, name, caps):
+    """Returns [errors] — pure, testable."""
+    errs = []
+
+    block = fenced_block(text, "yaml spec")
+    if block is None:
+        return [f"{name}: missing ```yaml spec``` header block"]
+    header, header_errs = parse_header(block)
+    errs += [f"{name}: {e}" for e in header_errs]
+
+    if not header.get("issue"):
+        errs.append(f"{name}: header needs `issue:` (issue#NNN or adhoc:<slug>)")
+    if header.get("kind") not in KINDS:
+        errs.append(f"{name}: `kind` must be one of {sorted(KINDS)}, got `{header.get('kind')}`")
+    touches = header.get("touches", [])
+    if not touches:
+        errs.append(f"{name}: `touches` must name at least one capability ID")
+    for t in touches:
+        if t not in caps:
+            errs.append(f"{name}: `touches` names unknown capability `{t}` "
+                        "(closed list: codemap/capabilities.yaml)")
+    for flag in TRIGGER_FLAGS:
+        if not isinstance(header.get(flag), bool):
+            errs.append(f"{name}: header needs `{flag}: true|false`")
+
+    delta = fenced_block(text, "diff signatures")
+    if delta is None:
+        errs.append(f"{name}: missing ```diff signatures``` contract-delta block "
+                    "(empty block = no-API-change promise, still required)")
+        delta = ""
+    has_removal = False
+    for line in delta.splitlines():
+        if not line.strip():
+            continue
+        m = DELTA_LINE.match(line)
+        if not m:
+            errs.append(f"{name}: bad contract-delta line `{line.strip()}` "
+                        "(want `<+|-> <Module>: <signature>`)")
+            continue
+        if m.group(1) == "-":
+            has_removal = True
+    if has_removal and header.get("breaking") is not True:
+        errs.append(f"{name}: contract delta removes a signature but `breaking: false` "
+                    "— removals ARE breaking (honesty cross-check)")
+
+    crit = section(text, "Criteria")
+    if crit is None:
+        errs.append(f"{name}: missing `## Criteria` section")
+    else:
+        rows = []
+        for line in crit.splitlines():
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            if len(cells) >= 4 and CRITERION_ID.match(cells[0]):
+                rows.append(cells)
+        if not rows:
+            errs.append(f"{name}: criteria table needs at least one `| Cn | … |` row")
+        for i, cells in enumerate(rows, start=1):
+            cid, _behavior, test, level = cells[0], cells[1], cells[2], cells[3]
+            if int(CRITERION_ID.match(cid).group(1)) != i:
+                errs.append(f"{name}: criteria IDs must be sequential — row {i} is `{cid}`")
+            if not test or test == "—":
+                errs.append(f"{name}: {cid} names no proving test")
+            if level not in LEVELS:
+                errs.append(f"{name}: {cid} level `{level}` not in {sorted(LEVELS)} "
+                            "(a boundary-crossing behavior must declare integration/acceptance)")
+
+    impact = section(text, "User impact")
+    if impact is None or not impact.strip():
+        errs.append(f"{name}: missing or empty `## User impact` section "
+                    "(\"None\" is acceptable; silence is not)")
+
+    triggered = [f for f in TRIGGER_FLAGS if header.get(f) is True]
+    if triggered:
+        adr = section(text, "ADR")
+        if adr is None or not ADR_LINK.search(adr):
+            errs.append(f"{name}: ADR trigger fired ({', '.join(triggered)}) but the "
+                        "`## ADR` section links no docs/decisions/NNNN-slug.md")
+
+    return errs
+
+
+def plan_joins(text, caps):
+    """The mechanical joins the pipeline consumes: touches -> required design
+    reviews (risk tags) + test-impact globs."""
+    header, _ = parse_header(fenced_block(text, "yaml spec") or "")
+    touches = [t for t in header.get("touches", []) if t in caps]
+    reviews = []
+    if any(caps[t]["security"] for t in touches):
+        reviews.append("security")
+    if any(caps[t]["perf"] for t in touches):
+        reviews.append("perf")
+    globs = sorted({g for t in touches for g in caps[t]["tests"]})
+    return {"touches": touches, "design_reviews": reviews, "test_impact_globs": globs}
+
+
+# ── self-test ────────────────────────────────────────────────────────────────
+
+VALID_FIXTURE = """# Change 001: example
+
+Intent paragraph.
+
+```yaml spec
+issue: issue#712
+kind: feature
+touches: [core-primitives]
+breaking: false
+new-dependency: false
+new-capability: false
+new-extension-point: false
+```
+
+## Contract delta
+
+```diff signatures
++ Text: slugify :: Text -> Text
+```
+
+## Criteria
+
+| ID | Behavior | Proving test | Level |
+|----|----------|--------------|-------|
+| C1 | slugifies | `TextSpec` "slugifies" | unit |
+| C2 | rejects empty | `TextSpec` "rejects empty" | unit |
+
+## User impact
+
+None.
+
+## ADR
+
+Not required.
+"""
+
+
+def self_test():
+    caps = load_capabilities()
+    fails = 0
+
+    def expect(label, text, want_error_containing):
+        nonlocal fails
+        errs = check_spec(text, "fixture", caps)
+        if want_error_containing is None:
+            if errs:
+                print(f"self-test FAIL {label}: expected valid, got {errs}")
+                fails += 1
+        elif not any(want_error_containing in e for e in errs):
+            print(f"self-test FAIL {label}: no error containing `{want_error_containing}` in {errs}")
+            fails += 1
+
+    expect("valid", VALID_FIXTURE, None)
+    expect("bad-kind", VALID_FIXTURE.replace("kind: feature", "kind: epic"), "`kind` must be")
+    expect("unknown-capability",
+           VALID_FIXTURE.replace("[core-primitives]", "[warp-drive]"), "unknown capability")
+    expect("removal-not-breaking",
+           VALID_FIXTURE.replace("+ Text: slugify", "- Text: slugify"), "removals ARE breaking")
+    expect("triggered-without-adr",
+           VALID_FIXTURE.replace("breaking: false", "breaking: true")
+                        .replace("+ Text: slugify", "- Text: slugify"), "links no docs/decisions")
+    expect("bad-level", VALID_FIXTURE.replace("| unit |", "| mocked |", 1), "not in")
+    expect("gap-in-ids", VALID_FIXTURE.replace("| C2 |", "| C7 |"), "sequential")
+    expect("no-delta-block",
+           re.sub(r"```diff signatures\n.*?```", "", VALID_FIXTURE, flags=re.DOTALL),
+           "contract-delta block")
+    expect("bad-delta-line",
+           VALID_FIXTURE.replace("+ Text: slugify :: Text -> Text", "+ added a function"),
+           "bad contract-delta line")
+    expect("no-impact",
+           VALID_FIXTURE.replace("## User impact\n\nNone.\n", "## User impact\n\n"),
+           "User impact")
+
+    joins = plan_joins(
+        VALID_FIXTURE.replace("[core-primitives]", "[auth, concurrency]"), caps)
+    if joins["design_reviews"] != ["security", "perf"]:
+        print(f"self-test FAIL plan-joins: expected both reviews, got {joins}")
+        fails += 1
+    if not joins["test_impact_globs"]:
+        print("self-test FAIL plan-joins: expected test globs for auth+concurrency")
+        fails += 1
+
+    if fails == 0:
+        print("spec-check self-test: OK — 11 fixture mutations + plan joins covered")
+    return 1 if fails else 0
+
+
+def main():
+    args = sys.argv[1:]
+    if args and args[0] == "--self-test":
+        return self_test()
+
+    caps = load_capabilities()
+
+    if args and args[0] == "--plan":
+        if len(args) != 2:
+            print("usage: spec-check --plan <spec-file>", file=sys.stderr)
+            return 2
+        print(json.dumps(plan_joins(Path(args[1]).read_text(), caps), indent=2))
+        return 0
+
+    files = [Path(a) for a in args] if args else sorted(
+        p for p in CHANGES.glob("*.md") if p.name != "README.md")
+    if not files:
+        print("spec-check: no specs to validate")
+        return 0
+
+    errors = []
+    for path in files:
+        if path.name != "TEMPLATE.md" and not FILENAME.match(path.name):
+            errors.append(f"{path.name}: filename must be NNN-slug.md (3-digit, kebab-case)")
+        errors += check_spec(path.read_text(), path.name, caps)
+
+    for e in errors:
+        print(f"spec-check: FAIL — {e}", file=sys.stderr)
+    if not errors:
+        print(f"spec-check: OK — {len(files)} spec(s) valid")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/spec-check
+++ b/scripts/spec-check
@@ -36,6 +36,10 @@ import re
 import sys
 from pathlib import Path
 
+sys.dont_write_bytecode = True  # no scripts/__pycache__/ (doctor scans scripts/)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import speclib  # noqa: E402 — shared delta grammar with spec-drift
+
 ROOT = Path(__file__).resolve().parent.parent
 CHANGES = ROOT / "docs" / "changes"
 CAPABILITIES = ROOT / "codemap" / "capabilities.yaml"
@@ -43,7 +47,6 @@ CAPABILITIES = ROOT / "codemap" / "capabilities.yaml"
 KINDS = {"feature", "bug", "refactor"}
 LEVELS = {"unit", "integration", "acceptance"}
 FILENAME = re.compile(r"^\d{3}-[a-z0-9][a-z0-9-]*\.md$")
-DELTA_LINE = re.compile(r"^([+-])\s+([A-Za-z][\w.]*):\s+(.+)$")
 CRITERION_ID = re.compile(r"^C(\d+)$")
 ADR_LINK = re.compile(r"decisions/\d{4}-[a-z0-9-]+\.md")
 TRIGGER_FLAGS = ("breaking", "new-dependency", "new-capability", "new-extension-point")
@@ -90,7 +93,9 @@ def parse_header(block):
     line-based (stdlib only). Returns (dict, [errors])."""
     header, errs = {}, []
     for raw in block.splitlines():
-        line = raw.split("#", 1)[0].rstrip()
+        # YAML comment = `#` preceded by whitespace (or line start) — a bare
+        # split on "#" would truncate `issue: issue#712` to `issue`
+        line = re.split(r"(?:^|\s)#", raw, maxsplit=1)[0].rstrip()
         if not line.strip():
             continue
         m = re.match(r"^([a-z-]+):\s*(.+)$", line)
@@ -136,7 +141,7 @@ def check_spec(text, name, caps):
         if not isinstance(header.get(flag), bool):
             errs.append(f"{name}: header needs `{flag}: true|false`")
 
-    delta = fenced_block(text, "diff signatures")
+    delta = speclib.delta_block(text)
     if delta is None:
         errs.append(f"{name}: missing ```diff signatures``` contract-delta block "
                     "(empty block = no-API-change promise, still required)")
@@ -145,7 +150,7 @@ def check_spec(text, name, caps):
     for line in delta.splitlines():
         if not line.strip():
             continue
-        m = DELTA_LINE.match(line)
+        m = speclib.DELTA_LINE.match(line)
         if not m:
             errs.append(f"{name}: bad contract-delta line `{line.strip()}` "
                         "(want `<+|-> <Module>: <signature>`)")
@@ -261,6 +266,12 @@ def self_test():
             fails += 1
 
     expect("valid", VALID_FIXTURE, None)
+    # regression: `issue#712` must survive comment stripping (only
+    # whitespace-preceded `#` starts a YAML comment)
+    header, _ = parse_header("issue: issue#712  # trailing comment")
+    if header.get("issue") != "issue#712":
+        print(f"self-test FAIL issue-hash: parsed `{header.get('issue')}`, want `issue#712`")
+        fails += 1
     expect("bad-kind", VALID_FIXTURE.replace("kind: feature", "kind: epic"), "`kind` must be")
     expect("unknown-capability",
            VALID_FIXTURE.replace("[core-primitives]", "[warp-drive]"), "unknown capability")
@@ -291,7 +302,7 @@ def self_test():
         fails += 1
 
     if fails == 0:
-        print("spec-check self-test: OK — 11 fixture mutations + plan joins covered")
+        print("spec-check self-test: OK — fixture mutations, header parsing, plan joins covered")
     return 1 if fails else 0
 
 

--- a/scripts/spec-drift
+++ b/scripts/spec-drift
@@ -25,14 +25,16 @@ Exit: 0 = honored, 1 = drift, 2 = usage/missing input.
 Run: ./dev spec-drift    CI: .github/workflows/checks.yml `spec` job
 """
 
-import re
 import subprocess
 import sys
 from pathlib import Path
 
+sys.dont_write_bytecode = True  # no scripts/__pycache__/ (doctor scans scripts/)
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import speclib  # noqa: E402 — shared delta grammar with spec-check
+
 ROOT = Path(__file__).resolve().parent.parent
 SIGNATURES = ROOT / "codemap" / "signatures"
-DELTA_LINE = re.compile(r"^([+-])\s+([A-Za-z][\w.]*):\s+(.+)$")
 
 
 def load_surface():
@@ -49,12 +51,12 @@ def load_surface():
 
 
 def delta_lines(text):
-    m = re.search(r"```diff signatures\n(.*?)```", text, re.DOTALL)
-    if m is None:
+    block = speclib.delta_block(text)
+    if block is None:
         return None
     out = []
-    for line in m.group(1).splitlines():
-        dm = DELTA_LINE.match(line)
+    for line in block.splitlines():
+        dm = speclib.DELTA_LINE.match(line)
         if dm:
             out.append((dm.group(1), dm.group(2), " ".join(dm.group(3).split())))
     return out
@@ -77,11 +79,15 @@ def check(path, surface):
 
 def pr_specs(base):
     """Specs added/modified on this branch vs the merge base."""
-    out = subprocess.run(
+    proc = subprocess.run(
         ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
          "--", "docs/changes/"],
-        cwd=ROOT, capture_output=True, text=True, check=True).stdout
-    return [ROOT / p for p in out.splitlines() if p.endswith(".md")]
+        cwd=ROOT, capture_output=True, text=True)
+    if proc.returncode != 0:
+        print(f"spec-drift: git diff against `{base}` failed — bad base ref? "
+              f"({proc.stderr.strip()})", file=sys.stderr)
+        sys.exit(2)
+    return [ROOT / p for p in proc.stdout.splitlines() if p.endswith(".md")]
 
 
 def main():

--- a/scripts/spec-drift
+++ b/scripts/spec-drift
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Spec-drift check (pipeline Phase 5, task 7).
+
+At PR-ready: verify the code's actual public API surface honors the spec's
+promised contract delta — a mismatch is flagged mechanically BEFORE the
+maintainer reviews. The join is exact: contract-delta lines are written in
+codemap/signatures vocabulary, and codemap/signatures/*.txt is the CI-sync-
+gated truth (test.yml codemap-sync regenerates and diffs it), so checking
+against the committed files IS checking against the code.
+
+Semantics per delta line:
+  `+ Module: entry`  the entry must EXIST in Module's signature section
+  `- Module: entry`  the entry must be ABSENT from Module's section
+An empty delta block passes trivially — the no-API-change promise is checked
+by the same mechanism (any surface change would fail codemap-sync instead).
+
+Usage:
+  spec-drift <spec.md> […]   check specific specs
+  spec-drift --pr [BASE]     check the specs this branch adds/modifies vs
+                             the merge base (default: origin/main) — the CI
+                             mode; passes trivially when the diff has none
+  (docs/changes/TEMPLATE.md is always skipped — its delta is a placeholder)
+
+Exit: 0 = honored, 1 = drift, 2 = usage/missing input.
+Run: ./dev spec-drift    CI: .github/workflows/checks.yml `spec` job
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SIGNATURES = ROOT / "codemap" / "signatures"
+DELTA_LINE = re.compile(r"^([+-])\s+([A-Za-z][\w.]*):\s+(.+)$")
+
+
+def load_surface():
+    """module -> set of normalized entry lines, across all signature files."""
+    surface, module = {}, None
+    for f in sorted(SIGNATURES.glob("*.txt")):
+        for line in f.read_text().splitlines():
+            if line.startswith("module "):
+                module = line[len("module "):].strip()
+                surface.setdefault(module, set())
+            elif module and line.strip() and not line.startswith("--"):
+                surface[module].add(" ".join(line.split()))
+    return surface
+
+
+def delta_lines(text):
+    m = re.search(r"```diff signatures\n(.*?)```", text, re.DOTALL)
+    if m is None:
+        return None
+    out = []
+    for line in m.group(1).splitlines():
+        dm = DELTA_LINE.match(line)
+        if dm:
+            out.append((dm.group(1), dm.group(2), " ".join(dm.group(3).split())))
+    return out
+
+
+def check(path, surface):
+    errs = []
+    lines = delta_lines(path.read_text())
+    if lines is None:
+        return [f"{path.name}: no ```diff signatures``` block (run ./dev spec-check first)"]
+    for sign, module, entry in lines:
+        present = entry in surface.get(module, set())
+        if sign == "+" and not present:
+            errs.append(f"{path.name}: promised `+ {module}: {entry}` — not in the "
+                        f"generated surface (module {'exists' if module in surface else 'MISSING'})")
+        if sign == "-" and present:
+            errs.append(f"{path.name}: promised removal `- {module}: {entry}` — still present")
+    return errs
+
+
+def pr_specs(base):
+    """Specs added/modified on this branch vs the merge base."""
+    out = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
+         "--", "docs/changes/"],
+        cwd=ROOT, capture_output=True, text=True, check=True).stdout
+    return [ROOT / p for p in out.splitlines() if p.endswith(".md")]
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__.strip().splitlines()[0], file=sys.stderr)
+        print("usage: spec-drift <spec.md> […] | spec-drift --pr [BASE]", file=sys.stderr)
+        return 2
+
+    if args[0] == "--pr":
+        base = args[1] if len(args) > 1 else "origin/main"
+        files = pr_specs(base)
+        if not files:
+            print(f"spec-drift: no specs changed vs {base} — nothing to check")
+            return 0
+    else:
+        files = [Path(a) for a in args]
+
+    files = [f for f in files if f.name not in ("TEMPLATE.md", "README.md")]
+    missing = [f for f in files if not f.exists()]
+    if missing:
+        for f in missing:
+            print(f"spec-drift: no such spec {f}", file=sys.stderr)
+        return 2
+    if not files:
+        print("spec-drift: only template/readme in scope — nothing to check")
+        return 0
+
+    surface = load_surface()
+    errors = [e for f in files for e in check(f, surface)]
+    for e in errors:
+        print(f"spec-drift: FAIL — {e}", file=sys.stderr)
+    if errors:
+        print("spec-drift: the spec is the approved contract — either finish the "
+              "implementation or (with maintainer sign-off) amend the spec in the "
+              "same PR.", file=sys.stderr)
+        return 1
+    print(f"spec-drift: OK — {len(files)} spec(s) honored by the generated surface")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/spec-drift
+++ b/scripts/spec-drift
@@ -25,7 +25,6 @@ Exit: 0 = honored, 1 = drift, 2 = usage/missing input.
 Run: ./dev spec-drift    CI: .github/workflows/checks.yml `spec` job
 """
 
-import subprocess
 import sys
 from pathlib import Path
 
@@ -62,36 +61,75 @@ def delta_lines(text):
     return out
 
 
-def check(path, surface):
+def check_text(name, text, surface):
+    """Pure: does `text`'s contract delta hold against `surface`? Testable."""
     errs = []
-    lines = delta_lines(path.read_text())
+    lines = delta_lines(text)
     if lines is None:
-        return [f"{path.name}: no ```diff signatures``` block (run ./dev spec-check first)"]
+        return [f"{name}: no ```diff signatures``` block (run ./dev spec-check first)"]
     for sign, module, entry in lines:
         present = entry in surface.get(module, set())
         if sign == "+" and not present:
-            errs.append(f"{path.name}: promised `+ {module}: {entry}` — not in the "
+            errs.append(f"{name}: promised `+ {module}: {entry}` — not in the "
                         f"generated surface (module {'exists' if module in surface else 'MISSING'})")
         if sign == "-" and present:
-            errs.append(f"{path.name}: promised removal `- {module}: {entry}` — still present")
+            errs.append(f"{name}: promised removal `- {module}: {entry}` — still present")
     return errs
 
 
+def check(path, surface):
+    return check_text(path.name, path.read_text(), surface)
+
+
 def pr_specs(base):
-    """Specs added/modified on this branch vs the merge base."""
-    proc = subprocess.run(
-        ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
-         "--", "docs/changes/"],
-        cwd=ROOT, capture_output=True, text=True)
-    if proc.returncode != 0:
-        print(f"spec-drift: git diff against `{base}` failed — bad base ref? "
-              f"({proc.stderr.strip()})", file=sys.stderr)
+    """Specs added/modified on this branch vs the merge base — shared with
+    spec-check's review-record gate via speclib.changed_specs."""
+    try:
+        return speclib.changed_specs(ROOT, base)
+    except speclib.GitDiffError as e:
+        print(f"spec-drift: git diff against `{base}` failed — bad base ref? ({e})",
+              file=sys.stderr)
         sys.exit(2)
-    return [ROOT / p for p in proc.stdout.splitlines() if p.endswith(".md")]
+
+
+def self_test():
+    fails = 0
+    surface = {"Text": {"slugify :: Text -> Text"}}
+
+    def expect(label, text, want_ok):
+        nonlocal fails
+        errs = check_text("fixture.md", text, surface)
+        if want_ok and errs:
+            print(f"self-test FAIL {label}: expected honored, got {errs}")
+            fails += 1
+        elif not want_ok and not errs:
+            print(f"self-test FAIL {label}: expected drift, got none")
+            fails += 1
+
+    expect("honored-plus", "```diff signatures\n+ Text: slugify :: Text -> Text\n```", True)
+    expect("drift-plus-absent",
+           "```diff signatures\n+ Text: explode :: Text -> Array Text\n```", False)
+    expect("honored-minus-absent",
+           "```diff signatures\n- Text: explode :: Text -> Array Text\n```", True)
+    expect("drift-minus-present",
+           "```diff signatures\n- Text: slugify :: Text -> Text\n```", False)
+
+    # Fix 1: design-review records are not specs — the drift filter skips them
+    for nm, is_rec in (("067-x.security-review.md", True),
+                       ("067-x.perf-review.md", True), ("067-x.md", False)):
+        if speclib.is_review_record(nm) is not is_rec:
+            print(f"self-test FAIL is_review_record({nm}): want {is_rec}")
+            fails += 1
+
+    if fails == 0:
+        print("spec-drift self-test: OK — honored/drift +/- and review-record filter covered")
+    return 1 if fails else 0
 
 
 def main():
     args = sys.argv[1:]
+    if args and args[0] == "--self-test":
+        return self_test()
     if not args:
         print(__doc__.strip().splitlines()[0], file=sys.stderr)
         print("usage: spec-drift <spec.md> […] | spec-drift --pr [BASE]", file=sys.stderr)
@@ -106,14 +144,16 @@ def main():
     else:
         files = [Path(a) for a in args]
 
-    files = [f for f in files if f.name not in ("TEMPLATE.md", "README.md")]
+    files = [f for f in files
+             if f.name not in ("TEMPLATE.md", "README.md")
+             and not speclib.is_review_record(f.name)]
     missing = [f for f in files if not f.exists()]
     if missing:
         for f in missing:
             print(f"spec-drift: no such spec {f}", file=sys.stderr)
         return 2
     if not files:
-        print("spec-drift: only template/readme in scope — nothing to check")
+        print("spec-drift: only template/readme/review-records in scope — nothing to check")
         return 0
 
     surface = load_surface()

--- a/scripts/speclib.py
+++ b/scripts/speclib.py
@@ -1,0 +1,19 @@
+"""Shared contract-delta parsing for spec-check and spec-drift (Phase 5).
+
+One definition of the delta-line grammar and block extraction — if the spec
+format evolves, both gates move together instead of one silently diverging
+(a spec must never pass spec-check but fail spec-drift on syntax).
+
+Imported, never executed (doctor exemption: no ./dev verb).
+"""
+
+import re
+
+# `<+|-> <Module>: <signature line>` — the codemap/signatures vocabulary.
+DELTA_LINE = re.compile(r"^([+-])\s+([A-Za-z][\w.]*):\s+(.+)$")
+
+
+def delta_block(text):
+    """Content of the ```diff signatures``` fence, or None when absent."""
+    m = re.search(r"```diff signatures\n(.*?)```", text, re.DOTALL)
+    return m.group(1) if m else None

--- a/scripts/speclib.py
+++ b/scripts/speclib.py
@@ -1,19 +1,61 @@
-"""Shared contract-delta parsing for spec-check and spec-drift (Phase 5).
+"""Shared spec-set + contract-delta parsing for spec-check and spec-drift (Phase 5).
 
-One definition of the delta-line grammar and block extraction — if the spec
-format evolves, both gates move together instead of one silently diverging
-(a spec must never pass spec-check but fail spec-drift on syntax).
+One definition of the delta-line grammar, block extraction, the review-record
+naming convention, and the "which specs did this PR touch" enumeration — if any
+of these evolve, both gates move together instead of one silently diverging
+(a spec must never pass spec-check but fail spec-drift on syntax; a review
+record the writer produces must never be rejected by one gate and required by
+the other under different names).
 
 Imported, never executed (doctor exemption: no ./dev verb).
 """
 
 import re
+import subprocess
+from pathlib import Path
 
 # `<+|-> <Module>: <signature line>` — the codemap/signatures vocabulary.
 DELTA_LINE = re.compile(r"^([+-])\s+([A-Za-z][\w.]*):\s+(.+)$")
+
+# The design-review kinds spec-check --plan can route (matches capability risk
+# tags security-sensitive / perf-sensitive → "security" / "perf").
+REVIEW_KINDS = ("security", "perf")
+
+
+class GitDiffError(Exception):
+    """`git diff` failed while enumerating changed specs (bad base ref, or not
+    a git checkout). Callers translate this to their own exit-2 message."""
 
 
 def delta_block(text):
     """Content of the ```diff signatures``` fence, or None when absent."""
     m = re.search(r"```diff signatures\n(.*?)```", text, re.DOTALL)
     return m.group(1) if m else None
+
+
+def is_review_record(name):
+    """True for a committed design-review record (`NNN-slug.<kind>-review.md`).
+    Not a spec: both validators skip it; the review-record existence gate
+    requires it. One suffix, one definition — the writer (design-review skills),
+    the gate exclusion, and the existence check all agree."""
+    return name.endswith("-review.md")
+
+
+def review_record_name(spec_name, kind):
+    """The design-review record a spec routes to:
+    `067-foo.md` + `security` → `067-foo.security-review.md`."""
+    stem = spec_name[:-len(".md")] if spec_name.endswith(".md") else spec_name
+    return f"{stem}.{kind}-review.md"
+
+
+def changed_specs(root, base):
+    """`docs/changes/*.md` added or modified on this branch vs the merge `base`
+    — the shared spec set for spec-drift's drift gate and spec-check's
+    review-record gate. Raises GitDiffError on a bad base ref."""
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=AM", f"{base}...HEAD",
+         "--", "docs/changes/"],
+        cwd=root, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise GitDiffError(proc.stderr.strip() or f"git diff against `{base}` failed")
+    return [Path(root) / p for p in proc.stdout.splitlines() if p.endswith(".md")]

--- a/telemetry/bench-budgets.json
+++ b/telemetry/bench-budgets.json
@@ -1,0 +1,21 @@
+{
+  "schema": 1,
+  "mode": "compiled `cabal test` (default project, not the -O0 dev flavor) — timings are only comparable within this mode",
+  "calibration": "a null budget_s records the measured time and never fails the run; after >=3 nightly datapoints, set budget_s to ~2x the median observed seconds and commit the number (the weekly telemetry review owns this)",
+  "entries": [
+    {
+      "name": "eventstore-inmemory",
+      "suite": "nhcore-test-service",
+      "match": "Service.EventStore.InMemory",
+      "requires": null,
+      "budget_s": null
+    },
+    {
+      "name": "eventstore-postgres",
+      "suite": "nhcore-test-service",
+      "match": "Service.EventStore.Postgres",
+      "requires": "postgres",
+      "budget_s": null
+    }
+  ]
+}


### PR DESCRIPTION
Part of #715 (Phase 5). Decision record: [ADR-0067](docs/decisions/0067-contract-delta-spec-gate.md).

The change flow now has **exactly two human gates** — spec approval (draft PR) and final PR review — with everything between mechanical, resumable, and telemetered.

## What ships

| Piece | Where | Gate |
|---|---|---|
| Contract-delta spec template | `docs/changes/TEMPLATE.md` | template is a **validated instance** — CI runs `spec-check` on it, so it can't drift from the validator |
| Spec validator + plan joins | `./dev spec-check` (`--plan` emits design-review routing + test-impact globs from `touches:`) | checks.yml `spec` job + `--self-test` in `./dev doctor` (11 fixture mutations) |
| Spec-drift check | `./dev spec-drift` — promised API lines vs `codemap/signatures/` | checks.yml, **PR-ready only** (drift on a draft is expected, not an error) |
| Resume contract | `./dev pipeline` → `.pipeline/state.json` — advance past `spec` refused without recorded approval; park requires a taxonomy label; **resume never re-plans** | schema-validated on every save + `--self-test` in doctor |
| Maintainer-only continue signal | `claude.yml` author-association allowlist (OWNER/MEMBER) | also closes the standing anyone-can-`@claude` hole |
| Draft-PR CI guard | test.yml: heavy matrix skipped on drafts; `ready_for_review` re-triggers (not a default activity type!); ci-gate accepts skips only while draft | cheap checks (doctor/codemap/lint/spec) still run on drafts |
| Design-review skills | `neohaskell-security-design-review`, `neohaskell-performance-design-review` — post-approval, pre-implementation, routed mechanically by risk tags; records **committed next to the spec** (audit trail) | salvage-corrected: INLINABLE over blanket INLINE, UNPACK scoping, 4-question grounding filter |
| Orchestrator skill | `neohaskell-pipeline` — stage flow on telemetry stage names, enforced verification order (red → green → test-impact → full suite once), time-boxes → retry → escalate → park | doctor verb-reference check |
| Expectation-protection hook | `expectation-guard.py` — removing/rewording existing test expectations blocked without maintainer marker `.pipeline/allow-expectation-edits`; **no inline escape hatch by design** | 14-case `--self-test` in doctor, same contract as dialect-guard |
| Nightly benchmarks | `./dev bench` vs `telemetry/bench-budgets.json` (null = calibration mode), `nightly-bench.yml` schedule + manual dispatch | **never PR-blocking by construction** — not wired to pull_request |

## Verified locally

- `./dev doctor` green: 19 verbs, 26 scripts accounted, 5 self-test suites (dialect-guard 33 cases, expectation-guard 14 + parse/census, spec-check 9 mutations, spec-drift honored/drift, pipeline-state lifecycle)
- `./dev bench` live run: in-memory EventStore suite timed at 125.3s (calibration), Postgres entry correctly skipped without `POSTGRES_AVAILABLE`
- `spec-drift` exercised in all three modes (honored / drifted / `--pr` no-specs)
- all 4 touched workflows parse

## Two judgment calls to sanity-check

1. **Bench telemetry**: the plan says regressions produce "a notification + telemetry entry"; doctrine says `runs.jsonl` is pipeline-only. Reconciliation: the workflow failure is the notification, the uploaded `bench-results` artifact (90d retention) is the entry; the Phase 6 weekly review reads the artifact trend and owns budget calibration. No new jsonl.
2. **`claude.yml` allowlist is OWNER/MEMBER** (not COLLABORATOR) — strictest reading of "maintainer-only". If org privacy makes your comments read as NONE, widening is a one-line diff.

Exit criteria note: the phase's "one feature + one bug shipped end-to-end" criterion is exercised by the *first real runs* through this machinery — infrastructure lands here, the exercise happens next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 3 — adversarial self-review fixes (f2d3c86)

A 6-dimension, adversarially-verified review of this PR found **one blocker + five anti-rot gaps**; all fixed in `f2d3c86`, each with a self-test or CI gate so it can't regress:

- **Blocker (reproduced):** the risk-tiered design-review flow broke CI on first use — `spec-check`/`spec-drift` rejected the `NNN-slug.<kind>-review.md` record they exist to produce. Both now skip review records (naming centralized in `speclib`); `spec-drift` gains its first `--self-test`, wired into `doctor`.
- **Review-record existence gate:** `spec-check --reviews-pr` (checks.yml `spec` job, PR-ready only) asserts every routed design review has its committed, spec-backlinking record — the compliance artifact is now gated, not merely prosed.
- **Expectation guard hardened:** the hook fails loud-open on unparseable stdin; a new `expectations` CI job census-diffs committed test files against the merge base and blocks net-removed/reworded expectations unless a maintainer applies the `expectations-approved` label. Covers the rename / Bash / non-test-path bypasses the local matcher missed (verified: a pure `git mv` is *not* a false positive; a `git mv` that drops an expectation *is* caught).
- **doctor** check #4 now scans AGENTS.md/CLAUDE.md for `./dev` verb truth (not just SKILL.md).
- **pipeline-state:** `set plan.<typo>` and over-deep keys are rejected (exit 2) instead of silently corrupting the binding plan; `state.json` is written atomically with graceful recovery on a truncated file.
- **Nits:** honest "cannot drift" wording (ADR/TEMPLATE/spec-check), clean errors for missing specs and short criteria rows, `set`/`validate` surfaced in `./dev` + AGENTS help, TEMPLATE ADR example uses a fictional number.

**Rollout (maintainer, out-of-repo):** mark the new `expectations` job **required** in branch protection (else it's informational); create the maintainer-applied `expectations-approved` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expectation-edit protection gate with CI backstop for test expectation line removals.
  * Introduced contract-delta spec validation, API signature drift checks, and a resumable draft PR/spec pipeline flow.
  * Added new design-review workflow guidance (security and performance) and nightly benchmark runs with persisted results.
* **Bug Fixes**
  * Draft pull requests now correctly run only the appropriate checks and gate outcomes.
* **Documentation**
  * Added a change-spec template plus updated decision and contributor pipeline guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
