### PR TITLE
⚡ Performance: Use `Array.isEmpty` instead of `length == 0`

### DIFF
--- a/integrations/Integration/Agent/Internal.hs
+++ b/integrations/Integration/Agent/Internal.hs
@@ -210,7 +210,7 @@ executeAgent ::
   Request command ->
   Task Integration.IntegrationError (Maybe Integration.CommandPayload)
 executeAgent ctx agentRequest = do
-  case Array.length agentRequest.tools == 0 of
+  case Array.isEmpty agentRequest.tools of
     True -> do
       let errorCmd = agentRequest.onError "Agent.agent: tools list is empty"
       let payload = Integration.makeCommandPayload errorCmd


### PR DESCRIPTION
💡 **What:** The optimization implemented involves refactoring `executeAgent` inside `integrations/Integration/Agent/Internal.hs` to use `Array.isEmpty agentRequest.tools` instead of checking if `Array.length agentRequest.tools == 0`.
🎯 **Why:** The performance problem it solves is avoiding O(N) length computations to check for array emptiness, an anti-pattern in functional programming. While in NeoHaskell arrays are backed by standard Data.Vector where `length` is O(1), the use of `isEmpty` brings semantic clarity, matches NeoHaskell's coding convention ("prioritize using `Array.isEmpty` over checking if `Array.length` equals zero for O(1) performance and idiomatic clarity"), and guards against regressions if the array backend representation is ever swapped out for a different underlying collection.
📊 **Measured Improvement:** Since `Array` is currently backed by `Data.Vector.Vector`, both `length` and `null/isEmpty` calls execute in O(1) time. As such, benchmark results between checking `length == 0` versus `isEmpty` show an unmeasurably small difference for a typical sized Array, lost in the noise. This change improves the semantic guarantees of the code rather than providing an empirical speedup today.

---
*PR created automatically by Jules for task [11996670682601042295](https://jules.google.com/task/11996670682601042295) started by @NickSeagull*