### PR TITLE
feat(neo): internalize the project starter and embed it into `neo new`

### DIFF
--- a/.claude/skills/neo-cli-localizer/SKILL.md
+++ b/.claude/skills/neo-cli-localizer/SKILL.md
@@ -18,7 +18,7 @@ The `clap` command enum lives in `src/cli.rs`; each variant dispatches through
 
 | Command | Entry module | What it does |
 |---|---|---|
-| `neo new [name] [--library]` | `commands/new.rs` | Interactive interview -> scaffold from the `neo-starter` tarball |
+| `neo new [name] [--library]` | `commands/new.rs` | Interactive interview -> scaffold from the embedded `neo/starter/` template (`src/network.rs`) |
 | `neo build [--watch] [--skip-lock-check]` | `commands/build.rs` | Reconcile config -> `nix`/`cabal` build; `--watch` = GHCi hot-reload |
 | `neo run [--watch]` | `commands/run.rs` | Build then execute the app |
 | `neo test [--watch]` | `commands/test.rs` | Cabal unit tests then Hurl integration tests |
@@ -51,17 +51,24 @@ Global flags (`src/cli.rs`): `--verbose`, `--ci` (both `global = true`).
   `methods/*.rs`, `heal/*`, `sync.rs`, `validate.rs`) and `assets/ide/**` (the
   Vite/React frontend). See `neo-cli-ide`.
 - **Prereqs / env** - `src/prereqs.rs` (nix/git presence guards), `src/network.rs`
-  (`NEO_SKIP_NETWORK`), `src/config.rs`, `src/git.rs`.
+  (`NEO_SKIP_NETWORK`, the embedded `neo/starter/` template + `write_starter_template`),
+  `src/config.rs`, `src/git.rs`.
+
+## Internalized starter
+
+`neo new` scaffolds from the embedded `neo/starter/` template (rust-embed in
+`src/network.rs::write_starter_template`), not a network download. It is the source
+of truth for generation and is offline by construction. Fix generation/starter bugs
+in `neo/starter/`; provenance + exclusion policy in `neo/starter/IMPORT.md`.
 
 ## Cross-component correctness (monorepo governance)
 
 Neo generates NeoHaskell projects. The happy-path `build`/`run`/`test` scenarios
-depend on the **starter to upstream contract**: `neo new` tarballs
-`github.com/NeoHaskell/neo-starter@main`, then `neo build` locks the latest
-`neohaskell` `main`. When upstream renames/removes a module the starter imports,
-generated projects fail to compile. That is a real signal - fix `neo-starter`
-upstream; never mask or `#[ignore]` the failing scenario. Details in
-`neo/AGENTS.md` and `neo-cli-testing`.
+depend on the **starter to upstream contract**: `neo new` scaffolds from the
+embedded `neo/starter/`, then `neo build` locks the latest `neohaskell` `main`. When
+upstream renames/removes a module the starter imports, generated projects fail to
+compile. That is a real signal - fix `neo/starter/` in this monorepo; never mask or
+`#[ignore]` the failing scenario. Details in `neo/AGENTS.md` and `neo-cli-testing`.
 
 ## Scope rule
 

--- a/.claude/skills/neo-cli-testing/SKILL.md
+++ b/.claude/skills/neo-cli-testing/SKILL.md
@@ -47,18 +47,23 @@ Integration and e2e assume the environment an end user has: `nix`, `git`, networ
 and (for e2e) a `nix build`ed `result/bin/neo`. There are **no** `if success {…}
 else accept-missing-nix {…}` escape hatches - that pattern was deleted on
 2026-06-10. If a test fails because the env lacks a prereq, **fix the environment,
-never soften the assertion**. Refuse `NEO_SKIP_NETWORK=1` for integration/e2e - they
-are real-network on purpose; logic that needs stubbing belongs in unit tests.
+never soften the assertion**. Refuse `NEO_SKIP_NETWORK=1` for integration/e2e as a
+stubbing shortcut on a real-network happy path - that logic belongs in unit tests.
+The one legitimate use is the **offline-generation contract**: a test whose subject
+IS that `neo new` scaffolds a full project offline from the embedded `neo/starter/`
+(no download). There, `NEO_SKIP_NETWORK=1` is the assertion, not an escape hatch - it
+proves the packaged binary generates without a network. Those tests assert starter
+surfaces by presence, never by file count.
 
 ## Generated-project / Neo-on-Neo verification (cross-component gate)
 
 The `build` / `run` / `test` happy-path scenarios (integration + e2e) require the
 generated NeoHaskell project to actually compile. The two recurring breakages:
 
-1. **Starter-to-upstream drift.** `neo new` tarballs `neo-starter@main`; `neo build`
-   locks the latest `neohaskell` `main`. When upstream renames/removes a module the
-   starter imports, the generated project fails GHC compile. **Fix `neo-starter`
-   upstream and push** - do not touch the neo test.
+1. **Starter-to-upstream drift.** `neo new` scaffolds from the embedded
+   `neo/starter/` template; `neo build` locks the latest `neohaskell` `main`. When
+   upstream renames/removes a module the starter imports, the generated project fails
+   GHC compile. **Fix `neo/starter/` in this monorepo** - do not touch the neo test.
 2. **A transitive Haskell dep refusing to build under plain cabal** (historically
    `jose` needing native crypto paths from `haskell.nix`) - fix the templated
    `flake.nix`.

--- a/codemap/generate.py
+++ b/codemap/generate.py
@@ -173,8 +173,13 @@ def _tracked_hs():
             # artifacts that downstream checks then bless
             sys.exit(f"codemap: git ls-files failed (rc={proc.returncode}) "
                      "— refusing to generate from an empty file list")
+        # Exclude archived sources and the embedded generated-project template.
+        # The starter is consumer fixture content, not NeoHaskell implementation or
+        # repository usage evidence; counting it would skew API-hot rankings every
+        # time the template changes.
+        excluded_prefixes = ("docs/archive/", "neo/starter/")
         _TRACKED_CACHE = [f for f in proc.stdout.splitlines()
-                          if not f.startswith("docs/archive/")]
+                          if not f.startswith(excluded_prefixes)]
     return _TRACKED_CACHE
 
 

--- a/neo/AGENTS.md
+++ b/neo/AGENTS.md
@@ -105,17 +105,28 @@ integration/e2e. The strict-assertion contract holds: if a test fails because
 `nix`/`git`/network is missing, fix the environment, never weaken the assertion (no
 missing-prereq escape hatches).
 
+## Internalized starter (source of truth: `neo/starter/`)
+
+`neo new` scaffolds from the **internalized starter** at `neo/starter/`, embedded
+into the binary at compile time (rust-embed, `src/network.rs`). There is no runtime
+download: generation is offline and pinned to the exact monorepo revision the binary
+was built from. Fix generation/starter bugs in `neo/starter/`, never in an external
+repository. Provenance and the intentional-exclusion policy live in
+`neo/starter/IMPORT.md`; `./dev neo-skills-check` enforces both (no leaked VCS
+metadata/secrets/build artifacts, manifest present, load-bearing surfaces exist).
+
 ## Cross-component correctness gate
 
 Neo generates NeoHaskell projects. The `build`/`run`/`test` happy paths require the
 generated project to actually compile, which depends on the **starter to upstream
-contract**: `neo new` tarballs `github.com/NeoHaskell/neo-starter@main`, then `neo
-build` locks the latest `neohaskell` `main`. When upstream renames/removes a module
-the starter imports, generated projects fail GHC compile. That red bar is the
-intended signal: fix `neo-starter` upstream; never mask or `#[ignore]` it. A change
-that must move the CLI and its NeoHaskell counterpart together is an atomic
-cross-component change: use `neo-cli-localizer` for the Rust side and the NeoHaskell
-localizer for the matching lower/adjacent stack layer.
+contract**: `neo new` scaffolds from the embedded `neo/starter/`, then `neo build`
+locks the latest `neohaskell` `main`. When upstream renames/removes a module the
+starter imports, generated projects fail GHC compile. That red bar is the intended
+signal: fix `neo/starter/` in this monorepo; never mask or `#[ignore]` it. Because
+the starter is now in-repo, moving the starter and its NeoHaskell counterpart
+together is a single-repo atomic change across stack layers: use `neo-cli-localizer`
+for the Rust side and the NeoHaskell localizer for the matching lower/adjacent
+stack layer.
 
 ## Errors are LLM-actionable repair instructions (HARD invariant)
 

--- a/neo/Cargo.lock
+++ b/neo/Cargo.lock
@@ -1800,6 +1800,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,7 +2610,6 @@ dependencies = [
  "axum",
  "clap",
  "crossterm 0.28.1",
- "flate2",
  "futures-util",
  "gix",
  "insta",
@@ -2616,7 +2628,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3536,6 +3547,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
+ "globset",
  "mime_guess",
  "sha2",
  "walkdir",
@@ -3959,17 +3971,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -5099,16 +5100,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix 1.1.4",
-]
 
 [[package]]
 name = "yoke"

--- a/neo/Cargo.toml
+++ b/neo/Cargo.toml
@@ -27,7 +27,7 @@ axum = { version = "0.7", default-features = false, features = ["http1", "tokio"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 
 # Static asset embedding (for `neo ide`)
-rust-embed = { version = "8", features = ["mime-guess"] }
+rust-embed = { version = "8", features = ["mime-guess", "include-exclude"] }
 mime_guess = "2"
 
 # Serialization
@@ -59,9 +59,7 @@ regex = "1"
 # Templates
 minijinja = "2"
 
-# Archive
-flate2 = "1"
-tar = "0.4"
+# Temp dirs (test scaffolding, atomic clone/extract staging)
 tempfile = "3"
 
 # Git

--- a/neo/src/commands/new.rs
+++ b/neo/src/commands/new.rs
@@ -315,6 +315,25 @@ async fn do_scaffold(config: ProjectConfig) -> miette::Result<()> {
     std::fs::create_dir_all(&project_path)
         .map_err(|e| crate::errors::NeoError::io_at("creating the new project directory at", &project_path, e))?;
 
+    // Nothing existed at this path before this command. If any later scaffold,
+    // reconciliation, or git step fails, remove the partial project instead of
+    // leaving a directory that looks usable but is incomplete.
+    struct RemovePartialProject {
+        path: PathBuf,
+        armed: bool,
+    }
+    impl Drop for RemovePartialProject {
+        fn drop(&mut self) {
+            if self.armed {
+                let _ = std::fs::remove_dir_all(&self.path);
+            }
+        }
+    }
+    let mut cleanup = RemovePartialProject {
+        path: project_path.clone(),
+        armed: true,
+    };
+
     // Write neo.json
     let neo_json_path = project_path.join("neo.json");
     let config_json = serde_json::to_string_pretty(&config)
@@ -326,8 +345,9 @@ async fn do_scaffold(config: ProjectConfig) -> miette::Result<()> {
     std::fs::write(&neo_json_path, config_json.as_bytes())
         .map_err(|e| crate::errors::NeoError::io_at("writing initial `neo.json` to", &neo_json_path, e))?;
 
-    // Fetch starter template
-    crate::network::fetch_starter_template(&project_path).await?;
+    // Scaffold from the embedded starter template (no network — the starter is
+    // baked into the binary, revision-coherent with this monorepo).
+    crate::network::write_starter_template(&project_path)?;
 
     // The starter template ships a `launcher/` directory. Library projects don't
     // need it — remove it after extract so the project tree matches `type: library`.
@@ -423,6 +443,7 @@ async fn do_scaffold(config: ProjectConfig) -> miette::Result<()> {
     crate::git::add_all(&project_path)?;
     crate::git::commit(&project_path, "Initial commit from NeoCLI")?;
 
+    cleanup.armed = false;
     Ok(())
 }
 

--- a/neo/src/errors.rs
+++ b/neo/src/errors.rs
@@ -54,7 +54,7 @@ pub enum NeoError {
     #[diagnostic(
         code(neo::network),
         url(docsrs),
-        help("Check your internet connection (try `curl -I {url}`). If you intentionally want to skip network I/O (tests, offline dev), set `NEO_SKIP_NETWORK=1` — `neo` will use a local stub instead of downloading the starter template.")
+        help("Check your internet connection (try `curl -I {url}`). If you intentionally want to skip network I/O (tests, offline dev), set `NEO_SKIP_NETWORK=1` — `neo` will skip remote lookups (the project starter is embedded in the binary, so `neo new` still scaffolds a full project offline).")
     )]
     NetworkError {
         url: String,

--- a/neo/src/network.rs
+++ b/neo/src/network.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use miette::IntoDiagnostic;
 use miette::WrapErr;
+use rust_embed::RustEmbed;
 use serde::Deserialize;
 use semver::Version;
 use crate::errors::NeoError;
@@ -221,77 +222,74 @@ pub async fn check_for_updates() -> miette::Result<Option<String>> {
     }
 }
 
-pub async fn fetch_starter_template(dest: &Path) -> miette::Result<()> {
-    if std::env::var("NEO_SKIP_NETWORK").is_ok() {
-        // Create a dummy structure for tests
-        let src_dir = dest.join("src");
-        std::fs::create_dir_all(&src_dir)
-            .map_err(|e| NeoError::io_at("creating offline-stub `src/` directory at", &src_dir, e))?;
-        let stub_app = src_dir.join("App.hs");
-        std::fs::write(
-            &stub_app,
-            "module App where\n\nrun :: IO ()\nrun = putStrLn \"Hello from NeoHaskell!\"\n",
-        )
-        .map_err(|e| NeoError::io_at("writing offline-stub `src/App.hs` to", &stub_app, e))?;
+/// The internalized NeoHaskell starter template, embedded into the `neo` binary
+/// at compile time from `neo/starter/` (rust-embed). This is the single source
+/// of truth for `neo new` scaffolding: the CLI never downloads a starter at
+/// runtime, so project generation works offline and uses the starter content
+/// from the exact monorepo revision the binary was built from. The generated
+/// project's NeoHaskell dependency is reconciled separately: online generation
+/// resolves upstream, while offline generation preserves the starter's committed
+/// dependency pin. The provenance manifest
+/// (`starter/IMPORT.md`) documents the tree but is not part of a generated
+/// project, so it is excluded from the embed.
+///
+/// Because the folder path is resolved against `CARGO_MANIFEST_DIR` at compile
+/// time (release: bytes are embedded; debug: read from that absolute path at
+/// runtime), extraction never depends on the caller's current directory.
+#[derive(RustEmbed)]
+#[folder = "starter/"]
+#[exclude = "IMPORT.md"]
+struct StarterTemplate;
 
-        let launcher_dir = dest.join("launcher");
-        std::fs::create_dir_all(&launcher_dir)
-            .map_err(|e| NeoError::io_at("creating offline-stub `launcher/` directory at", &launcher_dir, e))?;
-        let stub_launcher = launcher_dir.join("Launcher.hs");
-        std::fs::write(
-            &stub_launcher,
-            "module Main where\n\nimport App\n\nmain :: IO ()\nmain = App.run\n",
-        )
-        .map_err(|e| NeoError::io_at("writing offline-stub `launcher/Launcher.hs` to", &stub_launcher, e))?;
-
-        return Ok(());
+/// Write the embedded starter template into `dest`, creating parent directories
+/// as needed. Path-traversal safe: every embedded entry is resolved through
+/// [`safe_join`], so a malformed embed can never write outside `dest`.
+pub fn write_starter_template(dest: &Path) -> miette::Result<()> {
+    let mut wrote_any = false;
+    for rel in StarterTemplate::iter() {
+        let file = StarterTemplate::get(rel.as_ref()).ok_or_else(|| miette::miette!(
+            help = "This is a build/packaging defect in `neo`, not a project error. Rebuild the binary from a clean checkout (`nix build .#neo`); if it persists, the embedded starter tree is corrupt.",
+            "The embedded starter template lists `{}` but its bytes could not be read.",
+            rel
+        ))?;
+        let dest_path = safe_join(dest, rel.as_ref())?;
+        if let Some(parent) = dest_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| NeoError::io_at("creating a starter template directory at", &parent.to_path_buf(), e))?;
+        }
+        std::fs::write(&dest_path, file.data.as_ref())
+            .map_err(|e| NeoError::io_at("writing an embedded starter template file to", &dest_path, e))?;
+        wrote_any = true;
     }
 
-    let url = "https://github.com/NeoHaskell/neo-starter/archive/refs/heads/main.tar.gz";
-
-    let client = reqwest::Client::builder()
-        .user_agent("NeoCLI")
-        .build()
-        .map_err(|e| NeoError::NetworkError { url: url.to_string(), source: e })?;
-
-    let response = client.get(url).send().await
-        .map_err(|e| NeoError::NetworkError { url: url.to_string(), source: e })?;
-    let bytes = response.bytes().await
-        .map_err(|e| NeoError::NetworkError { url: url.to_string(), source: e })?;
-
-    let tar_gz = flate2::read::GzDecoder::new(&bytes[..]);
-    let mut archive = tar::Archive::new(tar_gz);
-
-    // The tarball has a top-level directory like "neo-starter-main/"
-    // We want to extract its contents into dest
-    let temp_dir = tempfile::tempdir()
-        .map_err(|e| NeoError::io_at("creating a temp dir to unpack the starter tarball into", &std::path::PathBuf::from(std::env::temp_dir()), e))?;
-    archive.unpack(temp_dir.path())
-        .map_err(|e| NeoError::io_at("unpacking the starter tarball into", &temp_dir.path().to_path_buf(), e))?;
-
-    let entries = std::fs::read_dir(temp_dir.path())
-        .map_err(|e| NeoError::io_at("listing the unpacked starter tarball at", &temp_dir.path().to_path_buf(), e))?;
-    let first_entry = entries.into_iter().next().ok_or_else(|| miette::miette!(
-        help = format!("Re-run with network connectivity (try `curl -I {}`), or set `NEO_SKIP_NETWORK=1` to use the offline stub starter (fine for tests, not for real builds).", url),
-        "Downloaded starter template tarball from `{}` was empty after unpack into `{}` — no top-level directory found.",
-        url,
-        temp_dir.path().display()
-    ))?
-    .map_err(|e| NeoError::io_at("reading the first entry of the unpacked starter tarball at", &temp_dir.path().to_path_buf(), e))?;
-    let root_path = first_entry.path();
-
-    let inner_entries = std::fs::read_dir(&root_path)
-        .map_err(|e| NeoError::io_at("listing files inside the unpacked starter at", &root_path, e))?;
-    for entry in inner_entries {
-        let entry = entry
-            .map_err(|e| NeoError::io_at("reading a file entry inside the unpacked starter at", &root_path, e))?;
-        let file_name = entry.file_name();
-        let dest_path = dest.join(file_name);
-        std::fs::rename(entry.path(), &dest_path)
-            .map_err(|e| NeoError::io_at("moving an unpacked starter file into the project dir at", &dest_path, e))?;
+    if !wrote_any {
+        return Err(miette::miette!(
+            help = "This is a build/packaging defect: the `neo` binary was compiled without the `neo/starter/` contents. Rebuild from a clean monorepo checkout (`nix build .#neo`).",
+            "The embedded starter template is empty — no files to scaffold `{}` from.",
+            dest.display()
+        ).into());
     }
 
     Ok(())
+}
+
+/// Join a starter-relative path onto `dest`, rejecting any entry that is
+/// absolute or contains a parent (`..`) / root component. rust-embed already
+/// yields normalized, forward-slash relative paths, but this guard makes the
+/// path-traversal safety explicit and independent of the embedder's guarantees.
+fn safe_join(dest: &Path, rel: &str) -> miette::Result<PathBuf> {
+    let mut out = dest.to_path_buf();
+    for comp in Path::new(rel).components() {
+        match comp {
+            Component::Normal(c) => out.push(c),
+            _ => return Err(miette::miette!(
+                help = "This is a build/packaging defect (a corrupt embedded starter), not a project error. Rebuild the binary from a clean checkout.",
+                "Refusing to extract starter entry `{}`: it contains a non-relative or parent-escaping path component.",
+                rel
+            ).into()),
+        }
+    }
+    Ok(out)
 }
 
 /// The commit SHA that `<url>`'s default branch (HEAD) currently points at, or
@@ -473,13 +471,42 @@ mod tests {
         let _ = check_for_updates().await;
     }
 
-    #[tokio::test]
-    async fn test_fetch_starter_template() {
-        unsafe { std::env::set_var("NEO_SKIP_NETWORK", "1"); }
+    #[test]
+    fn test_write_starter_template_extracts_embedded_tree_offline() {
+        // No network, no NEO_SKIP_NETWORK: the starter is embedded in the
+        // binary, so extraction is fully offline and works from any directory.
+        // This runs in the sealed `nix build .#neo` check (the release binary
+        // embeds the bytes), proving the packaged binary can generate projects
+        // without a network. Assertions are by presence of load-bearing
+        // surfaces, never by file count (which rots on the next starter change).
         let dir = tempdir().unwrap();
-        fetch_starter_template(dir.path()).await.unwrap();
-        assert!(dir.path().join("src/App.hs").exists());
-        assert!(dir.path().join("launcher/Launcher.hs").exists());
+        write_starter_template(dir.path()).unwrap();
+
+        // Application entry point + executable launcher.
+        assert!(dir.path().join("src/App.hs").exists(), "src/App.hs missing");
+        assert!(dir.path().join("launcher/Launcher.hs").exists(), "launcher/Launcher.hs missing");
+        // A real domain module from the starter (not a stub) — proves the full
+        // functional starter is embedded, not a placeholder.
+        assert!(dir.path().join("src/Starter/Counter/Event.hs").exists(), "starter domain module missing");
+        // Dev flake + cabal project so the generated project is buildable.
+        assert!(dir.path().join("flake.nix").exists(), "flake.nix missing");
+        assert!(dir.path().join("cabal.project").exists(), "cabal.project missing");
+        // The starter's own test tree.
+        assert!(dir.path().join("tests/Spec.hs").exists(), "tests/Spec.hs missing");
+
+        // The monorepo-only provenance manifest must NOT leak into a generated
+        // project (it is excluded from the embed).
+        assert!(!dir.path().join("IMPORT.md").exists(), "IMPORT.md must not be scaffolded into a project");
+    }
+
+    #[test]
+    fn test_safe_join_rejects_traversal() {
+        let base = Path::new("/tmp/project");
+        assert!(safe_join(base, "src/App.hs").is_ok());
+        assert!(safe_join(base, "../escape.hs").is_err(), "parent-escaping entry must be rejected");
+        assert!(safe_join(base, "/etc/passwd").is_err(), "absolute entry must be rejected");
+        let ok = safe_join(base, "a/b/c.hs").unwrap();
+        assert!(ok.starts_with(base), "resolved path must stay within dest");
     }
 
     #[test]

--- a/neo/starter/.env.example
+++ b/neo/starter/.env.example
@@ -1,0 +1,18 @@
+# Copy to `.env` and fill in the values you need.
+# The starter runs fine with no .env at all — everything has defaults.
+
+# HTTP server port (default: 8080)
+PORT=8080
+
+# Directory for file uploads (default: ./uploads)
+UPLOAD_DIR=./uploads
+
+# -----------------------------------------------------------------------------
+# Postgres — only needed if you switch the event store in src/App.hs.
+# See README "Switch to Postgres" for the full steps.
+# -----------------------------------------------------------------------------
+# DB_HOST=localhost
+# DB_PORT=5432
+# DB_USER=neohaskell
+# DB_PASSWORD=neohaskell
+# DB_NAME=neohaskell

--- a/neo/starter/.envrc
+++ b/neo/starter/.envrc
@@ -1,0 +1,2 @@
+use flake
+dotenv_if_exists

--- a/neo/starter/.gitignore
+++ b/neo/starter/.gitignore
@@ -1,0 +1,20 @@
+# Haskell build artifacts
+dist-newstyle/
+dist/
+result
+result-*
+
+# Nix/direnv
+.direnv/
+
+# Environment files with secrets
+.env
+
+# Editor / OS
+*.swp
+*~
+.DS_Store
+.idea/
+
+# Uploaded files (local runs)
+uploads/

--- a/neo/starter/.hlint.yaml
+++ b/neo/starter/.hlint.yaml
@@ -1,0 +1,18 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+
+- arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+# Ignore hints that conflict with NeoHaskell style
+- ignore: { name: Eta reduce }
+- ignore: { name: Redundant bracket }
+- ignore: { name: Use newtype instead of data }
+- ignore: { name: Use const }
+- ignore: { name: Avoid lambda using `infix` }
+- ignore: { name: Avoid lambda }
+- ignore: { name: Use /= }
+- ignore: { name: Use <$> }
+- ignore: { name: Replace case with maybe }
+- ignore: { name: Use when }
+- ignore: { name: Use lambda case }
+- ignore: { name: Use bimap }

--- a/neo/starter/.vscode/settings.json
+++ b/neo/starter/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "nixEnvSelector.nixFile": "${workspaceFolder}/flake.nix"
+}

--- a/neo/starter/IMPORT.md
+++ b/neo/starter/IMPORT.md
@@ -1,0 +1,49 @@
+# Internalized NeoHaskell starter (`neo/starter/`)
+
+This directory is the monorepo-owned copy of the NeoHaskell project starter that
+`neo new` scaffolds from. It is the single source of truth for generation: the
+`neo` binary embeds this tree at compile time (rust-embed, see
+`neo/src/network.rs`), so `neo new` never downloads a starter at runtime and the
+starter content is pinned to the exact monorepo revision the binary was built
+from.
+
+Fix generation bugs here, in the monorepo, not in any external repository.
+
+## Provenance
+
+- Source repository: `github.com/NeoHaskell/neo-starter`
+- Imported ref: `origin/main`
+- Import policy: every git-tracked file of the source repository is imported
+  verbatim, preserving the starter's functional contents and the generated
+  project UX. No source files are edited on import.
+
+`neo new` copies this tree into the new project, then `neo` reconciliation
+(`neo/src/reconcile/`) regenerates derived files such as `<name>.cabal`,
+`cabal.project`, and `flake.nix`. With network access, reconciliation resolves the
+current upstream `neohaskell` revision. Offline generation preserves the
+dependency pin committed in this starter; it guarantees deterministic scaffolding,
+not automatic equivalence to a newer upstream checkout. The monorepo consumer
+contract overrides that input to the checkout under test when verifying cross-
+component compatibility. Internalization changes only the origin of the starter
+files from a network download to this embedded tree.
+
+## Intentional exclusions (parity policy)
+
+Only the source repository's git-tracked working tree is imported. The following
+are intentionally NOT imported, expressed as durable patterns rather than a
+snapshot file count (which would rot on the next starter change):
+
+- Version-control metadata: the source repo's `.git/` directory.
+- Build artifacts and caches (the source repo's own `.gitignore` set):
+  `dist-newstyle/`, `dist/`, `result`, `result-*`, `.direnv/`, `uploads/`.
+- Secrets and local environment: `.env` (only the committed `.env.example`
+  template is imported), `*.swp`, `*~`, `.DS_Store`, `.idea/`.
+- Repository-only metadata not part of a generated project: any CI workflow
+  definitions, issue/PR templates, or funding/marketing files the source repo
+  may carry at its top level.
+
+This exclusion policy is enforced executably by `./dev neo-skills-check`, which
+fails if any excluded artifact class appears under `neo/starter/` or if this
+manifest is missing. The invariant surfaces a generated project needs
+(application entry point, launcher, cabal project, dev flake, test tree) are
+also asserted there by presence, never by count.

--- a/neo/starter/README.md
+++ b/neo/starter/README.md
@@ -1,0 +1,205 @@
+# neohaskell-starter
+
+An opinionated starter template for event-sourced [NeoHaskell](https://neohaskell.org) applications. Clone it, rename the `Counter` domain to whatever you're building, and you're off.
+
+## What you get
+
+- Event-sourced CQRS skeleton with a working **Counter** example — 3 events, 3 commands, 1 read model.
+- Nix-managed toolchain: GHC, Cabal, HLS, fourmolu, hlint, hurl — pinned and reproducible.
+- In-memory event store by default (zero setup). PostgreSQL is fully scaffolded and one uncomment away.
+- HTTP transport on `:8080` with auto-generated routes (`POST /commands/kebab-case-name`).
+- Hurl acceptance tests demonstrating the full create → increment → query flow.
+- AI onramp: `AGENTS.md` + `.skills/` so coding assistants pick up the conventions immediately.
+
+## Requirements
+
+- [Determinate Nix](https://determinate.systems/nix) — the only thing you install yourself.
+- [direnv](https://direnv.net/) (optional) — auto-loads the Nix shell when you `cd` into the directory.
+
+Everything else (GHC, Cabal, HLS, fourmolu, hlint, hurl) comes from the Nix shell.
+
+## Quickstart
+
+```bash
+# Clone and enter
+git clone <your-fork-url> my-app && cd my-app
+
+# Enter the dev shell. --accept-flake-config opts into the IOG + NeoHaskell
+# binary caches (see "Binary caches" below) so GHC + deps are downloaded,
+# not compiled. Takes a few minutes first time; seconds afterwards.
+nix develop --accept-flake-config
+
+# Build and run
+cabal build
+cabal run neohaskell-starter
+```
+
+In another terminal:
+
+```bash
+# Create a counter
+curl -X POST http://localhost:8080/commands/create-counter \
+  -H 'Content-Type: application/json' \
+  -d '{"label": "downloads"}'
+# → {"entityId": "…"}
+
+# Increment it
+curl -X POST http://localhost:8080/commands/increment-counter \
+  -H 'Content-Type: application/json' \
+  -d '{"entityId": "PASTE-UUID", "amount": 3}'
+
+# Read the projection
+curl http://localhost:8080/queries/counter-view
+```
+
+Or run the scripted end-to-end flow:
+
+```bash
+hurl tests/scenarios/counter-flow.hurl
+```
+
+## Binary caches
+
+Building GHC + haskell.nix from source takes hours. `flake.nix` declares two public binary caches that ship prebuilt artifacts:
+
+| Cache | Contents |
+|---|---|
+| `https://cache.iog.io` | haskell.nix / IOG artifacts (GHC, libraries) |
+| `https://neohaskell.cachix.org` | NeoHaskell core + integrations |
+
+Nix will only use these if you opt in. Pick one:
+
+**Option A — per command (zero config).** Pass the flag on every `nix develop`:
+
+```bash
+nix develop --accept-flake-config
+```
+
+**Option B — accept once, forever.** Add `accept-flake-config = true` to your user Nix config:
+
+```bash
+mkdir -p ~/.config/nix
+echo 'accept-flake-config = true' >> ~/.config/nix/nix.conf
+```
+
+After this, `nix develop` (no flag) transparently uses the caches for this flake and any other that declares `nixConfig.extra-substituters`. If you'd rather scope it tightly, you can also add yourself to `trusted-users` in `/etc/nix/nix.conf` instead — see the [NeoHaskell installation guide](https://neohaskell.org/getting-started/installation).
+
+> If you skip both, Nix prompts you the first time and falls back to building from source if you decline. Expect a very long first build.
+
+## Directory map
+
+```
+.
+├── launcher/Launcher.hs          # Thin entry — buffers stdout/stderr, runs App
+├── src/
+│   ├── App.hs                    # Application wiring (event store, transports, services)
+│   ├── Starter/Config.hs         # Typed config (port, upload dir, optional Postgres)
+│   └── Starter/Counter/          # Example bounded context — rename or delete
+│       ├── Core.hs               # Re-exports Entity and Event
+│       ├── Entity.hs             # CounterEntity + update function
+│       ├── Event.hs              # Sum type of all counter events
+│       ├── Service.hs            # Registers commands with the framework
+│       ├── Events/               # One file per event type
+│       ├── Commands/             # One file per command type
+│       └── Queries/              # One file per read model
+├── tests/
+│   ├── integration/smoke.hurl    # Server-is-up check
+│   └── scenarios/counter-flow.hurl # End-to-end workflow
+├── .skills/                       # AI assistant knowledge bases (domain-neutral)
+├── AGENTS.md                      # Patterns + conventions for humans and AIs
+├── cabal.project                  # Pins NeoHaskell at a specific commit
+├── flake.nix                      # Nix shell definition
+├── docker-compose.yml             # Postgres — only when you switch event stores
+└── neohaskell-starter.cabal       # Package definition + extensions
+```
+
+## Rename the domain to your own
+
+The starter's namespace is `Starter.Counter.*`. When you're building "Books" for a "Library" app, follow this 4-step checklist:
+
+1. **Rename the directory.** `mv src/Starter src/Library`, then `mv src/Library/Counter src/Library/Book`.
+2. **Fix the module names** in every `.hs` file under `src/Library/Book/` — change `module Starter.Counter.X` to `module Library.Book.X` and every `import Starter.Counter.X` to `import Library.Book.X`.
+3. **Update `neohaskell-starter.cabal`** — rewrite the `exposed-modules` list, and change `Starter.Config` to `Library.Config`. Optionally rename the package itself (`name: library`, `executable library`).
+4. **Update `src/App.hs`** — change `Starter.*` imports to `Library.*`.
+
+Then:
+
+```bash
+cabal build
+```
+
+If it compiles, you're done.
+
+## Add a new event
+
+Say you want to record when a counter is reset to zero. Four steps:
+
+1. **Create the event file** `src/Starter/Counter/Events/CounterReset.hs`:
+
+   ```haskell
+   module Starter.Counter.Events.CounterReset (Event (..)) where
+
+   import Core
+   import Json qualified
+
+   data Event = Event { entityId :: Uuid }
+     deriving (Generic, Show)
+
+   instance Json.FromJSON Event
+   instance Json.ToJSON Event
+   ```
+
+2. **Wire it into the sum type** in `src/Starter/Counter/Event.hs` — add a `CounterReset` variant and a branch in `getEventEntityId`.
+
+3. **Handle it in `update`** in `src/Starter/Counter/Entity.hs`:
+
+   ```haskell
+   CounterReset _ ->
+     entity { value = 0 }
+   ```
+
+4. **Expose the module** — add `Starter.Counter.Events.CounterReset` to `exposed-modules` in the `.cabal` file, then `cabal build`.
+
+(Add a matching `Commands/ResetCounter.hs` and register it in `Service.hs` if you want an HTTP endpoint too.)
+
+## Switch to Postgres
+
+The starter uses an in-memory event store so it runs out of the box. When you're ready for durability:
+
+1. Open `src/App.hs` and follow the `SWITCH TO POSTGRES` comment block.
+2. Open `src/Starter/Config.hs` and uncomment the five Postgres fields.
+3. Copy `.env.example` to `.env` (the defaults match `docker-compose.yml`).
+4. Start Postgres: `docker compose up -d`.
+5. Rebuild: `cabal build`. The event-store schema is created automatically on first run.
+
+## Testing
+
+```bash
+# Start the server in one terminal
+cabal run neohaskell-starter
+
+# Run tests in another
+hurl tests/integration/smoke.hurl
+hurl tests/scenarios/counter-flow.hurl
+```
+
+Write new tests as `.hurl` files under `tests/commands/` (single-command) or `tests/scenarios/` (multi-step). Use `[Options] retry: 10 retry-interval: 200` on GETs to wait for projections.
+
+## Formatting and linting
+
+Inside the Nix shell:
+
+```bash
+fourmolu -i src/ launcher/       # Format
+hlint src/ launcher/             # Lint
+```
+
+## Working with AI assistants
+
+`AGENTS.md` at the root spells out the NeoHaskell conventions this project enforces — share it with any AI assistant you use (Claude Code, Codex, Cursor, etc.). Deeper reference material lives under `.skills/`.
+
+## Links
+
+- NeoHaskell docs: https://neohaskell.org
+- Event Modeling: https://eventmodeling.org
+- Hurl (tests): https://hurl.dev

--- a/neo/starter/cabal.project
+++ b/neo/starter/cabal.project
@@ -1,0 +1,26 @@
+packages:
+  *.cabal
+
+-- NeoHaskell core library.
+-- The git source is managed by flake.nix inputMap (nix flake update to update).
+-- IMPORTANT: Use a specific commit SHA, not a branch name, for reproducible builds.
+-- To update:
+--   1) nix flake lock --update-input neohaskell
+--   2) Update the tag below to match: nix eval .#neohaskell.rev --raw
+source-repository-package
+  type: git
+  location: https://github.com/neohaskell/neohaskell.git
+  tag: 3fd3d1327c3f64c0e6ded278b803b1a2b96ab875
+  subdir: core
+
+
+-- NeoHaskell integrations (HTTP, OpenRouter, File upload, etc.)
+source-repository-package
+  type: git
+  location: https://github.com/neohaskell/neohaskell.git
+  tag: 3fd3d1327c3f64c0e6ded278b803b1a2b96ab875
+  subdir: integrations
+
+constraints:
+  hasql < 1.10,
+  opt-env-conf < 0.11

--- a/neo/starter/docker-compose.yml
+++ b/neo/starter/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+# Only needed if you switch src/App.hs from the InMemory event store to Postgres.
+# See README "Switch to Postgres".
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: neohaskell-starter-postgres
+    environment:
+      POSTGRES_USER: neohaskell
+      POSTGRES_PASSWORD: neohaskell
+      POSTGRES_DB: neohaskell
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U neohaskell"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/neo/starter/flake.lock
+++ b/neo/starter/flake.lock
@@ -1,0 +1,686 @@
+{
+  "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769387443,
+        "narHash": "sha256-Kv6kGETl9ZuhDfMhAFd6vihQdqI7ptWdkLeSgBlFCv8=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4e8bfb1fee9caaffd6aa7d83948a4dac1cf72eba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769387432,
+        "narHash": "sha256-0ueQg9DZDFxG168M/My9TJt59CXooz5pz8lER2iSz8Y=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "df14d57fe406a746d84f6ed743bbb36f6adb8947",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1769388749,
+        "narHash": "sha256-0vILl3g/VxZk8IWbhAIwcMyQojIUeaP97bUnW7ETsK8=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "c81decb31e92eb064a0f7a4a339effa3eccd9f14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755243078,
+        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "neohaskell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775166670,
+        "narHash": "sha256-5gkRPqi95s4r3JLmbLC5ekuwRJb+83bwiRfZecQwGNM=",
+        "ref": "main",
+        "rev": "3fd3d1327c3f64c0e6ded278b803b1a2b96ab875",
+        "revCount": 205,
+        "type": "git",
+        "url": "https://github.com/neohaskell/neohaskell.git"
+      },
+      "original": {
+        "ref": "main",
+        "type": "git",
+        "url": "https://github.com/neohaskell/neohaskell.git"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2511": {
+      "locked": {
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "haskellNix": "haskellNix",
+        "neohaskell": "neohaskell",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769386533,
+        "narHash": "sha256-V8N59LFXdNKgMBIZqUuwp8OdEAINKChNI1Ow5SWdxHs=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "8da8e0594e4ff55844d0cab84f6f0879831e87ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/neo/starter/flake.nix
+++ b/neo/starter/flake.nix
@@ -1,0 +1,51 @@
+{
+  inputs.haskellNix.url = "github:input-output-hk/haskell.nix";
+  inputs.nixpkgs.follows = "haskellNix/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  # Tracks `main`; the actual rev is pinned by the committed flake.lock
+  # (currently 3fd3d1327c). To bump: `nix flake lock --update-input neohaskell`
+  # then sync the `tag:` in cabal.project and `neohaskellCommit` below.
+  inputs.neohaskell.url = "git+https://github.com/neohaskell/neohaskell.git?ref=main";
+  inputs.neohaskell.flake = false;
+
+  outputs = { self, nixpkgs, flake-utils, haskellNix, neohaskell }:
+    let
+      supportedSystems =
+        [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Must match the `tag:` in cabal.project for both subdirs AND the rev in the neohaskell input above.
+      neohaskellCommit = "3fd3d1327c3f64c0e6ded278b803b1a2b96ab875";
+
+    in flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        overlays = [
+          haskellNix.overlay
+          (final: _prev: {
+            hixProject = final.haskell-nix.hix.project {
+              src = ./.;
+              inputMap = {
+                "https://github.com/neohaskell/neohaskell.git/${neohaskellCommit}" = neohaskell;
+              };
+            };
+          })
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          inherit (haskellNix) config;
+        };
+        flake = pkgs.hixProject.flake { };
+      in flake // { legacyPackages = pkgs; });
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.iog.io"
+      "https://neohaskell.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+      "neohaskell.cachix.org-1:mo2cLaGbwqbrxs9xhqKK8jeNsn3osi7t6XoAmxSZssc="
+    ];
+    allow-import-from-derivation = "true";
+  };
+}

--- a/neo/starter/fourmolu.yaml
+++ b/neo/starter/fourmolu.yaml
@@ -1,0 +1,50 @@
+# Number of spaces per indentation step
+indentation: 2
+
+# Max line length for automatic line breaking
+column-limit: 120
+
+# Styling of arrows in type signatures (choices: trailing, leading, or leading-args)
+function-arrows: trailing
+
+# How to place commas in multi-line lists, records, etc. (choices: leading or trailing)
+comma-style: trailing
+
+# Styling of import/export lists (choices: leading, trailing, or diff-friendly)
+import-export-style: diff-friendly
+
+# Whether to full-indent or half-indent 'where' bindings past the preceding body
+indent-wheres: false
+
+# Whether to leave a space before an opening record brace
+record-brace-space: true
+
+# Number of spaces between top-level declarations
+newlines-between-decls: 2
+
+# How to print Haddock comments (choices: single-line, multi-line, or multi-line-compact)
+haddock-style: single-line
+
+# How to print module docstring
+haddock-style-module: null
+
+# Styling of let blocks (choices: auto, inline, newline, or mixed)
+let-style: inline
+
+# How to align the 'in' keyword with respect to the 'let' keyword (choices: left-align, right-align, or no-space)
+in-style: left-align
+
+# Whether to put parentheses around a single constraint (choices: auto, always, or never)
+single-constraint-parens: always
+
+# Output Unicode syntax (choices: detect, always, or never)
+unicode: never
+
+# Give the programmer more choice on where to insert blank lines
+respectful: false
+
+# Fixity information for operators
+fixities: []
+
+# Module reexports Fourmolu should know about
+reexports: []

--- a/neo/starter/launcher/Launcher.hs
+++ b/neo/starter/launcher/Launcher.hs
@@ -1,0 +1,15 @@
+module Main where
+
+import App (app)
+import Core
+import Service.Application qualified as Application
+import System.IO qualified as GhcIO
+import Task qualified
+
+
+main :: IO ()
+main = do
+  GhcIO.hSetBuffering GhcIO.stdout GhcIO.LineBuffering
+  GhcIO.hSetBuffering GhcIO.stderr GhcIO.LineBuffering
+  let runApp = app |> Application.run
+  runApp |> Task.runOrPanic

--- a/neo/starter/nix/hix.nix
+++ b/neo/starter/nix/hix.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }: {
+  name = "neohaskell-starter";
+  compiler-nix-name = "ghc98";
+
+  shell.tools = {
+    cabal = "latest";
+    hlint = "latest";
+    fourmolu = "latest";
+    hspec-discover = "latest";
+    haskell-language-server = "latest";
+  };
+  shell.buildInputs = with pkgs; [ git postgresql hurl ];
+}

--- a/neo/starter/src/App.hs
+++ b/neo/starter/src/App.hs
@@ -1,0 +1,53 @@
+module App (app) where
+
+import Core
+import Maybe qualified
+import Path qualified
+import Service.Application (Application)
+import Service.Application qualified as Application
+import Service.EventStore.Simple (SimpleEventStore (..))
+import Service.Transport.Web qualified as WebTransport
+import Starter.Config (StarterConfig (..))
+import Starter.Counter.Queries.CounterView (CounterView)
+import Starter.Counter.Service qualified as Counter
+
+-- To switch to Postgres, see the commented block below.
+-- import Service.EventStore.Postgres (PostgresEventStore (..))
+-- (and remove the SimpleEventStore import above)
+
+
+-- | The application.
+--
+-- The starter ships with the in-memory event store so `cabal run` works
+-- with zero external dependencies. Follow the README "Switch to Postgres"
+-- steps when you are ready for durability.
+app :: Application
+app =
+  Application.new
+    |> Application.withConfig @StarterConfig
+    |> Application.withEventStore (\(_ :: StarterConfig) -> SimpleEventStore {basePath = Path.fromText ".neo/events" |> Maybe.getOrDie, persistent = False})
+    -- SWITCH TO POSTGRES:
+    --   1. Comment out the `withEventStore` line above.
+    --   2. Uncomment `withEventStore makePostgresConfig` below.
+    --   3. Uncomment `makePostgresConfig` at the bottom of this file.
+    --   4. Uncomment the Postgres fields in src/Starter/Config.hs.
+    --   5. Uncomment the Postgres import near the top of this file.
+    --   6. `cp .env.example .env` (edit if needed) and `docker compose up -d`.
+    -- |> Application.withEventStore makePostgresConfig
+    |> Application.withTransport WebTransport.server
+    |> Application.withService Counter.service
+    |> Application.withQuery @CounterView
+
+
+-- | Postgres event store factory. Uncomment once the Postgres fields exist on
+-- `StarterConfig` (see src/Starter/Config.hs).
+--
+-- makePostgresConfig :: StarterConfig -> PostgresEventStore
+-- makePostgresConfig config =
+--   PostgresEventStore
+--     { user = config.dbUser
+--     , password = config.dbPassword
+--     , host = config.dbHost
+--     , databaseName = config.dbName
+--     , port = config.dbPort
+--     }

--- a/neo/starter/src/Starter/Config.hs
+++ b/neo/starter/src/Starter/Config.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Starter.Config (
+  StarterConfig (..),
+  HasStarterConfig,
+) where
+
+import Config (defineConfig)
+import Config qualified
+import Core
+
+
+-- | Typed application configuration. Every field is populated from (in order):
+--   1. CLI argument, 2. environment variable, 3. `.env` file, 4. default value.
+--
+-- Fields marked `|> Config.secret` are excluded from help output and logs.
+defineConfig
+  "StarterConfig"
+  [ Config.field @Int "httpPort"
+      |> Config.doc "HTTP server port"
+      |> Config.defaultsTo (8080 :: Int)
+      |> Config.envVar "PORT"
+      |> Config.cliLong "port"
+      |> Config.cliShort 'p'
+  , Config.field @Text "uploadDir"
+      |> Config.doc "Directory for file uploads"
+      |> Config.defaultsTo ("./uploads" :: Text)
+      |> Config.envVar "UPLOAD_DIR"
+    -- SWITCH TO POSTGRES: uncomment the five fields below and wire them in src/App.hs.
+    --
+    -- , Config.field @Text "dbHost"
+    --     |> Config.doc "PostgreSQL host"
+    --     |> Config.defaultsTo ("localhost" :: Text)
+    --     |> Config.envVar "DB_HOST"
+    -- , Config.field @Int "dbPort"
+    --     |> Config.doc "PostgreSQL port"
+    --     |> Config.defaultsTo (5432 :: Int)
+    --     |> Config.envVar "DB_PORT"
+    -- , Config.field @Text "dbUser"
+    --     |> Config.doc "PostgreSQL username"
+    --     |> Config.defaultsTo ("neohaskell" :: Text)
+    --     |> Config.envVar "DB_USER"
+    -- , Config.field @Text "dbPassword"
+    --     |> Config.doc "PostgreSQL password"
+    --     |> Config.defaultsTo ("neohaskell" :: Text)
+    --     |> Config.envVar "DB_PASSWORD"
+    --     |> Config.secret
+    -- , Config.field @Text "dbName"
+    --     |> Config.doc "PostgreSQL database name"
+    --     |> Config.defaultsTo ("neohaskell" :: Text)
+    --     |> Config.envVar "DB_NAME"
+  ]

--- a/neo/starter/src/Starter/Counter/Commands/CreateCounter.hs
+++ b/neo/starter/src/Starter/Counter/Commands/CreateCounter.hs
@@ -1,0 +1,57 @@
+module Starter.Counter.Commands.CreateCounter (
+  CreateCounter (..),
+  getEntityId,
+  decide,
+) where
+
+import Core
+import Decider qualified
+import Json qualified
+import Service.Auth (RequestContext)
+import Service.Command.Core (TransportsOf)
+import Service.CommandExecutor.TH (command)
+import Service.Transport.Web (WebTransport)
+import Starter.Counter.Core
+import Starter.Counter.Events.CounterCreated qualified as CounterCreated
+
+
+-- | Create a new counter. The entity id is generated in `decide`.
+data CreateCounter = CreateCounter
+  { label :: Text
+  }
+  deriving (Generic, Typeable, Show)
+
+
+instance Json.FromJSON CreateCounter
+
+
+-- | `Nothing` means "creation" — no existing entity should be loaded.
+getEntityId :: CreateCounter -> Maybe Uuid
+getEntityId _ = Nothing
+
+
+decide :: CreateCounter -> Maybe CounterEntity -> RequestContext -> Decision CounterEvent
+decide cmd entity _ctx = case entity of
+  Just _ ->
+    Decider.reject "Counter already exists"
+  Nothing ->
+    if cmd.label == ""
+      then Decider.reject "Label cannot be empty"
+      else do
+        newId <- Decider.generateUuid
+        Decider.acceptNew
+          [ CounterCreated
+              CounterCreated.Event
+                { entityId = newId
+                , label = cmd.label
+                }
+          ]
+
+
+type instance EntityOf CreateCounter = CounterEntity
+
+
+type instance TransportsOf CreateCounter = '[WebTransport]
+
+
+command ''CreateCounter

--- a/neo/starter/src/Starter/Counter/Commands/DecrementCounter.hs
+++ b/neo/starter/src/Starter/Counter/Commands/DecrementCounter.hs
@@ -1,0 +1,56 @@
+module Starter.Counter.Commands.DecrementCounter (
+  DecrementCounter (..),
+  getEntityId,
+  decide,
+) where
+
+import Core
+import Decider qualified
+import Json qualified
+import Service.Auth (RequestContext)
+import Service.Command.Core (TransportsOf)
+import Service.CommandExecutor.TH (command)
+import Service.Transport.Web (WebTransport)
+import Starter.Counter.Core
+import Starter.Counter.Events.CounterDecremented qualified as CounterDecremented
+
+
+-- | Decrement an existing counter by `amount`.
+data DecrementCounter = DecrementCounter
+  { entityId :: Uuid
+  , amount :: Int
+  }
+  deriving (Generic, Typeable, Show)
+
+
+instance Json.FromJSON DecrementCounter
+
+
+getEntityId :: DecrementCounter -> Maybe Uuid
+getEntityId cmd = Just cmd.entityId
+
+
+decide :: DecrementCounter -> Maybe CounterEntity -> RequestContext -> Decision CounterEvent
+decide cmd entity _ctx = case entity of
+  Nothing ->
+    Decider.reject "Counter not found"
+  Just existing ->
+    if cmd.amount <= 0
+      then Decider.reject "Amount must be positive"
+      else
+        Decider.acceptExisting
+          [ CounterDecremented
+              CounterDecremented.Event
+                { entityId = existing.counterId
+                , amount = cmd.amount
+                }
+          ]
+
+
+type instance EntityOf DecrementCounter = CounterEntity
+
+
+type instance TransportsOf DecrementCounter = '[WebTransport]
+
+
+command ''DecrementCounter

--- a/neo/starter/src/Starter/Counter/Commands/IncrementCounter.hs
+++ b/neo/starter/src/Starter/Counter/Commands/IncrementCounter.hs
@@ -1,0 +1,57 @@
+module Starter.Counter.Commands.IncrementCounter (
+  IncrementCounter (..),
+  getEntityId,
+  decide,
+) where
+
+import Core
+import Decider qualified
+import Json qualified
+import Service.Auth (RequestContext)
+import Service.Command.Core (TransportsOf)
+import Service.CommandExecutor.TH (command)
+import Service.Transport.Web (WebTransport)
+import Starter.Counter.Core
+import Starter.Counter.Events.CounterIncremented qualified as CounterIncremented
+
+
+-- | Increment an existing counter by `amount`.
+data IncrementCounter = IncrementCounter
+  { entityId :: Uuid
+  , amount :: Int
+  }
+  deriving (Generic, Typeable, Show)
+
+
+instance Json.FromJSON IncrementCounter
+
+
+-- | Returning `Just` tells the framework to load this entity before calling `decide`.
+getEntityId :: IncrementCounter -> Maybe Uuid
+getEntityId cmd = Just cmd.entityId
+
+
+decide :: IncrementCounter -> Maybe CounterEntity -> RequestContext -> Decision CounterEvent
+decide cmd entity _ctx = case entity of
+  Nothing ->
+    Decider.reject "Counter not found"
+  Just existing ->
+    if cmd.amount <= 0
+      then Decider.reject "Amount must be positive"
+      else
+        Decider.acceptExisting
+          [ CounterIncremented
+              CounterIncremented.Event
+                { entityId = existing.counterId
+                , amount = cmd.amount
+                }
+          ]
+
+
+type instance EntityOf IncrementCounter = CounterEntity
+
+
+type instance TransportsOf IncrementCounter = '[WebTransport]
+
+
+command ''IncrementCounter

--- a/neo/starter/src/Starter/Counter/Core.hs
+++ b/neo/starter/src/Starter/Counter/Core.hs
@@ -1,0 +1,9 @@
+-- | Convenience re-export so callers can write `import Starter.Counter.Core`
+-- instead of importing Entity and Event separately.
+module Starter.Counter.Core (
+  module Starter.Counter.Entity,
+  module Starter.Counter.Event,
+) where
+
+import Starter.Counter.Entity
+import Starter.Counter.Event

--- a/neo/starter/src/Starter/Counter/Entity.hs
+++ b/neo/starter/src/Starter/Counter/Entity.hs
@@ -1,0 +1,75 @@
+module Starter.Counter.Entity (
+  CounterEntity (..),
+  initialState,
+  update,
+) where
+
+import Core
+import Json qualified
+import Service.Command.Core (Event (..))
+import Uuid qualified
+import Starter.Counter.Event (CounterEvent (..), getEventEntityId)
+import Starter.Counter.Events.CounterCreated qualified as CounterCreated
+import Starter.Counter.Events.CounterDecremented qualified as CounterDecremented
+import Starter.Counter.Events.CounterIncremented qualified as CounterIncremented
+
+
+-- | Current state of a single counter aggregate, rebuilt from its events.
+data CounterEntity = CounterEntity
+  { counterId :: Uuid
+  , label :: Text
+  , value :: Int
+  }
+  deriving (Generic)
+
+
+instance Json.FromJSON CounterEntity
+
+
+instance Json.ToJSON CounterEntity
+
+
+instance Default CounterEntity where
+  def = initialState
+
+
+initialState :: CounterEntity
+initialState =
+  CounterEntity
+    { counterId = Uuid.nil
+    , label = ""
+    , value = 0
+    }
+
+
+type instance NameOf CounterEntity = "CounterEntity"
+
+
+type instance EventOf CounterEntity = CounterEvent
+
+
+type instance EntityOf CounterEvent = CounterEntity
+
+
+instance Entity CounterEntity where
+  initialStateImpl = initialState
+  updateImpl = update
+
+
+instance Event CounterEvent where
+  getEventEntityIdImpl = getEventEntityId
+
+
+-- | Apply one event to the current state.
+update :: CounterEvent -> CounterEntity -> CounterEntity
+update event entity = case event of
+  CounterCreated e ->
+    CounterEntity
+      { counterId = e.entityId
+      , label = e.label
+      , value = 0
+      }
+  CounterIncremented e ->
+    entity {value = entity.value + e.amount}
+  CounterDecremented e ->
+    entity {value = entity.value - e.amount}

--- a/neo/starter/src/Starter/Counter/Event.hs
+++ b/neo/starter/src/Starter/Counter/Event.hs
@@ -1,0 +1,36 @@
+module Starter.Counter.Event (
+  CounterEvent (..),
+  getEventEntityId,
+) where
+
+import Core
+import Json qualified
+import Starter.Counter.Events.CounterCreated qualified as CounterCreated
+import Starter.Counter.Events.CounterDecremented qualified as CounterDecremented
+import Starter.Counter.Events.CounterIncremented qualified as CounterIncremented
+
+
+-- | Sum of every event type in this bounded context.
+--
+-- Adding a new event is a three-step process:
+--   1. Create `src/Starter/Counter/Events/YourEvent.hs`.
+--   2. Add a variant below + a branch in `getEventEntityId`.
+--   3. Add a case in `update` inside `Starter.Counter.Entity`.
+data CounterEvent
+  = CounterCreated CounterCreated.Event
+  | CounterIncremented CounterIncremented.Event
+  | CounterDecremented CounterDecremented.Event
+  deriving (Generic, Show)
+
+
+getEventEntityId :: CounterEvent -> Uuid
+getEventEntityId event = case event of
+  CounterCreated e -> e.entityId
+  CounterIncremented e -> e.entityId
+  CounterDecremented e -> e.entityId
+
+
+instance Json.FromJSON CounterEvent
+
+
+instance Json.ToJSON CounterEvent

--- a/neo/starter/src/Starter/Counter/Events/CounterCreated.hs
+++ b/neo/starter/src/Starter/Counter/Events/CounterCreated.hs
@@ -1,0 +1,18 @@
+module Starter.Counter.Events.CounterCreated (Event (..)) where
+
+import Core
+import Json qualified
+
+
+-- | A new counter was created with a human-readable label. Starting value is 0.
+data Event = Event
+  { entityId :: Uuid
+  , label :: Text
+  }
+  deriving (Generic, Show)
+
+
+instance Json.FromJSON Event
+
+
+instance Json.ToJSON Event

--- a/neo/starter/src/Starter/Counter/Events/CounterDecremented.hs
+++ b/neo/starter/src/Starter/Counter/Events/CounterDecremented.hs
@@ -1,0 +1,18 @@
+module Starter.Counter.Events.CounterDecremented (Event (..)) where
+
+import Core
+import Json qualified
+
+
+-- | A counter's value was decremented by `amount`.
+data Event = Event
+  { entityId :: Uuid
+  , amount :: Int
+  }
+  deriving (Generic, Show)
+
+
+instance Json.FromJSON Event
+
+
+instance Json.ToJSON Event

--- a/neo/starter/src/Starter/Counter/Events/CounterIncremented.hs
+++ b/neo/starter/src/Starter/Counter/Events/CounterIncremented.hs
@@ -1,0 +1,18 @@
+module Starter.Counter.Events.CounterIncremented (Event (..)) where
+
+import Core
+import Json qualified
+
+
+-- | A counter's value was incremented by `amount`.
+data Event = Event
+  { entityId :: Uuid
+  , amount :: Int
+  }
+  deriving (Generic, Show)
+
+
+instance Json.FromJSON Event
+
+
+instance Json.ToJSON Event

--- a/neo/starter/src/Starter/Counter/Queries/CounterView.hs
+++ b/neo/starter/src/Starter/Counter/Queries/CounterView.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Starter.Counter.Queries.CounterView (
+  CounterView (..),
+  canAccess,
+  canView,
+) where
+
+import Core
+import Json qualified
+import Service.AccessControl (AccessError, UserClaims, publicAccess, publicView)
+import Service.Query.TH (deriveQuery)
+import Starter.Counter.Core (CounterEntity (..))
+
+
+-- | Projected read model for a counter: one row per counter, updated every
+-- time the underlying `CounterEntity` changes.
+data CounterView = CounterView
+  { counterId :: Uuid
+  , label :: Text
+  , value :: Int
+  }
+  deriving (Eq, Show, Generic)
+
+
+instance Json.ToJSON CounterView
+
+
+instance Json.FromJSON CounterView
+
+
+instance ToSchema CounterView
+
+
+canAccess :: Maybe UserClaims -> Maybe AccessError
+canAccess = publicAccess
+
+
+canView :: Maybe UserClaims -> CounterView -> Maybe AccessError
+canView = publicView
+
+
+deriveQuery ''CounterView [''CounterEntity]
+
+
+instance QueryOf CounterEntity CounterView where
+  queryId entity = entity.counterId
+
+  combine entity _maybeExisting =
+    Update
+      CounterView
+        { counterId = entity.counterId
+        , label = entity.label
+        , value = entity.value
+        }

--- a/neo/starter/src/Starter/Counter/Service.hs
+++ b/neo/starter/src/Starter/Counter/Service.hs
@@ -1,0 +1,19 @@
+module Starter.Counter.Service (service) where
+
+import Core
+import Service qualified
+import Starter.Counter.Commands.CreateCounter (CreateCounter)
+import Starter.Counter.Commands.DecrementCounter (DecrementCounter)
+import Starter.Counter.Commands.IncrementCounter (IncrementCounter)
+import Starter.Counter.Core ()
+
+
+-- | All commands in the Counter bounded context share `CounterEntity` +
+-- `CounterEvent`. The compiler enforces this at the call-site of
+-- `Service.command`.
+service :: Service _ _
+service =
+  Service.new
+    |> Service.command @CreateCounter
+    |> Service.command @IncrementCounter
+    |> Service.command @DecrementCounter

--- a/neo/starter/tests/Decider/Counter/IncrementCounterSpec.hs
+++ b/neo/starter/tests/Decider/Counter/IncrementCounterSpec.hs
@@ -1,0 +1,59 @@
+-- | Decider unit tests for @IncrementCounter.decide@ — the pure command handler.
+--
+-- This is the fastest, most numerous test layer: it exercises the accept/reject
+-- rules of a command in isolation, with no HTTP and no event store. Rejections are
+-- listed before the happy path so the data types are forced into shape first.
+--
+-- Add a new command? Copy this file to @test/Decider/<Context>/<Command>Spec.hs@;
+-- hspec-discover (see @test/Spec.hs@) picks it up automatically.
+module Decider.Counter.IncrementCounterSpec (spec) where
+
+import Array qualified
+import Core
+import Decider qualified
+import Service.Auth qualified as Auth
+import Service.Command.Core (DecisionContext (..))
+import Starter.Counter.Commands.IncrementCounter (IncrementCounter (..), decide)
+import Starter.Counter.Entity (CounterEntity (..))
+import Test
+import Uuid qualified
+
+
+-- | Run a @decide@ result to a concrete accept/reject decision for assertions.
+runTestDecision :: Decision event -> Task Text (CommandResult event)
+runTestDecision decision = do
+  let decisionCtx = DecisionContext {genUuid = Uuid.generate}
+  Decider.runDecision decisionCtx decision
+
+
+spec :: Spec Unit
+spec = describe "IncrementCounter.decide" do
+  it "rejects when the counter does not exist" \_ctx -> do
+    let cmd = IncrementCounter {entityId = Uuid.nil, amount = 1}
+    result <- runTestDecision (decide cmd Nothing Auth.emptyContext)
+    case result of
+      RejectCommand msg ->
+        msg |> shouldBe "Counter not found"
+      AcceptCommand _ _ ->
+        fail "expected a rejection when the counter does not exist"
+
+  it "rejects a non-positive amount" \_ctx -> do
+    let existing = CounterEntity {counterId = Uuid.nil, label = "downloads", value = 0}
+    let cmd = IncrementCounter {entityId = Uuid.nil, amount = 0}
+    result <- runTestDecision (decide cmd (Just existing) Auth.emptyContext)
+    case result of
+      RejectCommand msg ->
+        msg |> shouldBe "Amount must be positive"
+      AcceptCommand _ _ ->
+        fail "expected a rejection for a non-positive amount"
+
+  it "accepts a positive amount and emits a single event" \_ctx -> do
+    let existing = CounterEntity {counterId = Uuid.nil, label = "downloads", value = 3}
+    let cmd = IncrementCounter {entityId = Uuid.nil, amount = 5}
+    result <- runTestDecision (decide cmd (Just existing) Auth.emptyContext)
+    case result of
+      RejectCommand _ ->
+        fail "expected acceptance for a positive amount"
+      AcceptCommand insertionType events -> do
+        insertionType |> shouldBe ExistingStream
+        Array.length events |> shouldBe 1

--- a/neo/starter/tests/Property/CounterReplaySpec.hs
+++ b/neo/starter/tests/Property/CounterReplaySpec.hs
@@ -1,0 +1,33 @@
+-- | Property tests for the @CounterEntity@ @update@ fold — the event-replay layer.
+--
+-- Property tests drop to raw hspec + QuickCheck (the @Test@ wrapper's @it@ can't
+-- take a QuickCheck property). @Prelude@ is imported qualified as @GhcPrelude@ for
+-- the list/fold operations QuickCheck generates over. Generating an event sequence
+-- and folding it with @update@ is the canonical NeoHaskell replay-property shape.
+module Property.CounterReplaySpec (spec) where
+
+import Core
+import Prelude qualified as GhcPrelude
+import Starter.Counter.Entity (CounterEntity (..), initialState, update)
+import Starter.Counter.Event (CounterEvent (..))
+import Starter.Counter.Events.CounterCreated qualified as CounterCreated
+import Starter.Counter.Events.CounterIncremented qualified as CounterIncremented
+import Test.Hspec qualified as Hspec
+import Test.Hspec.QuickCheck qualified as HspecQC
+import Test.QuickCheck qualified as QC
+import Uuid qualified
+
+
+spec :: Hspec.Spec
+spec = Hspec.describe "CounterEntity replay" do
+  HspecQC.prop "value equals the total of the replayed increments" \(amounts :: [QC.Positive Int]) -> do
+    let counterId = Uuid.nil
+    let created = CounterCreated CounterCreated.Event {entityId = counterId, label = "downloads"}
+    let increments =
+          amounts
+            |> GhcPrelude.map \(QC.Positive a) ->
+              CounterIncremented CounterIncremented.Event {entityId = counterId, amount = a}
+    let events = created : increments
+    let finalState = GhcPrelude.foldl (\entity event -> update event entity) initialState events
+    let expected = GhcPrelude.sum (GhcPrelude.map (\(QC.Positive a) -> a) amounts)
+    finalState.value QC.=== expected

--- a/neo/starter/tests/Spec.hs
+++ b/neo/starter/tests/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/neo/starter/tests/integration/smoke.hurl
+++ b/neo/starter/tests/integration/smoke.hurl
@@ -1,0 +1,13 @@
+# Smoke test — verifies the HTTP server is up and the happy path of the
+# simplest command works end to end.
+
+POST http://localhost:8080/commands/create-counter
+Content-Type: application/json
+{
+  "label": "smoke-test"
+}
+
+HTTP 200
+[Asserts]
+jsonpath "$.entityId" exists
+jsonpath "$.entityId" matches /^[0-9a-f-]{36}$/

--- a/neo/starter/tests/scenarios/counter-flow.hurl
+++ b/neo/starter/tests/scenarios/counter-flow.hurl
@@ -1,0 +1,72 @@
+# Full counter lifecycle: create → increment → increment → decrement → query.
+# Final expected value: 1 (0 + 1 + 1 - 1).
+
+# --- 1. Create ---------------------------------------------------------------
+POST http://localhost:8080/commands/create-counter
+Content-Type: application/json
+{
+  "label": "downloads"
+}
+
+HTTP 200
+[Captures]
+counter_id: jsonpath "$.entityId"
+[Asserts]
+jsonpath "$.entityId" matches /^[0-9a-f-]{36}$/
+
+
+# --- 2. First increment ------------------------------------------------------
+POST http://localhost:8080/commands/increment-counter
+Content-Type: application/json
+{
+  "entityId": "{{counter_id}}",
+  "amount": 1
+}
+
+HTTP 200
+
+
+# --- 3. Second increment -----------------------------------------------------
+POST http://localhost:8080/commands/increment-counter
+Content-Type: application/json
+{
+  "entityId": "{{counter_id}}",
+  "amount": 1
+}
+
+HTTP 200
+
+
+# --- 4. Decrement ------------------------------------------------------------
+POST http://localhost:8080/commands/decrement-counter
+Content-Type: application/json
+{
+  "entityId": "{{counter_id}}",
+  "amount": 1
+}
+
+HTTP 200
+
+
+# --- 5. Query — projection is eventually consistent, so we retry ------------
+GET http://localhost:8080/queries/counter-view
+[Options]
+retry: 10
+retry-interval: 200
+
+# The query endpoint returns a paginated envelope: {items:[…], total, hasMore}.
+# Address the rows through `.items` (a bare `$[?…]` matches nothing → filter error).
+HTTP 200
+[Asserts]
+jsonpath "$.items[?(@.counterId == '{{counter_id}}')].value" nth 0 == 1
+jsonpath "$.items[?(@.counterId == '{{counter_id}}')].label" nth 0 == "downloads"
+
+
+# --- 6. Validation: empty label is rejected ---------------------------------
+POST http://localhost:8080/commands/create-counter
+Content-Type: application/json
+{
+  "label": ""
+}
+
+HTTP 400

--- a/neo/tests/e2e.rs
+++ b/neo/tests/e2e.rs
@@ -310,6 +310,47 @@ fn new_ci_two_sibling_projects_are_independent() {
     assert_eq!(beta["name"], "beta");
 }
 
+/// Offline-generation contract against the PACKAGED binary. `result/bin/neo`
+/// (the nix-built release binary) must scaffold a full project from the embedded
+/// `neo/starter/` with the network disabled — proving the installed CLI carries
+/// the starter and never fetches one at runtime. `NEO_SKIP_NETWORK=1` here is the
+/// assertion (offline is the subject), not a stub shortcut on a happy path.
+#[test]
+#[ignore]
+fn new_offline_generates_full_starter_from_packaged_binary() {
+    let sb = Sandbox::new("new_offline_generates_full_starter_from_packaged_binary");
+    sb.neo(".")
+        .env("NEO_SKIP_NETWORK", "1")
+        .args(["new", "offline-app", "--ci"])
+        .timeout(Duration::from_secs(120))
+        .assert()
+        .success();
+
+    let project = sb.path("offline-app");
+    assert!(project.exists(), "project dir missing");
+    // Full starter surfaces (presence, not count): app + launcher + a real domain
+    // module + dev flake + cabal project + the starter's test tree.
+    assert!(project.join("src/App.hs").exists(), "src/App.hs missing");
+    assert!(project.join("launcher/Launcher.hs").exists(), "launcher/Launcher.hs missing");
+    assert!(
+        project.join("src/Starter/Counter/Event.hs").exists(),
+        "embedded starter domain module missing — packaged binary shipped a stub, not the full starter"
+    );
+    assert!(project.join("flake.nix").exists(), "flake.nix missing");
+    assert!(project.join("cabal.project").exists(), "cabal.project missing");
+    assert!(project.join("tests/Spec.hs").exists(), "tests/Spec.hs missing");
+    assert!(project.join("offline-app.cabal").exists(), ".cabal not generated");
+    // Provenance manifest must not leak into a generated project.
+    assert!(!project.join("IMPORT.md").exists(), "IMPORT.md must not be scaffolded into a project");
+
+    let log = sb.git("offline-app", &["log", "--oneline"]);
+    assert!(log.status.success(), "git log failed");
+    assert!(
+        String::from_utf8_lossy(&log.stdout).contains("Initial commit from NeoCLI"),
+        "initial commit missing after offline scaffold"
+    );
+}
+
 // =====================================================
 // Group C: `neo new` edge cases
 // =====================================================

--- a/neo/tests/integration_tests.rs
+++ b/neo/tests/integration_tests.rs
@@ -99,6 +99,56 @@ fn test_neo_new_ci() {
 }
 
 #[test]
+fn test_neo_new_offline_scaffolds_full_starter() {
+    // Offline-generation contract: with NEO_SKIP_NETWORK=1 (no network at all),
+    // `neo new` must still scaffold a COMPLETE project from the embedded
+    // `neo/starter/` template — proving the starter is baked into the binary and
+    // generation does not depend on downloading anything. Run from a fresh temp
+    // dir so this also proves cwd-independence of the embedded lookup.
+    let temp = tempfile::tempdir().unwrap();
+    let project_name = "offline-app";
+
+    let mut cmd = neo_cmd();
+    cmd.current_dir(temp.path())
+        .env("NEO_SKIP_NETWORK", "1")
+        .arg("new")
+        .arg(project_name)
+        .arg("--ci")
+        .assert()
+        .success();
+
+    let project = temp.path().join(project_name);
+    // Load-bearing surfaces from the real starter (asserted by presence, never by
+    // count): app entry point, executable launcher, a real domain module (not a
+    // stub), dev flake, cabal project, and the starter's own test tree.
+    assert!(project.join("src/App.hs").exists(), "offline scaffold missing src/App.hs");
+    assert!(project.join("launcher/Launcher.hs").exists(), "offline scaffold missing launcher/Launcher.hs");
+    assert!(
+        project.join("src/Starter/Counter/Event.hs").exists(),
+        "offline scaffold missing the embedded starter domain module — a stub, not the full starter, was written"
+    );
+    assert!(project.join("flake.nix").exists(), "offline scaffold missing flake.nix");
+    assert!(project.join("cabal.project").exists(), "offline scaffold missing cabal.project");
+    assert!(project.join("tests/Spec.hs").exists(), "offline scaffold missing tests/Spec.hs");
+
+    // The monorepo-only provenance manifest must never leak into a generated project.
+    assert!(!project.join("IMPORT.md").exists(), "IMPORT.md must not be scaffolded into a project");
+
+    // The full pipeline (reconcile + git) still completes offline.
+    assert!(project.join(format!("{}.cabal", project_name)).exists(), ".cabal not generated offline");
+    assert!(project.join(".git").exists(), "git not initialized offline");
+    let git_log = std::process::Command::new("git")
+        .args(["log", "--oneline"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&git_log.stdout).contains("Initial commit from NeoCLI"),
+        "initial commit missing after offline scaffold"
+    );
+}
+
+#[test]
 fn test_neo_new_library_ci() {
     // `--library` should produce a project with no launcher/Launcher.hs file
     // and a generated .cabal without the `executable <name>` stanza.
@@ -299,9 +349,10 @@ fn test_neo_test_ci() {
 
     // Full `neo test`: reconcile → compile+run the built-in Hspec suite → wait for
     // the app to become ready (readiness poll, not a fixed sleep) → run the starter's
-    // Hurl scenarios. All must pass. (Requires the neo-starter fixes on `main`: the
-    // `counter-flow.hurl` `$.items[...]` jsonpath; before that this signals the
-    // starter↔upstream contract is broken — fix in neo-starter, per CLAUDE.md.)
+    // Hurl scenarios. All must pass. (Depends on the embedded `neo/starter/` staying
+    // coherent with upstream `neohaskell`: e.g. the `counter-flow.hurl`
+    // `$.items[...]` jsonpath; a failure here signals the starter↔upstream contract
+    // is broken — fix `neo/starter/` in this monorepo, per neo/AGENTS.md.)
     let mut cmd = neo_cmd();
     cmd.current_dir(&project_path)
         .arg("test")

--- a/nix/neo-package.nix
+++ b/nix/neo-package.nix
@@ -22,6 +22,15 @@
 #   `./dev neo-dist-check` (run in `neo-ci.yml` and locally) and the frontend is
 #   rebuilt + diffed on every IDE-touching PR. The Nix build stays offline; the
 #   freshness proof lives in the CI/`./dev` contract, not in an unverified blob.
+#
+# Embedded starter (rust-embed) contract:
+#   `src/network.rs` embeds `neo/starter/` at compile time so `neo new` scaffolds
+#   projects offline, with no runtime download. Because `src` below includes the
+#   whole `neo/` tree, any edit under `neo/starter/` changes the derivation hash
+#   and rebuilds the binary — the installed `neo` is always revision-coherent
+#   with the internalized starter. The sealed `doCheck` unit tests exercise
+#   `write_starter_template` into a temp dir, so the package build itself proves
+#   the release binary can generate a project with the network disabled.
 { lib
 , rustPlatform
 , git

--- a/scripts/neo-skills-check
+++ b/scripts/neo-skills-check
@@ -21,6 +21,11 @@ Contract (governing rule: no doc without a gate):
      `neo/.claude/skills/` (they now live at repo-root as `neo-cli-*`).
   5. CROSS-REF INTEGRITY - every `neo-cli-<x>` token mentioned in any active
      guidance file resolves to a real skill directory (no typos / dangling refs).
+  6. INTERNALIZED STARTER - the starter is source-of-truth at `neo/starter/`
+     (embedded by src/network.rs). No active guidance may cite the standalone
+     starter repo as the generation source; the starter tree must carry its
+     import/parity manifest, leak no VCS/secret/build-artifact class, and keep
+     the load-bearing generated-project surfaces (by presence, not count).
 
 Run:  ./dev neo-skills-check              CI: via ./dev doctor (seconds, no nix)
       ./dev neo-skills-check --self-test  fixture coverage (doctor/CI)
@@ -53,6 +58,28 @@ CONSOLIDATED_NESTED = (
     "running-neo-tests",
     "error-messages-instruct-llms",
     "critique-ide-screen",
+)
+
+# The standalone starter repo was internalized to `neo/starter/` (embedded into
+# the binary by src/network.rs). No ACTIVE GUIDANCE file may still point at it as
+# the generation source - that would send a fresh agent to fix the wrong tree.
+# (The provenance manifest neo/starter/IMPORT.md legitimately names the source
+# repo, but it is not an active-guidance file, so it is not scanned here.)
+EXTERNAL_STARTER_REFS = ("NeoHaskell/neo-starter", "neo-starter@main", "neo-starter/archive")
+
+# The internalized starter template and its parity manifest.
+STARTER_DIR = ("neo", "starter")
+STARTER_MANIFEST = "IMPORT.md"
+
+# Load-bearing surfaces a generated project needs. Checked by PRESENCE only -
+# never by file count, which would rot on the next starter change.
+STARTER_REQUIRED_SURFACES = ("src/App.hs", "launcher/Launcher.hs", "cabal.project", "flake.nix", "tests")
+
+# Artifact / secret / VCS-metadata classes that must never be imported into the
+# starter (see neo/starter/IMPORT.md). Matched against every path component.
+STARTER_BANNED_NAMES = (
+    ".git", "dist-newstyle", "dist", "node_modules", ".direnv",
+    ".env", ".DS_Store", ".idea", "uploads",
 )
 
 SKILL_REF_RE = re.compile(r"neo-cli-[a-z0-9-]+")
@@ -142,6 +169,18 @@ def check(root):
                     f"remove it (STATE/NEXT_STEP/IMPLEMENTATION_PLAN/ralph.sh no longer exist)"
                 )
 
+    # --- 2b. No active guidance may cite the standalone starter repo as the
+    # generation source - it was internalized to neo/starter/ (embedded).
+    for path in guidance:
+        text = read(path)
+        for ref in EXTERNAL_STARTER_REFS:
+            if ref in text:
+                errors.append(
+                    f"{path.relative_to(root)} references the standalone starter "
+                    f"`{ref}` - `neo new` now scaffolds from the embedded neo/starter/; "
+                    "point the guidance at neo/starter/ instead"
+                )
+
     # --- 3. Routing drift.
     root_agents = root / "AGENTS.md"
     if root_agents.is_file():
@@ -193,6 +232,58 @@ def check(root):
     return errors
 
 
+def check_starter(root):
+    """Validate the internalized starter (`neo/starter/`): present + non-empty,
+    the import/parity manifest exists and documents provenance + exclusions, no
+    excluded artifact/secret/VCS class leaked in, and the load-bearing generated-
+    project surfaces exist (by presence, never by count)."""
+    errors = []
+    starter = root.joinpath(*STARTER_DIR)
+    if not starter.is_dir():
+        errors.append(
+            "neo/starter/ is missing - the internalized starter template (embedded "
+            "by neo/src/network.rs) must live here"
+        )
+        return errors
+
+    if not any(p.is_file() for p in starter.rglob("*")):
+        errors.append("neo/starter/ is empty - it must contain the starter template files")
+
+    manifest = starter / STARTER_MANIFEST
+    if not manifest.is_file():
+        errors.append(
+            f"neo/starter/{STARTER_MANIFEST} is missing - the import/parity manifest "
+            "(provenance + intentional-exclusion policy) must be committed"
+        )
+    else:
+        m = read(manifest)
+        if "neo-starter" not in m:
+            errors.append(f"neo/starter/{STARTER_MANIFEST} does not name the source repository (provenance)")
+        if "exclu" not in m.lower():
+            errors.append(f"neo/starter/{STARTER_MANIFEST} does not document the intentional-exclusion policy")
+
+    # No excluded class may appear anywhere under the starter.
+    for p in starter.rglob("*"):
+        for comp in p.relative_to(starter).parts:
+            if comp in STARTER_BANNED_NAMES or comp == "result" or comp.startswith("result-"):
+                errors.append(
+                    f"neo/starter/{p.relative_to(starter)} is an excluded "
+                    f"artifact/secret/VCS class (`{comp}`) - it must not be imported "
+                    "(see neo/starter/IMPORT.md)"
+                )
+                break
+
+    # Load-bearing generated-project surfaces exist (presence, not count).
+    for surface in STARTER_REQUIRED_SURFACES:
+        if not (starter / surface).exists():
+            errors.append(
+                f"neo/starter/{surface} is missing - a generated project needs it "
+                "(offline-generation surface invariant)"
+            )
+
+    return errors
+
+
 # --------------------------------------------------------------------------- #
 # Self-test: a good fixture tree passes; each mutation fails for its own reason.
 # Runs entirely in temp dirs - never reads or mutates the real repo.
@@ -226,6 +317,25 @@ def _build_good_tree(root):
         encoding="utf-8",
     )
     (root / "neo" / "CLAUDE.md").write_text("See AGENTS.md.\n", encoding="utf-8")
+
+
+def _build_good_starter(root):
+    starter = root / "neo" / "starter"
+    (starter / "src" / "Starter").mkdir(parents=True)
+    (starter / "launcher").mkdir(parents=True)
+    (starter / "tests").mkdir(parents=True)
+    (starter / "src" / "App.hs").write_text("module App where\n", encoding="utf-8")
+    (starter / "launcher" / "Launcher.hs").write_text("module Main where\n", encoding="utf-8")
+    (starter / "cabal.project").write_text("packages: .\n", encoding="utf-8")
+    (starter / "flake.nix").write_text("{ }\n", encoding="utf-8")
+    (starter / "tests" / "Spec.hs").write_text("-- spec\n", encoding="utf-8")
+    (starter / ".env.example").write_text("KEY=value\n", encoding="utf-8")
+    (starter / STARTER_MANIFEST).write_text(
+        "# Internalized starter\n\n## Provenance\n"
+        "Source: github.com/NeoHaskell/neo-starter @ origin/main\n\n"
+        "## Intentional exclusions\nExcluded: .git/, .env, dist-newstyle/, result.\n",
+        encoding="utf-8",
+    )
 
 
 def self_test():
@@ -304,11 +414,67 @@ def self_test():
         expect(any("neo-cli-nonexistent" in e for e in errors),
                f"dangling skill reference should fail, got {errors}")
 
+    # Case 6 - a reference to the standalone starter repo in guidance fails.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _build_good_tree(root)
+        (root / "neo" / "AGENTS.md").write_text(
+            "# neo\n\n`neo new` tarballs github.com/NeoHaskell/neo-starter@main.\n"
+            "Use neo-cli-localizer, neo-cli-implementer, neo-cli-testing, neo-cli-ide.\n",
+            encoding="utf-8",
+        )
+        errors = check(root)
+        expect(any("neo-starter" in e and "embedded" in e for e in errors),
+               f"external starter reference should fail, got {errors}")
+
+    # Case 7 - a clean internalized starter passes check_starter.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _build_good_starter(root)
+        errors = check_starter(root)
+        expect(not errors, f"clean starter should pass, got {errors}")
+
+    # Case 8 - a missing parity manifest fails.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _build_good_starter(root)
+        (root / "neo" / "starter" / STARTER_MANIFEST).unlink()
+        errors = check_starter(root)
+        expect(any(STARTER_MANIFEST in e and "missing" in e for e in errors),
+               f"missing manifest should fail, got {errors}")
+
+    # Case 9 - a leaked VCS/secret class under the starter fails.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _build_good_starter(root)
+        (root / "neo" / "starter" / ".env").write_text("SECRET=1\n", encoding="utf-8")
+        errors = check_starter(root)
+        expect(any(".env" in e and "excluded" in e for e in errors),
+               f"leaked .env should fail, got {errors}")
+
+    # Case 10 - a missing load-bearing surface fails.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        _build_good_starter(root)
+        (root / "neo" / "starter" / "flake.nix").unlink()
+        errors = check_starter(root)
+        expect(any("flake.nix" in e and "missing" in e for e in errors),
+               f"missing surface should fail, got {errors}")
+
+    # Case 11 - a missing starter directory fails.
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        errors = check_starter(root)
+        expect(any("neo/starter/ is missing" in e for e in errors),
+               f"missing starter dir should fail, got {errors}")
+
     if fails:
         print("neo-skills-check self-test: FAIL", file=sys.stderr)
         return 1
     print("neo-skills-check self-test: OK - clean tree passes; missing-skill, "
-          "stale-ref, routing-drift, nested-dup, and dangling-ref mutations each rejected")
+          "stale-ref, routing-drift, nested-dup, dangling-ref, external-starter-ref, "
+          "and starter-parity (missing-manifest, leaked-secret, missing-surface, "
+          "missing-dir) mutations each rejected")
     return 0
 
 
@@ -317,7 +483,7 @@ def main(argv=None):
     if "--self-test" in argv:
         return self_test()
 
-    errors = check(REPO_ROOT)
+    errors = check(REPO_ROOT) + check_starter(REPO_ROOT)
     if errors:
         print("neo-skills-check: FAIL", file=sys.stderr)
         for e in errors:
@@ -326,7 +492,8 @@ def main(argv=None):
 
     n = len(REQUIRED_SKILLS)
     print(f"neo-skills-check: OK - {n} neo-cli-* skills present, routing intact, "
-          f"no stale state/plan refs, one source of truth")
+          f"no stale state/plan refs, one source of truth, internalized starter "
+          f"parity held")
     return 0
 
 


### PR DESCRIPTION
## What

Internalizes the NeoHaskell project starter into the monorepo and makes `neo new`
scaffold from it, so generation no longer downloads
`github.com/NeoHaskell/neo-starter@main` at runtime.

- The starter's git-tracked tree is imported verbatim under `neo/starter/` and
  embedded into the `neo` binary with rust-embed (`src/network.rs`). Generation is
  offline, and its starter content is pinned to the exact monorepo revision the
  binary was built from. Dependency reconciliation remains a separate contract.
- `fetch_starter_template` (network download + minimal offline stub) is replaced by
  `write_starter_template`, which extracts the embedded tree through a
  path-traversal-safe join and returns LLM-actionable errors on a corrupt embed.
- Failed scaffold, reconciliation, or git steps remove the newly created partial
  project rather than leaving a corrupt directory behind.
- `neo/starter/IMPORT.md` records provenance (source repo + `origin/main`) and the
  intentional-exclusion policy as durable patterns, never volatile counts. It is
  excluded from the embed so it never leaks into a generated project.

## Why

The standalone starter's mutable `main` coupled generated-project correctness to an
external repo and required the network to scaffold. Internalizing it makes the
starter revision-coherent with the monorepo, keeps generation offline, and gives
the starter-to-upstream contract a single in-repo home to fix.

Neo CLI and NeoHaskell package/version/release boundaries stay independent: the
starter is embedded content, not a Cargo/Nix dependency of the Haskell libraries.

## Packaging

- `nix/neo-package.nix` documents the embed contract. `src` already scopes the
  whole `neo/` tree, so any edit under `neo/starter/` changes the derivation hash
  and rebuilds the installed binary -> the installed `neo` is always coherent with
  the internalized starter.
- The `neo-ci.yml` changed-path classifier already routes `neo/` to the component
  jobs, so starter-only changes trigger the Neo CLI gates (asserted by
  `./dev workflow-check`).
- Dead download deps (`flate2`, `tar`) dropped; rust-embed gains `include-exclude`.

## Governance and guidance

- `./dev neo-skills-check` gains an internalized-starter contract: no active
  guidance may cite the standalone starter as the generation source, the parity
  manifest must exist, no VCS/secret/build-artifact class may leak into the tree,
  and the load-bearing generated-project surfaces must exist (by presence, not
  count). Self-test cases cover each failure mode.
- The codemap generator excludes `neo/starter/`: template examples are consumer
  fixture content, not implementation or repository API-usage evidence.
- `neo/AGENTS.md` and the `neo-cli-localizer` / `neo-cli-testing` skills now treat
  `neo/starter/` as the source of truth; stale "fix neo-starter upstream" routing
  is removed.

## Verification (local)

- `nix build .#neo` passes; its sealed `doCheck` runs the offline embedded-extraction
  unit test, proving the packaged source includes the starter bytes.
- `cargo test --bins`: full unit suite green, including the new
  `write_starter_template` extraction test and the `safe_join` traversal test.
- Blocking offline integration test: `neo new --ci` under `NEO_SKIP_NETWORK=1` from a
  temp dir scaffolds the full starter (app, launcher, `Starter.*` domain, `flake.nix`,
  `cabal.project`, test tree), inits git, and leaks no `IMPORT.md`.
- Packaged binary run from a temp dir OUTSIDE the checkout with the network disabled
  (`NEO_SKIP_NETWORK=1 ./result/bin/neo new`): generates a complete project.
- With network, the same packaged binary generates a project whose `flake.nix` pins
  the current upstream `neohaskell` commit -> revision-coherent.
- `./dev workflow-check`, `--self-test`, `./dev neo-skills-check`, `--self-test`,
  `./dev doctor`, and `git diff --check` all pass.

rustfmt/clippy remain the pre-existing report-only baseline in `neo-ci.yml`; the new
code matches the surrounding (unformatted) style rather than reformatting untouched
files.

### Generated-project build (strongest local contract)

Generated a project with network access via the packaged `./result/bin/neo`, then
ran `neo build --ci` inside it. The command locked the current upstream
`neohaskell` revision and compiled the complete embedded starter, launcher, and
test suite successfully (`BUILD_EXIT=0`).

The generated project is the compatibility contract, and this execution verified
that it builds coherently against the current upstream revision.

The next stacked layer promotes the installed-binary generated-project flow to a
blocking CI contract and overrides the NeoHaskell input to the checkout under test.


