### PR TITLE
chore(ci): bootstrap integration/neo-monorepo gate coverage

### DIFF
--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -17,7 +17,10 @@ on:
     paths:
       - 'installer/**'
   pull_request:
-    branches: [main]
+    # Neo CLI monorepo migration (bootstrap): installer PRs targeting the
+    # staging integration branch get the same required installer CI as PRs to
+    # main. main behavior is unchanged — this only ADDS the integration base.
+    branches: [main, integration/neo-monorepo]
     paths:
       - 'installer/**'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      # Neo CLI monorepo migration (bootstrap): scoped PRs land on the staging
+      # integration branch first, so the required Test gate must run on them
+      # exactly as it does on main. `main` behavior is unchanged — this only
+      # ADDS the integration base. The branch is retired at the final merge.
+      - integration/neo-monorepo
     # ready_for_review is NOT a default activity type — without it, flipping
     # a draft to ready would never re-trigger the suite the guard skipped
     types: [opened, synchronize, reopened, ready_for_review]
@@ -58,7 +63,15 @@ jobs:
             echo "compiled=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          PATTERN='^(core/|testbed/|integrations/|nix/|\.github/workflows/|cabal\.project|flake\.nix|flake\.lock)'
+          # `neo/` is the future Neo CLI monorepo surface. It is listed HERE
+          # (not as its own job — the surface does not exist yet) so that a
+          # neo-only PR reads compiled=true and this required gate actually
+          # builds/tests it, instead of classifying compiled=false and letting
+          # ci-gate accept every skip (a green no-op gate that would falsely
+          # claim neo was tested). `installer/` is deliberately absent: it is a
+          # Rust component with its own required workflow (installer-ci.yml), so
+          # the cabal build here neither compiles nor tests it.
+          PATTERN='^(core/|testbed/|integrations/|neo/|nix/|\.github/workflows/|cabal\.project|flake\.nix|flake\.lock)'
           if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE "$PATTERN"; then
             echo "compiled=true" >> "$GITHUB_OUTPUT"
           else

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -15,6 +15,14 @@ Two contracts, both learned from real breakage:
      is schedule- AND dispatch-triggered, and must NOT push/commit, invoke the
      LLM miner, or write recommendations.
 
+  3. Neo CLI monorepo migration bootstrap (test.yml required gate): scoped PRs
+     stage on `integration/neo-monorepo` before the final merge to `main`, so
+     the required Test gate must (a) trigger on PRs whose base is that branch,
+     and (b) classify a neo/** change as compiled — otherwise a neo-only PR
+     reads compiled=false and ci-gate accepts every skip, a green no-op gate
+     that falsely claims neo was tested. This check freezes both invariants so
+     they cannot silently regress before neo is imported.
+
 Run:  ./dev workflow-check          CI: .github/workflows/checks.yml
       ./dev workflow-check --self-test   (doctor/CI)
 """
@@ -27,6 +35,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 
 UPLOAD_RE = re.compile(r"uses:\s*actions/upload-artifact")
+
+# The required merge gate + the base branches it must cover, and the surfaces
+# its changed-path classifier must treat as compiled. See contract 3 above.
+REQUIRED_GATE = "test.yml"
+GATE_BASE_BRANCHES = ("main", "integration/neo-monorepo")
+COMPILED_SURFACES = ("neo/",)
 
 
 def _indent(line):
@@ -144,6 +158,81 @@ def check_retrospect(name, text):
     return errs
 
 
+def pull_request_branches(text):
+    """The `branches:` list under the `on: pull_request:` block, or None if the
+    trigger has no branch filter (runs on every base). Handles both the block
+    form (`branches:` then `- x` lines) and the inline form (`branches: [x, y]`).
+    """
+    lines = text.splitlines()
+    for i, ln in enumerate(lines):
+        if not re.match(r"^\s+pull_request:\s*$", ln):
+            continue
+        base = _indent(ln)
+        j = i + 1
+        while j < len(lines):
+            cur = lines[j]
+            if cur.strip() and _indent(cur) <= base:
+                break  # left the pull_request block without finding branches:
+            bm = re.match(r"(\s*)branches:\s*(.*)$", cur)
+            if bm:
+                inline = bm.group(2).strip()
+                if inline.startswith("["):
+                    return [x.strip() for x in inline.strip("[]").split(",") if x.strip()]
+                if inline and inline not in ("|", ">", "|-", ">-"):
+                    return [inline]
+                bind = _indent(cur)
+                items = []
+                k = j + 1
+                while k < len(lines):
+                    nxt = lines[k]
+                    if nxt.strip() and _indent(nxt) <= bind:
+                        break
+                    dm = re.match(r"\s*-\s*(\S.*?)\s*$", nxt)
+                    if dm:
+                        items.append(dm.group(1).strip())
+                    k += 1
+                return items
+            j += 1
+        return None
+    return None
+
+
+def classifier_pattern(text):
+    """The changed-path classifier regex in the `changes` job (PATTERN='…')."""
+    m = re.search(r"PATTERN='([^']*)'", text)
+    return m.group(1) if m else None
+
+
+def check_required_gate(name, text):
+    """test.yml is the required merge gate. Two bootstrap invariants (contract 3):
+    it must trigger on PRs to every GATE_BASE_BRANCHES base, and its classifier
+    must count every COMPILED_SURFACES entry as compiled so neo work can't slip
+    through a no-op skip."""
+    errs = []
+    prb = pull_request_branches(text)
+    if prb is None:
+        errs.append(f"{name}: no `on: pull_request: branches:` filter — cannot "
+                    "confirm the required gate targets "
+                    f"{', '.join(GATE_BASE_BRANCHES)}")
+    else:
+        for req in GATE_BASE_BRANCHES:
+            if req not in prb:
+                errs.append(f"{name}: pull_request does not target '{req}' — the "
+                            "required Test gate would never run on PRs based on it")
+    pat = classifier_pattern(text)
+    if pat is None:
+        errs.append(f"{name}: no changed-path classifier (PATTERN='…') found — "
+                    "cannot confirm neo/** classifies as compiled")
+    else:
+        for surface in COMPILED_SURFACES:
+            if surface not in pat:
+                errs.append(
+                    f"{name}: changed-path classifier lacks '{surface}' — a "
+                    f"'{surface}'-only PR reads compiled=false and ci-gate accepts "
+                    "every skip (a green no-op gate that claims it was tested)")
+    return errs
+
+
 def run(root=WORKFLOWS):
     errs = []
     for wf in sorted(root.glob("*.yml")):
@@ -151,9 +240,14 @@ def run(root=WORKFLOWS):
         errs += check_hidden_artifacts(wf.name, text)
         if wf.name == "retrospect.yml":
             errs += check_retrospect(wf.name, text)
+        if wf.name == REQUIRED_GATE:
+            errs += check_required_gate(wf.name, text)
     retro = root / "retrospect.yml"
     if not retro.exists():
         errs.append("retrospect.yml is missing (deterministic learning-loop digest)")
+    gate = root / REQUIRED_GATE
+    if not gate.exists():
+        errs.append(f"{REQUIRED_GATE} is missing (the required Test merge gate)")
     return errs
 
 
@@ -218,6 +312,37 @@ def self_test():
           not check_retrospect("retrospect.yml",
                                "# it must not git push or write recommendations.jsonl\n"
                                + good_retro))
+
+    good_gate = (
+        "on:\n  pull_request:\n    branches:\n"
+        "      - main\n      - integration/neo-monorepo\n"
+        "    types: [opened]\n  push:\n    branches:\n      - main\n"
+        "jobs:\n  changes:\n    steps:\n      - run: |\n"
+        "          PATTERN='^(core/|testbed/|integrations/|neo/|nix/)'\n"
+    )
+    check("well-wired required gate passes", not check_required_gate("test.yml", good_gate))
+    check("pull_request branches extracted (block form)",
+          pull_request_branches(good_gate) == ["main", "integration/neo-monorepo"])
+    check("missing integration base is flagged",
+          check_required_gate("test.yml",
+                              good_gate.replace("      - integration/neo-monorepo\n", "")))
+    check("missing main base is flagged",
+          check_required_gate("test.yml", good_gate.replace("      - main\n", "")))
+    check("neo/ absent from classifier is flagged",
+          check_required_gate("test.yml", good_gate.replace("neo/|", "")))
+    check("no pull_request branches filter is flagged",
+          check_required_gate("test.yml",
+                              "on:\n  pull_request:\n    types: [opened]\n"
+                              "jobs:\n  changes:\n    steps:\n"
+                              "      - run: PATTERN='^(neo/)'\n"))
+    inline_gate = (
+        "on:\n  pull_request:\n    branches: [main, integration/neo-monorepo]\n"
+        "    paths:\n      - 'x/**'\n"
+    )
+    check("pull_request branches extracted (inline form)",
+          pull_request_branches(inline_gate) == ["main", "integration/neo-monorepo"])
+    check("push branches are not mistaken for pull_request branches",
+          pull_request_branches("on:\n  push:\n    branches:\n      - main\n") is None)
 
     print("workflow-check: self-test", "OK" if ok else "FAILED")
     return 0 if ok else 1


### PR DESCRIPTION
## PR 0 — Neo CLI monorepo migration bootstrap

Bootstraps CI so future scoped PRs targeting `integration/neo-monorepo` run the
same required checks as PRs to `main`. **`main` behavior is unchanged**; the
integration branch is retired at the final integration PR.

### What changed
- **`.github/workflows/test.yml`** (the required Test gate)
  - `pull_request.branches`: added `integration/neo-monorepo` alongside `main`, so
    the required gate runs on integration PRs exactly as on main.
  - `changes` job classifier: added `neo/` to the compiled-change `PATTERN`. A
    neo-only PR now reads `compiled=true`, so `ci-gate` builds/tests it instead of
    accepting every skip as a green no-op. **No neo jobs added** — the surface
    does not exist yet; this only classifies it.
  - `installer/` deliberately **not** added to this classifier: it is a Rust
    component with its own required workflow, and `cabal build all` neither
    compiles nor tests it (would falsely claim installer coverage).
- **`.github/workflows/installer-ci.yml`**: extended the `pull_request` base
  filter to `[main, integration/neo-monorepo]` so installer PRs to the integration
  branch get the same required installer CI.
- **`scripts/workflow-check`**: added a static regression check (+ self-tests,
  run by `./dev doctor` and the `checks.yml` doctor job) that freezes both
  invariants — the required gate targets `main` + `integration/neo-monorepo`, and
  its classifier counts `neo/**` as compiled — so they cannot silently regress.

### Deliberately out of scope
No neo import, no skills, no product-code changes, no broadened automation. Push
filters untouched — neo is not claimed as tested before import.

### Verification (local)
- `./dev workflow-check` → OK (its real run proves the actual `test.yml` satisfies both invariants)
- `./dev workflow-check --self-test` → OK (8 new cases)
- `./dev doctor` → OK
- `git diff --check` → clean

### CI on this PR
Because GitHub evaluates the `pull_request` trigger config from the merged
result, the new base filter takes effect on this PR itself: the required **Test**
gate triggered (`changes` classifier + build/test), the `checks.yml` **doctor**
job (which runs `workflow-check`) passed, and the other governance checks
(spec, expectation, codemap, adr, lint) are running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)