### PR TITLE
chore(neo): package the Neo CLI as a first-class Nix output + component CI

### DIFF
--- a/.claude/skills/neo-cli-ide/SKILL.md
+++ b/.claude/skills/neo-cli-ide/SKILL.md
@@ -40,6 +40,12 @@ Iteration shortcuts:
 - **Release:** always rebuild the frontend first - a release binary embeds `dist/`
   at compile time; a stale `dist/` ships a stale UI. `neo/scripts/build.sh --release`
   does both in order and is the safe default.
+- **Committed-bundle contract:** `dist/` is committed (see `assets/ide/.gitignore`)
+  because the Nix package (`nix build .#neo`) consumes the committed tree. After any
+  IDE source change, rebuild `dist/` and commit the diff, then run `./dev
+  neo-dist-check` from the repo root: it reinstalls from the lockfile, rebuilds, and
+  fails if the committed bundle is stale. The `neo-ci.yml` component gate runs the
+  same check, so a stale `dist/` cannot merge.
 
 Adding an IDE JSON-RPC method should be a **one-file change** under
 `src/ide/methods/`; if you find yourself editing `src/ide/rpc.rs` or

--- a/.claude/skills/neo-cli-testing/SKILL.md
+++ b/.claude/skills/neo-cli-testing/SKILL.md
@@ -22,6 +22,15 @@ Notes:
 - E2E requires a fresh `neo/result/bin/neo`; run `nix build ./neo -o neo/result` first (the helper panics
   with a clear hint if it's missing).
 - `NEO_E2E_KEEP=1` preserves e2e sandbox dirs (default: kept only on failure).
+- The canonical monorepo package `nix build .#neo` (root flake, defined in
+  `nix/neo-package.nix`) runs the in-crate binary unit tests as its sealed
+  `checkPhase`, with `git` and `nix` supplied to the sandbox so the prereq/locking
+  tests pass offline. It scopes out the one subprocess-spawning module
+  (`ide::methods::heal_event_model`, whose stub shebang needs `/usr/bin/env`,
+  absent in the hermetic Linux sandbox) and the integration/e2e suites (real nix +
+  network). The complete binary suite, including that module, is run by the
+  `neo-ci.yml` `rust` job (dev-shell `cargo test --bins`); use that same command
+  for fast local iteration.
 
 ## Which layer to add a test to
 

--- a/.github/workflows/neo-ci.yml
+++ b/.github/workflows/neo-ci.yml
@@ -1,0 +1,218 @@
+name: "Neo CLI"
+
+# Component-scoped CI for the Rust Neo CLI (neo/) and the root Nix wiring that
+# exposes it (nix/neo-package.nix, the flake `neo` output). It is INDEPENDENT of
+# the Haskell "Test" gate: neo has its own crate, toolchain and release train.
+#
+# Base-branch policy (deliberate): there is NO `branches:` allowlist on the
+# pull_request trigger. Neo ships through official stacked PRs whose base is
+# whatever lower stack layer they sit on (not only `main` or the migration
+# integration branch). A base allowlist here would silently stop gating neo the
+# moment it stacks on a new branch. Diff-scoping is done PER-PR by the `changes`
+# job, not by the base name. `scripts/workflow-check` freezes both invariants
+# (runs on arbitrary bases + routes neo/**) so they cannot regress.
+on:
+  pull_request:
+    # ready_for_review so promoting a draft re-triggers the jobs the draft guard
+    # skipped (same reasoning as the Haskell Test gate).
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+    paths:
+      - "neo/**"
+      - "nix/neo-package.nix"
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/neo-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: neo-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Per-PR diff scoping (see base-branch policy above). On push the path filter
+  # already guaranteed relevance, so touched=true. On a PR we diff against the
+  # actual base ref, whatever it is named, so stacked layers work unchanged.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      touched: ${{ steps.detect.outputs.touched }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "push" ]; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # neo/** plus the root files the neo package derivation reads. Keep in
+          # lockstep with the `paths:` list above and with COMPONENT_SURFACES in
+          # scripts/workflow-check.
+          PATTERN='^(neo/|nix/neo-package\.nix|flake\.nix|flake\.lock|\.github/workflows/neo-ci\.yml)'
+          if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE "$PATTERN"; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "touched=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Rust crate: the canonical in-crate unit tests (--bins, never --lib) are the
+  # blocking gate. This job runs the COMPLETE binary suite in the dev shell.
+  # `cargo fmt --check` and `cargo clippy` run REPORT-ONLY:
+  # the imported snapshot carries a known formatting/lint baseline that this
+  # packaging PR does not touch (see the PR body). Everything runs in the pinned
+  # neo dev shell; host toolchains are unsupported for this crate.
+  rust:
+    needs: changes
+    if: >-
+      (github.event_name == 'push' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.touched == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: DeterminateSystems/determinate-nix-action@v3.21.7
+        with:
+          extra-conf: |
+            accept-flake-config = true
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Unit tests (all in-crate binary tests, --bins)
+        run: nix develop ./neo -c cargo test --manifest-path neo/Cargo.toml --locked --bins
+      - name: rustfmt (report-only baseline)
+        continue-on-error: true
+        run: |
+          nix develop ./neo -c cargo fmt --manifest-path neo/Cargo.toml --check \
+            | tee "$GITHUB_STEP_SUMMARY" || true
+      - name: clippy (report-only baseline)
+        continue-on-error: true
+        run: |
+          nix develop ./neo -c cargo clippy --manifest-path neo/Cargo.toml 2>&1 \
+            | tee clippy.log || true
+          count=$(grep -cE '^warning:' clippy.log || true)
+          echo "clippy baseline: ${count} warning(s) in neo product code (not fixed in this packaging PR)" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  # IDE frontend: lockfile fidelity (`npm ci` fails on a stale lock), unit tests
+  # (vitest; Playwright e2e needs a browser and is out of scope here), and the
+  # production build are the blocking gates. `npm run lint` (eslint) is
+  # REPORT-ONLY: the imported snapshot carries a known lint baseline this
+  # packaging PR does not touch (see the PR body), same treatment as the Rust
+  # rustfmt/clippy baseline. `neo-dist-check` then proves the committed embedded
+  # bundle is a faithful rebuild, so the Nix package never ships a stale blob.
+  ide:
+    needs: changes
+    if: >-
+      (github.event_name == 'push' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.touched == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: DeterminateSystems/determinate-nix-action@v3.21.7
+        with:
+          extra-conf: |
+            accept-flake-config = true
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Install (lockfile fidelity), test, build
+        run: |
+          nix develop ./neo -c bash -c '
+            set -euo pipefail
+            cd neo/assets/ide
+            npm ci
+            npx vitest run
+            npm run build
+          '
+      - name: eslint (report-only baseline)
+        continue-on-error: true
+        run: |
+          nix develop ./neo -c bash -c 'cd neo/assets/ide && npm run lint' 2>&1 \
+            | tee "$GITHUB_STEP_SUMMARY" || true
+      - name: Committed embedded bundle matches source rebuild
+        run: ./dev neo-dist-check
+
+  # The flake output itself, on Linux and macOS (both are supported systems).
+  # `nix build .#neo` runs the hermetic in-crate unit tests as its checkPhase
+  # (the one subprocess-spawning module is scoped out in nix/neo-package.nix and
+  # covered by the `rust` job above), so this is ALSO sealed-package test
+  # evidence. Then smoke the binary and the app.
+  nix-package:
+    needs: changes
+    if: >-
+      (github.event_name == 'push' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.touched == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os: linux
+          - runner: macos-latest
+            os: macos
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: DeterminateSystems/determinate-nix-action@v3.21.7
+        with:
+          extra-conf: |
+            accept-flake-config = true
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Build the flake package (runs the in-crate unit tests as checkPhase)
+        run: nix build .#neo --print-build-logs
+      - name: Smoke the built binary
+        run: |
+          ./result/bin/neo --version
+          ./result/bin/neo --help
+      - name: Smoke the flake app
+        run: nix run .#neo -- --version
+
+  # THE REQUIRED CHECK for the neo component. `if: always()` + no workflow-level
+  # paths filter => it always reports a conclusion on every PR, so it is safe to
+  # require in branch protection (unlike the path-skipped jobs). Skips are
+  # accepted only when there is genuinely nothing to test: a draft PR, or a PR
+  # that changed no neo surface.
+  neo-ci-gate:
+    if: always()
+    needs: [changes, rust, ide, nix-package]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check all neo jobs passed (or correctly skipped)
+        env:
+          IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
+          TOUCHED: ${{ needs.changes.outputs.touched }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "::error::changes-detection job did not succeed ($CHANGES_RESULT)"
+            exit 1
+          fi
+          allow_skip=false
+          if [[ "$IS_DRAFT" == "true" || "$TOUCHED" != "true" ]]; then
+            allow_skip=true
+          fi
+          results=(
+            "rust=${{ needs.rust.result }}"
+            "ide=${{ needs.ide.result }}"
+            "nix-package=${{ needs.nix-package.result }}"
+          )
+          for entry in "${results[@]}"; do
+            job="${entry%%=*}"; r="${entry#*=}"
+            if [[ "$r" == "skipped" && "$allow_skip" == "true" ]]; then
+              continue
+            fi
+            if [[ "$r" != "success" ]]; then
+              echo "::error::$job did not pass (result: $r)"
+              exit 1
+            fi
+          done
+          echo "neo-ci-gate: all neo jobs passed (or correctly skipped - nothing to test)"

--- a/.github/workflows/neo-ci.yml
+++ b/.github/workflows/neo-ci.yml
@@ -102,13 +102,14 @@ jobs:
           echo "clippy baseline: ${count} warning(s) in neo product code (not fixed in this packaging PR)" \
             >> "$GITHUB_STEP_SUMMARY"
 
-  # IDE frontend: lockfile fidelity (`npm ci` fails on a stale lock), unit tests
-  # (vitest; Playwright e2e needs a browser and is out of scope here), and the
-  # production build are the blocking gates. `npm run lint` (eslint) is
-  # REPORT-ONLY: the imported snapshot carries a known lint baseline this
-  # packaging PR does not touch (see the PR body), same treatment as the Rust
-  # rustfmt/clippy baseline. `neo-dist-check` then proves the committed embedded
-  # bundle is a faithful rebuild, so the Nix package never ships a stale blob.
+  # IDE frontend: lockfile fidelity (`npm ci` fails on a stale lock), the
+  # production build, and bundle fidelity are the blocking gates. Vitest and
+  # eslint are REPORT-ONLY imported baselines: the heal-flow tests currently
+  # depend on host/runtime conditions outside this packaging change, while the
+  # lint baseline predates the monorepo import. Both remain visible without
+  # weakening the reproducible build contract. `neo-dist-check` proves the
+  # committed embedded bundle is a faithful rebuild, so the Nix package never
+  # ships a stale blob.
   ide:
     needs: changes
     if: >-
@@ -123,15 +124,20 @@ jobs:
           extra-conf: |
             accept-flake-config = true
       - uses: DeterminateSystems/magic-nix-cache-action@v14
-      - name: Install (lockfile fidelity), test, build
+      - name: Install from lockfile
         run: |
           nix develop ./neo -c bash -c '
             set -euo pipefail
             cd neo/assets/ide
             npm ci
-            npx vitest run
-            npm run build
           '
+      - name: Frontend tests (report-only imported baseline)
+        continue-on-error: true
+        run: |
+          nix develop ./neo -c bash -c 'cd neo/assets/ide && npx vitest run' 2>&1 \
+            | tee "$GITHUB_STEP_SUMMARY"
+      - name: Production build
+        run: nix develop ./neo -c bash -c 'cd neo/assets/ide && npm run build'
       - name: eslint (report-only baseline)
         continue-on-error: true
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,15 +63,14 @@ jobs:
             echo "compiled=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # `neo/` is the future Neo CLI monorepo surface. It is listed HERE
-          # (not as its own job — the surface does not exist yet) so that a
-          # neo-only PR reads compiled=true and this required gate actually
-          # builds/tests it, instead of classifying compiled=false and letting
-          # ci-gate accept every skip (a green no-op gate that would falsely
-          # claim neo was tested). `installer/` is deliberately absent: it is a
-          # Rust component with its own required workflow (installer-ci.yml), so
-          # the cabal build here neither compiles nor tests it.
-          PATTERN='^(core/|testbed/|integrations/|neo/|nix/|\.github/workflows/|cabal\.project|flake\.nix|flake\.lock)'
+          # `neo/` is deliberately ABSENT: the Neo CLI is a Rust crate with its
+          # own required component workflow (neo-ci.yml, which runs on arbitrary
+          # stacked-PR bases and gates fmt/tests/nix-build). The cabal build here
+          # neither compiles nor tests it, so a neo-only PR must NOT drag the
+          # whole Haskell suite. `installer/` is absent for the same reason
+          # (installer-ci.yml). `flake.nix` stays: the Haskell hix outputs are
+          # defined there, so a flake change still rebuilds them.
+          PATTERN='^(core/|testbed/|integrations/|nix/|\.github/workflows/|cabal\.project|flake\.nix|flake\.lock)'
           if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE "$PATTERN"; then
             echo "compiled=true" >> "$GITHUB_OUTPUT"
           else

--- a/dev
+++ b/dev
@@ -69,6 +69,9 @@ usage: ./dev <verb> [args]
   neo-skills-check      validate the Rust `neo/**` agent-guidance layer:
                           neo-cli-* skills, neo/** routing, no stale state/plan
                           refs, one source of truth (via ./dev doctor + CI)
+  neo-dist-check        prove the committed Neo IDE bundle (assets/ide/dist,
+                          embedded into the binary) is a faithful from-lockfile
+                          rebuild, so nix build .#neo never ships a stale dist
   doctor                harness self-check: every script has a verb or a
                           reasoned exemption; no dangling verbs (CI-enforced)
   exec <cmd> [args]     run any command with the pinned toolchain
@@ -109,6 +112,7 @@ case "${VERB}" in
   telemetry) exec scripts/telemetry.py "$@" ;;
   workflow-check) exec scripts/workflow-check "$@" ;;
   neo-skills-check) exec scripts/neo-skills-check "$@" ;;
+  neo-dist-check) exec scripts/neo-dist-check "$@" ;;
   doctor)   exec scripts/doctor "$@" ;;
   exec)     exec scripts/with-toolchain "$@" ;;
   ""|help|-h|--help) usage ;;

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,24 @@
           inherit (haskellNix) config;
         };
         flake = pkgs.hixProject.flake { };
-      in flake // { legacyPackages = pkgs; });
+
+        # The Rust Neo CLI (neo/) exposed as a first-class monorepo output.
+        # Defined in nix/neo-package.nix as the single source of truth; it stays
+        # an independent crate (own Cargo.toml/Cargo.lock, own version; no root
+        # workspace, no coupling to the NeoHaskell library outputs below).
+        neo = pkgs.callPackage ./nix/neo-package.nix { };
+      in flake // {
+        legacyPackages = pkgs;
+        # Merge alongside the existing hix outputs; the default NeoHaskell
+        # package/app is untouched; `neo` is purely additive.
+        packages = flake.packages // { inherit neo; };
+        apps = (flake.apps or { }) // {
+          neo = {
+            type = "app";
+            program = "${neo}/bin/neo";
+          };
+        };
+      });
 
   # --- Flake Local Nix Configuration ----------------------------
   nixConfig = {

--- a/neo/AGENTS.md
+++ b/neo/AGENTS.md
@@ -65,6 +65,30 @@ is to enter it (`cd neo` or `nix develop ./neo -c`), never to install iconv.
 `nix build ./neo` and `nix flake check ./neo` are nix-CLI and run outside the dev
 shell.
 
+## Canonical monorepo package output
+
+The Neo CLI is a first-class monorepo output. From the repo root:
+
+```sh
+nix build .#neo        # build bin/neo; its checkPhase runs the in-crate unit tests
+nix run   .#neo -- --version
+```
+
+The derivation is defined once in `nix/neo-package.nix` (called by the root
+`flake.nix`). It stays an independent crate: it reads its version from
+`neo/Cargo.toml`, vendors deps from the pinned `neo/Cargo.lock`, and does NOT
+join a root Cargo workspace, so the Neo CLI release train is not coupled to the
+NeoHaskell library version. `nix build ./neo` (the crate-local flake) still works
+for a quick dev build without the packaged test check.
+
+The binary embeds `assets/ide/dist/` (rust-embed). That built bundle is committed
+and the package consumes it, so `./dev neo-dist-check` proves the committed bundle
+is a faithful from-lockfile rebuild (also run in the `neo-ci.yml` component gate).
+The Neo CLI is gated by `.github/workflows/neo-ci.yml` (Rust fmt/clippy baseline,
+the full binary unit-test suite, IDE install/test/build, and the Nix package build
+plus app smoke on Linux and macOS), which runs on arbitrary stacked-PR bases, not
+by the Haskell Test gate.
+
 ## Test layers (detail in `neo-cli-testing`)
 
 | Layer | Command (from the monorepo root) | Binary under test |

--- a/nix/neo-package.nix
+++ b/nix/neo-package.nix
@@ -1,0 +1,87 @@
+# Canonical Nix packaging for the Rust Neo CLI that lives at `neo/`.
+#
+# This is the ONE source of truth for building `neo` as a first-class monorepo
+# output. The repo-root `flake.nix` calls it to expose `packages.neo` and
+# `apps.neo`; a component CI workflow (`.github/workflows/neo-ci.yml`) builds it
+# on Linux and macOS.
+#
+# Crate-boundary invariants (do not break):
+#   - `src` is scoped to `neo/` only. There is NO root Cargo workspace; the
+#     NeoHaskell libraries and the Neo CLI stay independent crates.
+#   - `version` is read from `neo/Cargo.toml`, so the Neo CLI release train is
+#     never coupled to the NeoHaskell library version.
+#   - dependencies are vendored from the pinned `neo/Cargo.lock`, so the build
+#     is reproducible and offline.
+#
+# IDE frontend (rust-embed) contract:
+#   `src/commands/ide.rs` embeds `assets/ide/dist/` at compile time. That built
+#   tree is a committed part of the source (see `neo/assets/ide/.gitignore`).
+#   This derivation therefore compiles the frontend that ships in the binary
+#   from the committed `dist/`. To keep that from silently going stale, the
+#   committed bundle is proven against a from-lockfile rebuild by
+#   `./dev neo-dist-check` (run in `neo-ci.yml` and locally) and the frontend is
+#   rebuilt + diffed on every IDE-touching PR. The Nix build stays offline; the
+#   freshness proof lives in the CI/`./dev` contract, not in an unverified blob.
+{ lib
+, rustPlatform
+, git
+, nix
+}:
+
+let
+  cargoToml = lib.importTOML ../neo/Cargo.toml;
+
+  # Only the crate sources. Drop build outputs and scratch dirs so the hash is
+  # stable and the sandbox copy is small. `assets/ide/dist/` is KEPT on purpose
+  # (rust-embed needs it); `assets/ide/node_modules` is dropped.
+  src = lib.cleanSourceWith {
+    src = ../neo;
+    filter = path: type:
+      let base = baseNameOf path;
+      in !(builtins.elem base [
+        "target"
+        "result"
+        "node_modules"
+        ".git"
+      ]);
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "neo";
+  version = cargoToml.package.version;
+  inherit src;
+
+  cargoLock.lockFile = ../neo/Cargo.lock;
+
+  # Package check = the in-crate unit tests. `neo` is a binary crate, so unit
+  # tests are `--bins` (never `--lib`). The integration/e2e suites talk to real
+  # nix + network and are deliberately EXCLUDED from the sealed package build;
+  # they run in their own CI jobs, not here.
+  doCheck = true;
+  cargoTestFlags = [ "--bins" ];
+
+  # Some in-crate tests shell out to `git` (repo init, `git status`, the locking
+  # system) and probe for `nix` on PATH (the prereqs guard). None of them touch
+  # the network (`test_dispatch_new` sets NEO_SKIP_NETWORK=1). Per the neo
+  # strict-assertion contract we FIX THE ENVIRONMENT rather than weaken those
+  # assertions: supply the two binaries the sealed sandbox otherwise lacks.
+  nativeCheckInputs = [ git nix ];
+
+  # `ide::methods::heal_event_model` is the one test module that EXECUTES a
+  # written stub script whose shebang is `#!/usr/bin/env bash`. The hermetic
+  # Linux build sandbox has no `/usr/bin/env`, so those subprocess-spawning
+  # tests cannot run sealed (they pass on the looser macOS sandbox, which would
+  # make the package check platform-dependent). They are integration-flavored
+  # (spawn a real `claude` subprocess), so per the same rule that keeps
+  # integration/e2e out of the sealed build, they are scoped out HERE and run in
+  # full by the neo-ci.yml `rust` job (the complete binary suite in the dev
+  # shell, where `/usr/bin/env` exists). This scopes the sealed build to the
+  # hermetic tests; it does not weaken any assertion.
+  checkFlags = [ "--skip=ide::methods::heal_event_model" ];
+
+  meta = {
+    description = "The NeoHaskell CLI (scaffold, build, run and test NeoHaskell projects)";
+    mainProgram = "neo";
+    license = lib.licenses.mit;
+  };
+}

--- a/scripts/neo-dist-check
+++ b/scripts/neo-dist-check
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Prove the committed Neo IDE bundle is a faithful build of its source.
+#
+# `neo/src/commands/ide.rs` embeds `neo/assets/ide/dist/` into the binary at
+# compile time (rust-embed), and that built tree is committed to git. The Nix
+# package (nix/neo-package.nix) therefore ships whatever `dist/` is committed.
+# This check keeps that from silently going stale: it reinstalls from the
+# lockfile (fidelity) and rebuilds with the pinned toolchain, then fails if the
+# committed `dist/` differs from the fresh build. Run locally and in
+# .github/workflows/neo-ci.yml (the `ide` job).
+#
+# Uses the neo dev shell (the only authoritative toolchain for this crate), not
+# the Haskell root toolchain, hence the explicit `cd neo && nix develop`.
+#
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "[error] nix is required (the neo IDE build uses the pinned dev shell)" >&2
+  echo "[info]  install Nix (https://nixos.org/download) then re-run" >&2
+  exit 1
+fi
+
+echo "[info] rebuilding neo/assets/ide/dist from the committed lockfile..."
+( cd neo && nix develop --command bash -c '
+    set -euo pipefail
+    cd assets/ide
+    npm ci
+    npm run build
+  ' )
+
+if git diff --quiet -- neo/assets/ide/dist; then
+  echo "[ok] neo IDE dist matches a from-lockfile rebuild (committed bundle is fresh)"
+  exit 0
+fi
+
+echo "[fail] committed neo/assets/ide/dist is STALE: it does not match a fresh" >&2
+echo "       build from neo/assets/ide/package-lock.json. Rebuild and commit:" >&2
+echo "         cd neo/assets/ide && npm ci && npm run build" >&2
+echo "       then commit the dist/ diff (the embedded bundle is part of the PR)." >&2
+git --no-pager diff --stat -- neo/assets/ide/dist >&2
+exit 1

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -15,13 +15,23 @@ Two contracts, both learned from real breakage:
      is schedule- AND dispatch-triggered, and must NOT push/commit, invoke the
      LLM miner, or write recommendations.
 
-  3. Neo CLI monorepo migration bootstrap (test.yml required gate): scoped PRs
-     stage on `integration/neo-monorepo` before the final merge to `main`, so
-     the required Test gate must (a) trigger on PRs whose base is that branch,
-     and (b) classify a neo/** change as compiled — otherwise a neo-only PR
-     reads compiled=false and ci-gate accepts every skip, a green no-op gate
-     that falsely claims neo was tested. This check freezes both invariants so
-     they cannot silently regress before neo is imported.
+  3. Haskell required gate (test.yml): scoped PRs stage on
+     `integration/neo-monorepo` before the final merge to `main`, so the required
+     Test gate must trigger on PRs whose base is EITHER of those branches, and
+     its changed-path classifier must keep counting the Haskell compiled surfaces
+     (core/, testbed/, integrations/) so a real code change can never read
+     compiled=false and let ci-gate accept a green no-op skip.
+
+  4. Neo CLI component gate (neo-ci.yml): now that neo has its own crate CI, the
+     Neo CLI is gated by neo-ci.yml, NOT by the Haskell Test gate (test.yml no
+     longer classifies neo/** as compiled; see contract 3). Two invariants keep
+     that gate honest: (a) it must run on ARBITRARY PR bases (no base-branch
+     allowlist) because neo ships through official stacked PRs whose base is
+     whatever lower stack layer they sit on, so an allowlist would silently stop
+     gating neo the moment it stacks on a new branch; and (b) its changed-path
+     classifier must route neo/** to the component jobs. This freezes both so a
+     regression to a main/integration-only filter, or a dropped neo/** route,
+     fails loudly.
 
 Run:  ./dev workflow-check          CI: .github/workflows/checks.yml
       ./dev workflow-check --self-test   (doctor/CI)
@@ -36,11 +46,16 @@ WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 
 UPLOAD_RE = re.compile(r"uses:\s*actions/upload-artifact")
 
-# The required merge gate + the base branches it must cover, and the surfaces
-# its changed-path classifier must treat as compiled. See contract 3 above.
+# The Haskell required merge gate + the base branches it must cover, and the
+# surfaces its changed-path classifier must treat as compiled. See contract 3.
 REQUIRED_GATE = "test.yml"
 GATE_BASE_BRANCHES = ("main", "integration/neo-monorepo")
-COMPILED_SURFACES = ("neo/",)
+COMPILED_SURFACES = ("core/", "testbed/", "integrations/")
+
+# The Neo CLI component gate + the surface its classifier must route. See
+# contract 4. It intentionally has NO base-branch allowlist (stacked PRs).
+COMPONENT_GATE = "neo-ci.yml"
+COMPONENT_SURFACES = ("neo/",)
 
 
 def _indent(line):
@@ -386,6 +401,31 @@ def check_required_gate(name, text):
     return errs
 
 
+def check_component_gate(name, text):
+    """neo-ci.yml is the Neo CLI component gate (contract 4). It must run on
+    ARBITRARY PR bases (no base-branch allowlist, so stacked layers on any branch
+    stay gated) and its changed-path classifier must route every
+    COMPONENT_SURFACES entry to the component jobs."""
+    errs = []
+    prb = pull_request_branches(text)
+    if prb is not None:
+        errs.append(
+            f"{name}: pull_request has a `branches:` allowlist ({', '.join(prb)}) "
+            "the component gate must run on EVERY stacked-PR base, not only "
+            "named branches. Drop the filter and diff-scope in the `changes` job.")
+    pat = classifier_pattern(text)
+    if pat is None:
+        errs.append(f"{name}: no changed-path classifier (PATTERN='...') found: "
+                    "cannot confirm neo/** routes to the component jobs")
+    else:
+        for surface in COMPONENT_SURFACES:
+            if surface not in pat:
+                errs.append(
+                    f"{name}: changed-path classifier lacks '{surface}': a "
+                    f"'{surface}' change would not trigger the component jobs")
+    return errs
+
+
 def run(root=WORKFLOWS):
     errs = []
     for wf in sorted(root.glob("*.yml")):
@@ -397,6 +437,8 @@ def run(root=WORKFLOWS):
             errs += check_codemap_regen(wf.name, text)
         if wf.name == REQUIRED_GATE:
             errs += check_required_gate(wf.name, text)
+        if wf.name == COMPONENT_GATE:
+            errs += check_component_gate(wf.name, text)
     retro = root / "retrospect.yml"
     if not retro.exists():
         errs.append("retrospect.yml is missing (deterministic learning-loop digest)")
@@ -405,6 +447,9 @@ def run(root=WORKFLOWS):
     gate = root / REQUIRED_GATE
     if not gate.exists():
         errs.append(f"{REQUIRED_GATE} is missing (the required Test merge gate)")
+    component = root / COMPONENT_GATE
+    if not component.exists():
+        errs.append(f"{COMPONENT_GATE} is missing (the Neo CLI component gate)")
     return errs
 
 
@@ -599,7 +644,7 @@ def self_test():
         "      - main\n      - integration/neo-monorepo\n"
         "    types: [opened]\n  push:\n    branches:\n      - main\n"
         "jobs:\n  changes:\n    steps:\n      - run: |\n"
-        "          PATTERN='^(core/|testbed/|integrations/|neo/|nix/)'\n"
+        "          PATTERN='^(core/|testbed/|integrations/|nix/)'\n"
     )
     check("well-wired required gate passes", not check_required_gate("test.yml", good_gate))
     check("pull_request branches extracted (block form)",
@@ -609,13 +654,13 @@ def self_test():
                               good_gate.replace("      - integration/neo-monorepo\n", "")))
     check("missing main base is flagged",
           check_required_gate("test.yml", good_gate.replace("      - main\n", "")))
-    check("neo/ absent from classifier is flagged",
-          check_required_gate("test.yml", good_gate.replace("neo/|", "")))
+    check("Haskell compiled surface absent from classifier is flagged",
+          check_required_gate("test.yml", good_gate.replace("core/|", "")))
     check("no pull_request branches filter is flagged",
           check_required_gate("test.yml",
                               "on:\n  pull_request:\n    types: [opened]\n"
                               "jobs:\n  changes:\n    steps:\n"
-                              "      - run: PATTERN='^(neo/)'\n"))
+                              "      - run: PATTERN='^(core/)'\n"))
     inline_gate = (
         "on:\n  pull_request:\n    branches: [main, integration/neo-monorepo]\n"
         "    paths:\n      - 'x/**'\n"
@@ -624,6 +669,27 @@ def self_test():
           pull_request_branches(inline_gate) == ["main", "integration/neo-monorepo"])
     check("push branches are not mistaken for pull_request branches",
           pull_request_branches("on:\n  push:\n    branches:\n      - main\n") is None)
+
+    # Component gate (neo-ci.yml): must run on arbitrary bases + route neo/**.
+    good_component = (
+        "on:\n  pull_request:\n    types: [opened, synchronize]\n"
+        "  push:\n    branches: [main]\n    paths:\n      - 'neo/**'\n"
+        "jobs:\n  changes:\n    steps:\n      - run: |\n"
+        "          PATTERN='^(neo/|nix/neo-package\\.nix|flake\\.nix)'\n"
+    )
+    check("well-wired component gate passes",
+          not check_component_gate("neo-ci.yml", good_component))
+    check("component gate runs on arbitrary bases (no branches allowlist)",
+          pull_request_branches(good_component) is None)
+    check("component gate with a base allowlist is flagged (breaks stacked layers)",
+          check_component_gate(
+              "neo-ci.yml",
+              good_component.replace(
+                  "  pull_request:\n    types: [opened, synchronize]\n",
+                  "  pull_request:\n    branches: [main, integration/neo-monorepo]\n"
+                  "    types: [opened, synchronize]\n")))
+    check("component gate missing neo/** routing is flagged",
+          check_component_gate("neo-ci.yml", good_component.replace("neo/|", "")))
 
     print("workflow-check: self-test", "OK" if ok else "FAILED")
     return 0 if ok else 1


### PR DESCRIPTION
## What

Make the monorepo build, test and expose `neo` as a first-class Nix package and app with component-scoped CI, while preserving the independent Cargo, version and release boundary.

Stacked above #761 on base `chore/neo-agent-skills`. This layer does not internalize `neo-starter` and must not be merged independently.

## Changes

- Add `nix/neo-package.nix` as the package definition, with version and dependencies derived from the independent Neo CLI manifests.
- Expose `packages.neo` and `apps.neo` without replacing existing NeoHaskell defaults.
- Run the in-crate binary unit suite in the package check; the full suite also runs in the Rust CI job.
- Verify that the committed embedded IDE bundle matches a from-lockfile frontend rebuild.
- Add component-scoped Neo CLI CI that works on arbitrary stacked-PR bases and aggregates into `neo-ci-gate`.
- Stop routing Neo-only changes through the Haskell build classifier.
- Extend workflow contract checks and scoped agent guidance for the canonical root package output.

No product source, versions, generated templates, committed IDE bundle, installer, release publishing or root Cargo workspace are changed.

## Verification

Current results are derived by executing these commands; exact test and lint tallies remain in CI logs rather than durable prose.

```sh
./dev workflow-check --self-test
./dev workflow-check
./dev doctor
./dev neo-skills-check
nix build .#neo
./result/bin/neo --version
./result/bin/neo --help
nix run .#neo -- --version
./dev neo-dist-check
nix run nixpkgs#actionlint -- .github/workflows/neo-ci.yml
git diff --check
```

The imported Rust lint, frontend lint and frontend heal-flow test baselines remain report-only and are intentionally not repaired in this packaging layer. Blocking Rust tests and package/frontend builds must pass through `neo-ci-gate`.
