### PR TITLE
test(neo): gate generated projects against this checkout

### DIFF
--- a/.github/workflows/neo-ci.yml
+++ b/.github/workflows/neo-ci.yml
@@ -41,6 +41,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       touched: ${{ steps.detect.outputs.touched }}
+      contract: ${{ steps.detect.outputs.contract }}
     steps:
       - uses: actions/checkout@v7.0.0
         with:
@@ -54,16 +55,29 @@ jobs:
           set -euo pipefail
           if [ "$EVENT" = "push" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
+            echo "contract=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # neo/** plus the root files the neo package derivation reads. Keep in
-          # lockstep with the `paths:` list above and with COMPONENT_SURFACES in
-          # scripts/workflow-check.
+          CHANGED="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+          # Component jobs (rust/ide/nix-package): neo/** plus the root files the
+          # neo package derivation reads. Keep in lockstep with the `paths:` list
+          # above and with COMPONENT_SURFACES in scripts/workflow-check.
           PATTERN='^(neo/|nix/neo-package\.nix|flake\.nix|flake\.lock|\.github/workflows/neo-ci\.yml)'
-          if git diff --name-only "origin/${BASE_REF}...HEAD" | grep -qE "$PATTERN"; then
+          # Consumer contract: the component surfaces PLUS the monorepo Haskell
+          # sources the generated project compiles against (core/, integrations/)
+          # — a change there can break the starter->upstream contract — plus the
+          # contract script itself. Keep in lockstep with CONTRACT_SURFACES in
+          # scripts/workflow-check.
+          CONTRACT='^(neo/|core/|integrations/|nix/neo-package\.nix|flake\.nix|flake\.lock|\.github/workflows/neo-ci\.yml|scripts/neo-consumer-contract)'
+          if echo "$CHANGED" | grep -qE "$PATTERN"; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
           else
             echo "touched=false" >> "$GITHUB_OUTPUT"
+          fi
+          if echo "$CHANGED" | grep -qE "$CONTRACT"; then
+            echo "contract=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "contract=false" >> "$GITHUB_OUTPUT"
           fi
 
   # Rust crate: the canonical in-crate unit tests (--bins, never --lib) are the
@@ -182,38 +196,87 @@ jobs:
       - name: Smoke the flake app
         run: nix run .#neo -- --version
 
+  # The generated-project consumer contract (Linux). One blocking end-to-end
+  # proof that the Nix-packaged `neo` generates a project from the embedded
+  # starter offline and that the generated project builds, tests, runs, and
+  # answers GET /health against THIS monorepo checkout (neohaskell overridden to
+  # path:<checkout>), rather than mutable upstream `main`. It orchestrates the
+  # installed binary + a real generated project; it does not duplicate the Rust
+  # unit tests. It runs on the broader `contract` surface (also core/,
+  # integrations/) because a change there can break the starter->upstream
+  # contract. Blocking (never continue-on-error): a failure here is the signal.
+  consumer-contract:
+    needs: changes
+    if: >-
+      (github.event_name == 'push' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.contract == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    steps:
+      # The contract creates a local Git input at the exact checkout revision.
+      # Nix rejects git+file inputs cloned from shallow repositories.
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: DeterminateSystems/determinate-nix-action@v3.21.7
+        with:
+          extra-conf: |
+            accept-flake-config = true
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+      - name: Self-test the contract orchestration logic (timeout, cleanup, quoting, readiness)
+        run: ./dev neo-consumer-contract --self-test
+      - name: Run the generated-project consumer contract
+        env:
+          # Keep each heavy phase inside the job wall-clock so the contract's own
+          # bounded timeout + clean teardown fire before GitHub kills the job.
+          CONTRACT_BUILD_TIMEOUT: "5400"
+          CONTRACT_TEST_TIMEOUT: "2400"
+          CONTRACT_READY_DEADLINE: "300"
+        run: ./dev neo-consumer-contract
+
   # THE REQUIRED CHECK for the neo component. `if: always()` + no workflow-level
   # paths filter => it always reports a conclusion on every PR, so it is safe to
   # require in branch protection (unlike the path-skipped jobs). Skips are
   # accepted only when there is genuinely nothing to test: a draft PR, or a PR
-  # that changed no neo surface.
+  # that changed no relevant surface (per-job: component surface for
+  # rust/ide/nix-package, the broader contract surface for consumer-contract).
   neo-ci-gate:
     if: always()
-    needs: [changes, rust, ide, nix-package]
+    needs: [changes, rust, ide, nix-package, consumer-contract]
     runs-on: ubuntu-latest
     steps:
       - name: Check all neo jobs passed (or correctly skipped)
         env:
           IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
           TOUCHED: ${{ needs.changes.outputs.touched }}
+          CONTRACT: ${{ needs.changes.outputs.contract }}
           CHANGES_RESULT: ${{ needs.changes.result }}
         run: |
           if [[ "$CHANGES_RESULT" != "success" ]]; then
             echo "::error::changes-detection job did not succeed ($CHANGES_RESULT)"
             exit 1
           fi
-          allow_skip=false
+          # Component jobs may skip on a draft or when no neo surface changed.
+          allow_skip_component=false
           if [[ "$IS_DRAFT" == "true" || "$TOUCHED" != "true" ]]; then
-            allow_skip=true
+            allow_skip_component=true
+          fi
+          # The consumer contract may skip on a draft or when no contract surface
+          # changed (it covers a broader set than the component jobs).
+          allow_skip_contract=false
+          if [[ "$IS_DRAFT" == "true" || "$CONTRACT" != "true" ]]; then
+            allow_skip_contract=true
           fi
           results=(
-            "rust=${{ needs.rust.result }}"
-            "ide=${{ needs.ide.result }}"
-            "nix-package=${{ needs.nix-package.result }}"
+            "rust=${{ needs.rust.result }}=$allow_skip_component"
+            "ide=${{ needs.ide.result }}=$allow_skip_component"
+            "nix-package=${{ needs.nix-package.result }}=$allow_skip_component"
+            "consumer-contract=${{ needs.consumer-contract.result }}=$allow_skip_contract"
           )
           for entry in "${results[@]}"; do
-            job="${entry%%=*}"; r="${entry#*=}"
-            if [[ "$r" == "skipped" && "$allow_skip" == "true" ]]; then
+            job="${entry%%=*}"; rest="${entry#*=}"
+            r="${rest%%=*}"; may_skip="${rest#*=}"
+            if [[ "$r" == "skipped" && "$may_skip" == "true" ]]; then
               continue
             fi
             if [[ "$r" != "success" ]]; then

--- a/dev
+++ b/dev
@@ -72,6 +72,10 @@ usage: ./dev <verb> [args]
   neo-dist-check        prove the committed Neo IDE bundle (assets/ide/dist,
                           embedded into the binary) is a faithful from-lockfile
                           rebuild, so nix build .#neo never ships a stale dist
+  neo-consumer-contract  end-to-end contract: nix build .#neo, generate a project
+                          from the embedded starter offline, then build/test/run it
+                          against THIS checkout (neohaskell -> path:<checkout>) and
+                          poll /health (--self-test for the orchestration logic)
   doctor                harness self-check: every script has a verb or a
                           reasoned exemption; no dangling verbs (CI-enforced)
   exec <cmd> [args]     run any command with the pinned toolchain
@@ -113,6 +117,7 @@ case "${VERB}" in
   workflow-check) exec scripts/workflow-check "$@" ;;
   neo-skills-check) exec scripts/neo-skills-check "$@" ;;
   neo-dist-check) exec scripts/neo-dist-check "$@" ;;
+  neo-consumer-contract) exec scripts/neo-consumer-contract "$@" ;;
   doctor)   exec scripts/doctor "$@" ;;
   exec)     exec scripts/with-toolchain "$@" ;;
   ""|help|-h|--help) usage ;;

--- a/neo/AGENTS.md
+++ b/neo/AGENTS.md
@@ -97,6 +97,14 @@ by the Haskell Test gate.
 | Integration | `cd neo && nix develop --command cargo test --test integration_tests -- --test-threads=1` | `cargo`-built debug `neo` (real nix + network) |
 | E2E | `cd neo && nix build && nix develop --command cargo test --test e2e -- --ignored --test-threads=1` | nix-built `result/bin/neo` (real nix + network) |
 | Neo-on-Neo smoke | `neo new` a project, then `neo build` + `neo test` inside it | the built binary on a generated project |
+| Consumer contract | `./dev neo-consumer-contract` (from the repo root) | the Nix-packaged `.#neo` on a generated project, against THIS checkout |
+
+The generated-project consumer contract is run with `./dev neo-consumer-contract`.
+It proves the packaged CLI and generated project against the checkout under test.
+Treat `scripts/neo-consumer-contract` and `.github/workflows/neo-ci.yml` as the
+executable sources of truth for its phases, routing, platform, and gate wiring; use
+`--self-test` when changing its orchestration helpers. Do not weaken the contract
+to report-only.
 
 Timing is cold-vs-warm: test *execution* is seconds, but the *first* compile of the
 Rust crate (and the Haskell that integration/e2e build inside) can take minutes on a

--- a/neo/assets/templates/cabal.project.j2
+++ b/neo/assets/templates/cabal.project.j2
@@ -8,16 +8,16 @@ packages:
 --            2) Update the tag below to match: nix eval .#neohaskell.rev --raw
 source-repository-package
   type: git
-  location: https://github.com/neohaskell/neohaskell.git
-  tag: {{ neo_sha }}
+  location: {{ neohaskell_git_url }}
+  tag: {{ neohaskell_commit }}
   subdir: core
 
 
 -- NeoHaskell integrations (OpenRouter, HTTP, etc.)
 source-repository-package
   type: git
-  location: https://github.com/neohaskell/neohaskell.git
-  tag: {{ neo_sha }}
+  location: {{ neohaskell_git_url }}
+  tag: {{ neohaskell_commit }}
   subdir: integrations
 
 {% for dep in git_dependencies %}

--- a/neo/assets/templates/flake.nix.j2
+++ b/neo/assets/templates/flake.nix.j2
@@ -7,15 +7,22 @@
   # Pinned to the SHA in cabal.project; update both together with:
   #   nix flake lock --update-input neohaskell
   #   (then sync the tag: lines in cabal.project to match)
-  inputs.neohaskell.url = "git+https://github.com/neohaskell/neohaskell.git?rev={{ neo_sha }}";
-  inputs.neohaskell.flake = false;
+{% if neohaskell_source %}  # NEO_NEOHASKELL_SOURCE override (consumer contract): build this generated
+  # project against a local NeoHaskell checkout instead of the upstream revision,
+  # so the generated project is proven against the exact monorepo checkout under
+  # test. Inert in normal `neo` use (the env var is unset). The cabal.project tag
+  # and the inputMap key below still key on {{ neo_sha }}; only the fetched source
+  # is redirected. See scripts/neo-consumer-contract.
+  inputs.neohaskell.url = "{{ neohaskell_source }}";
+{% else %}  inputs.neohaskell.url = "git+https://github.com/neohaskell/neohaskell.git?rev={{ neo_sha }}";
+{% endif %}  inputs.neohaskell.flake = false;
 
   outputs = { self, nixpkgs, flake-utils, haskellNix, neohaskell }:
     let
       supportedSystems =
         [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
 
-      neohaskellCommit = "{{ neo_sha }}";
+      neohaskellCommit = "{{ neohaskell_commit }}";
 
     in flake-utils.lib.eachSystem supportedSystems (system:
       let
@@ -27,7 +34,7 @@
               # Wire the cabal.project source-repository-package to the already-fetched
               # neohaskell flake input, so haskell.nix does not need a separate fetch.
               inputMap = {
-                "https://github.com/neohaskell/neohaskell.git/${neohaskellCommit}" = neohaskell;
+                "{{ neohaskell_git_url }}/${neohaskellCommit}" = neohaskell;
               };
               shell.buildInputs = with final; [
                 hurl

--- a/neo/src/reconcile/cabal_project.rs
+++ b/neo/src/reconcile/cabal_project.rs
@@ -2,6 +2,7 @@ use minijinja::{context, Environment};
 use std::fs;
 use crate::reconcile::resolve::{ResolvedConfig, DependencySource};
 use crate::errors::NeoError;
+use crate::reconcile::flake::local_source_override;
 
 use std::path::Path;
 
@@ -28,10 +29,13 @@ pub fn generate<P: AsRef<Path>>(
         }
     }
 
+    let local_source = local_source_override()?;
     let rendered = template.render(context! {
         git_dependencies => git_dependencies,
         file_dependencies => file_dependencies,
         neo_sha => config.neo_sha,
+        neohaskell_git_url => local_source.as_ref().map(|s| s.git_url.as_str()).unwrap_or("https://github.com/neohaskell/neohaskell.git"),
+        neohaskell_commit => local_source.as_ref().map(|s| s.rev.as_str()).unwrap_or(config.neo_sha.as_str()),
         name => config.name,
     }).map_err(|e| NeoError::TemplateError { template: "cabal.project".to_string(), reason: e.to_string() })?;
 

--- a/neo/src/reconcile/flake.rs
+++ b/neo/src/reconcile/flake.rs
@@ -10,19 +10,103 @@ pub fn generate<P: AsRef<Path>>(
     env: &Environment,
     config: &ResolvedConfig,
 ) -> miette::Result<()> {
-    let template = env.get_template("flake.nix")
-        .map_err(|e| NeoError::TemplateError { template: "flake.nix".to_string(), reason: e.to_string() })?;
+    // Consumer-contract override: when NEO_NEOHASKELL_SOURCE points at a local
+    // NeoHaskell checkout, the generated flake fetches its `neohaskell` source
+    // from that path instead of the upstream git revision. This is the
+    // deterministic redirect the generated-project consumer contract uses to
+    // build against the exact monorepo checkout under test, and it survives
+    // re-reconciliation (`neo build`/`test`/`run` regenerate flake.nix on every
+    // invocation, so the override must be reproduced here, not patched in after).
+    // Unset in normal use, so `neo new`/`neo build` behavior is unchanged.
+    // Mirrors the existing NEO_SKIP_NETWORK test hook in resolve.rs.
+    let neohaskell_source = local_source_override()?;
 
-    let rendered = template.render(context! {
-        name => config.name,
-        description => config.description,
-        neo_sha => config.neo_sha,
-    }).map_err(|e| NeoError::TemplateError { template: "flake.nix".to_string(), reason: e.to_string() })?;
+    let rendered = render(env, config, neohaskell_source.as_ref())?;
 
     let out_path = project_dir.as_ref().join("flake.nix");
     fs::write(&out_path, rendered).map_err(|e| NeoError::io_at("writing generated `flake.nix` at", &out_path, e))?;
 
     Ok(())
+}
+
+pub(super) struct LocalSourceOverride {
+    pub(super) nix_url: String,
+    pub(super) git_url: String,
+    pub(super) rev: String,
+}
+
+/// Resolve the opt-in local checkout as both a Nix git input and a Cabal git
+/// source. Both consumers use the same immutable HEAD revision. `git+file:` makes
+/// Nix export a clean source tree instead of carrying a worktree's `.git` pointer.
+pub(super) fn local_source_override() -> miette::Result<Option<LocalSourceOverride>> {
+    let Some(raw) = std::env::var_os("NEO_NEOHASKELL_SOURCE").filter(|s| !s.is_empty()) else {
+        return Ok(None);
+    };
+    local_source_override_for_path(Path::new(&raw)).map(Some)
+}
+
+fn local_source_override_for_path(path: &Path) -> miette::Result<LocalSourceOverride> {
+    if !path.is_absolute() {
+        return Err(miette::miette!(
+            "NEO_NEOHASKELL_SOURCE must be an absolute path, got `{}`",
+            path.display()
+        ));
+    }
+    let canonical = path.canonicalize().map_err(|e| NeoError::io_at(
+        "resolving NEO_NEOHASKELL_SOURCE at",
+        &path.to_path_buf(),
+        e,
+    ))?;
+    let text = canonical.to_str().ok_or_else(|| miette::miette!(
+        "NEO_NEOHASKELL_SOURCE is not valid UTF-8: `{}`",
+        canonical.display()
+    ))?;
+    let mut encoded = String::with_capacity(text.len());
+    for byte in text.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                encoded.push(byte as char);
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    let output = std::process::Command::new("git")
+        .args(["-C", text, "rev-parse", "HEAD"])
+        .output()
+        .map_err(|e| NeoError::io_at("running git in NEO_NEOHASKELL_SOURCE at", &canonical, e))?;
+    if !output.status.success() {
+        return Err(miette::miette!(
+            "NEO_NEOHASKELL_SOURCE is not a readable Git checkout: `{}`",
+            canonical.display()
+        ));
+    }
+    let rev = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if rev.len() != 40 || !rev.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return Err(miette::miette!("Git returned an invalid HEAD revision for `{}`", canonical.display()));
+    }
+    let git_url = format!("file://{encoded}");
+    let nix_url = format!("git+{git_url}?rev={rev}");
+    Ok(LocalSourceOverride { nix_url, git_url, rev })
+}
+
+/// Render the flake template. Split from `generate` so the (env-driven) override
+/// branch is unit-testable without mutating process-global environment.
+fn render(
+    env: &Environment,
+    config: &ResolvedConfig,
+    neohaskell_source: Option<&LocalSourceOverride>,
+) -> miette::Result<String> {
+    let template = env.get_template("flake.nix")
+        .map_err(|e| NeoError::TemplateError { template: "flake.nix".to_string(), reason: e.to_string() })?;
+
+    template.render(context! {
+        name => config.name,
+        description => config.description,
+        neo_sha => config.neo_sha,
+        neohaskell_source => neohaskell_source.map(|s| s.nix_url.as_str()),
+        neohaskell_git_url => neohaskell_source.map(|s| s.git_url.as_str()).unwrap_or("https://github.com/neohaskell/neohaskell.git"),
+        neohaskell_commit => neohaskell_source.map(|s| s.rev.as_str()).unwrap_or(config.neo_sha.as_str()),
+    }).map_err(|e| NeoError::TemplateError { template: "flake.nix".to_string(), reason: e.to_string() }.into())
 }
 
 #[cfg(test)]
@@ -50,9 +134,99 @@ mod tests {
         };
 
         generate(dir.path(), &env, &config).unwrap();
-        
+
         let content = fs::read_to_string(dir.path().join("flake.nix")).unwrap();
         assert!(content.contains("description: A test description"));
         assert!(content.contains("sha: abc1234"));
+    }
+
+    fn real_env() -> Environment<'static> {
+        let mut env = Environment::new();
+        env.add_template("flake.nix", include_str!("../../assets/templates/flake.nix.j2"))
+            .unwrap();
+        env
+    }
+
+    fn real_config() -> ResolvedConfig {
+        ResolvedConfig {
+            name: "acme".to_string(),
+            version: "0.1.0".to_string(),
+            neo_version: "main".to_string(),
+            neo_sha: "cafef00d".to_string(),
+            description: Some("Acme".to_string()),
+            author: None,
+            license: "MIT".to_string(),
+            kind: crate::config::ProjectKind::Executable,
+            dependencies: vec![],
+        }
+    }
+
+    #[test]
+    fn render_without_override_uses_upstream_git_rev() {
+        let out = render(&real_env(), &real_config(), None).unwrap();
+        assert!(
+            out.contains(r#"inputs.neohaskell.url = "git+https://github.com/neohaskell/neohaskell.git?rev=cafef00d";"#),
+            "default generation must fetch the pinned upstream rev:\n{out}"
+        );
+        assert!(!out.contains("path:"), "no local path override when the env is unset:\n{out}");
+        assert!(!out.contains("{%"), "no unrendered template syntax should remain:\n{out}");
+        // The inputMap key + neohaskellCommit still key on the sha regardless.
+        assert!(out.contains(r#"neohaskellCommit = "cafef00d";"#));
+    }
+
+    #[test]
+    fn render_with_override_redirects_source_to_local_git() {
+        let source = LocalSourceOverride {
+            nix_url: "git+file:///abs/checkout?rev=0123456789012345678901234567890123456789".to_string(),
+            git_url: "file:///abs/checkout".to_string(),
+            rev: "0123456789012345678901234567890123456789".to_string(),
+        };
+        let out = render(&real_env(), &real_config(), Some(&source)).unwrap();
+        assert!(
+            out.contains(r#"inputs.neohaskell.url = "git+file:///abs/checkout?rev=0123456789012345678901234567890123456789";"#),
+            "the override must redirect the neohaskell source to the local checkout:\n{out}"
+        );
+        assert!(
+            !out.contains("git+https://github.com/neohaskell/neohaskell.git?rev="),
+            "the override must replace (not duplicate) the upstream git url:\n{out}"
+        );
+        assert!(out.contains("inputs.neohaskell.flake = false;"), "flake=false must be preserved:\n{out}");
+        assert!(out.contains(r#"neohaskellCommit = "0123456789012345678901234567890123456789";"#));
+        assert!(out.contains(r#"file:///abs/checkout/${neohaskellCommit}"#));
+        assert!(!out.contains("{%"), "no unrendered template syntax should remain:\n{out}");
+    }
+
+    #[test]
+    fn render_ignores_empty_override() {
+        // An empty NEO_NEOHASKELL_SOURCE is treated as unset (see `generate`).
+        let out = render(&real_env(), &real_config(), None).unwrap();
+        assert!(out.contains("git+https://github.com/neohaskell/neohaskell.git?rev=cafef00d"));
+    }
+
+    #[test]
+    fn local_source_override_requires_git_checkout_and_encodes_unsafe_bytes() {
+        assert!(local_source_override_for_path(Path::new("relative")).is_err());
+        assert!(local_source_override_for_path(Path::new("/definitely/missing/neo-checkout")).is_err());
+
+        let dir = tempfile::tempdir().unwrap();
+        let checkout = dir.path().join("checkout with # marker");
+        fs::create_dir(&checkout).unwrap();
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .arg("-C").arg(&checkout).args(args).status().unwrap();
+            assert!(status.success());
+        };
+        git(&["init", "-q"]);
+        git(&["config", "user.email", "contract@example.invalid"]);
+        git(&["config", "user.name", "Consumer Contract"]);
+        git(&["commit", "--allow-empty", "-qm", "fixture"]);
+
+        let source = local_source_override_for_path(&checkout).unwrap();
+        assert!(source.nix_url.starts_with("git+file:///"));
+        assert!(source.nix_url.contains("checkout%20with%20%23%20marker"));
+        assert!(source.nix_url.ends_with(&format!("?rev={}", source.rev)));
+        assert!(source.git_url.starts_with("file:///"));
+        assert!(!source.nix_url.contains(' '));
+        assert!(!source.nix_url.contains('#'));
     }
 }

--- a/neo/src/subprocess/hurl.rs
+++ b/neo/src/subprocess/hurl.rs
@@ -12,6 +12,37 @@ pub struct HurlResult {
     pub duration: std::time::Duration,
 }
 
+fn sanitized_ci_output(bytes: &[u8]) -> String {
+    const MAX_LINES: usize = 200;
+    const MAX_CHARS: usize = 16_000;
+    const SENSITIVE: &[&str] = &[
+        "authorization", "cookie", "password", "passwd", "token=", "api_key",
+        "apikey", "secret", "credential",
+    ];
+
+    let text = String::from_utf8_lossy(bytes);
+    let mut lines = text.lines().rev().take(MAX_LINES).collect::<Vec<_>>();
+    lines.reverse();
+    let redacted = lines
+        .into_iter()
+        .map(|line| {
+            let lower = line.to_ascii_lowercase();
+            if SENSITIVE.iter().any(|needle| lower.contains(needle)) {
+                "[REDACTED]"
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    if redacted.chars().count() <= MAX_CHARS {
+        redacted
+    } else {
+        let tail = redacted.chars().rev().take(MAX_CHARS).collect::<Vec<_>>();
+        format!("[output truncated]\n{}", tail.into_iter().rev().collect::<String>())
+    }
+}
+
 pub async fn discover_tests(base_path: Option<&std::path::Path>) -> miette::Result<Vec<PathBuf>> {
     let mut tests = Vec::new();
     let tests_dir = if let Some(base) = base_path {
@@ -42,7 +73,7 @@ pub async fn run_test(path: &PathBuf, output_mode: &mut OutputMode) -> miette::R
         println!("[info] Running Hurl test: {:?}", path);
     }
 
-    let mut child = Command::new("nix")
+    let child = Command::new("nix")
         .args(["develop", "--command", "hurl", "--test"])
         .arg(path)
         .stdout(Stdio::piped())
@@ -54,7 +85,7 @@ pub async fn run_test(path: &PathBuf, output_mode: &mut OutputMode) -> miette::R
             fix: "Ensure `nix` is installed and `hurl` is available inside `nix develop` (it is in this repo's flake). Re-run from the project root.".to_string(),
         })?;
 
-    let status = child.wait().await
+    let output = child.wait_with_output().await
         .map_err(|e| NeoError::SubprocessFailed {
             operation: format!("waiting on `hurl --test {}`", path.display()),
             cause: format!("could not reap child process: {}", e),
@@ -62,10 +93,20 @@ pub async fn run_test(path: &PathBuf, output_mode: &mut OutputMode) -> miette::R
         })?;
 
     let duration = start.elapsed();
+    if output_mode.is_ci() && !output.status.success() {
+        let stdout = sanitized_ci_output(&output.stdout);
+        let stderr = sanitized_ci_output(&output.stderr);
+        if !stdout.trim().is_empty() {
+            eprintln!("[fail] hurl stdout for {}:\n{}", path.display(), stdout.trim_end());
+        }
+        if !stderr.trim().is_empty() {
+            eprintln!("[fail] hurl stderr for {}:\n{}", path.display(), stderr.trim_end());
+        }
+    }
     
     Ok(HurlResult {
         file: path.clone(),
-        success: status.success(),
+        success: output.status.success(),
         duration,
     })
 }
@@ -98,5 +139,17 @@ mod tests {
         let dir = tempdir().unwrap();
         let tests = discover_tests(Some(dir.path())).await.unwrap();
         assert!(tests.is_empty());
+    }
+
+    #[test]
+    fn ci_output_redacts_sensitive_lines_and_keeps_diagnostics() {
+        let output = sanitized_ci_output(
+            b"assertion failed\nAuthorization: Bearer private\npassword=hunter2\nstatus 500\n",
+        );
+        assert!(output.contains("assertion failed"));
+        assert!(output.contains("status 500"));
+        assert_eq!(output.matches("[REDACTED]").count(), 2);
+        assert!(!output.contains("private"));
+        assert!(!output.contains("hunter2"));
     }
 }

--- a/neo/src/subprocess/nix.rs
+++ b/neo/src/subprocess/nix.rs
@@ -39,16 +39,24 @@ pub async fn spawn_app() -> miette::Result<tokio::process::Child> {
 pub async fn kill_app(mut child: tokio::process::Child) {
     #[cfg(unix)]
     if let Some(pid) = child.id() {
-        let group = format!("-{pid}");
-        let _ = std::process::Command::new("kill")
-            .args(["-TERM", &group])
+        let group = pid.to_string();
+        let _ = std::process::Command::new("pkill")
+            .args(["-TERM", "-g", &group])
             .status();
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-        let _ = std::process::Command::new("kill")
-            .args(["-KILL", &group])
+        let _ = std::process::Command::new("pkill")
+            .args(["-KILL", "-g", &group])
             .status();
     }
-    let _ = child.wait().await;
+    // Group signalling is best-effort and depends on the platform's `pkill`.
+    // Always terminate the direct child too, and never let test teardown hang
+    // indefinitely after every assertion has already completed.
+    let _ = child.start_kill();
+    let _ = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        child.wait(),
+    )
+    .await;
 }
 
 pub async fn test(output_mode: &mut OutputMode) -> miette::Result<()> {
@@ -379,5 +387,20 @@ mod tests {
         if let Ok(mut child) = result {
             child.kill().await.ok();
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn kill_app_is_bounded_even_when_child_ignores_term() {
+        let mut cmd = Command::new("bash");
+        cmd.args(["-c", "trap '' TERM; sleep 300"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        cmd.process_group(0);
+        let child = cmd.spawn().unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(8), kill_app(child))
+            .await
+            .expect("kill_app must never hang during test teardown");
     }
 }

--- a/scripts/neo-consumer-contract
+++ b/scripts/neo-consumer-contract
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+#
+# neo-consumer-contract — the executable consumer contract for `neo new` output.
+#
+# One blocking end-to-end proof that the Nix-packaged `neo` can generate a project
+# from the *internal* starter and that the generated project can build, test, run,
+# and answer a health request against the EXACT NeoHaskell monorepo checkout under
+# test — not the mutable upstream `main`. It orchestrates the actually-installed
+# binary and the actually-generated project; it does not re-test neo's Rust units
+# or the starter tree in isolation (neo-ci.yml already does that).
+#
+# Phases (each prints concise evidence; any failed invariant exits nonzero):
+#   0. preflight        require nix + git; resolve the checkout; make a temp world
+#   1. package          nix build .#neo  (the installed binary under test)
+#   2. generate         neo new, OFFLINE, from the embedded starter (outside the
+#                       checkout); assert generated surfaces + absence of the
+#                       internal-only provenance file
+#   3. build            neo build, with the neohaskell source overridden to
+#                       path:<checkout>; assert the override actually landed
+#   4. test             neo test --ci  (the generated project's blocking Haskell
+#                       unit/property/integration specs + its Hurl scenarios)
+#   5. run + health     neo run in the background; poll GET /health for 200 with a
+#                       bounded deadline (never a fixed sleep); exercise the starter
+#                       smoke command; terminate the whole process tree cleanly
+#
+# The override is deterministic and leaves normal user generation untouched: it is
+# carried by NEO_NEOHASKELL_SOURCE, which the neo reconciler honors only when set
+# (see neo/src/reconcile/flake.rs). Generation runs OFFLINE (NEO_SKIP_NETWORK=1),
+# so it exercises the embedded starter with no network round-trip.
+#
+# Run:  ./dev neo-consumer-contract            full contract (heavy: builds Haskell)
+#       ./dev neo-consumer-contract --self-test orchestration-logic self-tests (fast)
+#
+# Tunables (env): CONTRACT_APP_PORT (8080), CONTRACT_READY_DEADLINE (240),
+#   CONTRACT_BUILD_TIMEOUT (5400), CONTRACT_TEST_TIMEOUT (3600),
+#   CONTRACT_KEEP_LOGS_ON_FAIL (1). NEO_BIN=<path> reuses an already-built binary
+#   and skips phase 1.
+
+set -euo pipefail
+
+# --------------------------------------------------------------------------- #
+# Small, side-effect-free orchestration helpers (unit-tested by --self-test).  #
+# --------------------------------------------------------------------------- #
+
+log()   { printf '%s\n' "$*"; }
+phase() { printf '\n=== [neo-consumer-contract] %s ===\n' "$*"; }
+info()  { printf '  - %s\n' "$*"; }
+die()   { printf 'neo-consumer-contract: FAIL — %s\n' "$*" >&2; exit 1; }
+
+# Start a command in its own process session. SESSION_PID is both the direct PID
+# and PGID, so cleanup remains valid if descendants are reparented. Python's
+# os.setsid is portable across the Linux CI runner and local macOS validation.
+SESSION_PID=""
+start_session() {
+  local ready i
+  ready="$(mktemp "${TMPDIR:-/tmp}/neo-contract-session.XXXXXX")"
+  rm -f "$ready"
+  python3 -c 'import os, sys
+ready = sys.argv[1]
+os.setsid()
+with open(ready, "w", encoding="utf-8"):
+    pass
+os.execvp(sys.argv[2], sys.argv[2:])' "$ready" "$@" &
+  SESSION_PID=$!
+
+  # The child acknowledges os.setsid() before exec, eliminating the Linux race
+  # between launching a phase and the timeout watcher probing its process group.
+  for i in $(seq 1 100); do
+    if [ -f "$ready" ]; then
+      rm -f "$ready"
+      return 0
+    fi
+    if ! kill -0 "$SESSION_PID" 2>/dev/null; then
+      rm -f "$ready"
+      wait "$SESSION_PID" 2>/dev/null || true
+      return 1
+    fi
+    sleep 0.01
+  done
+  rm -f "$ready"
+  return 1
+}
+
+session_alive() {
+  python3 -c 'import os, sys
+try:
+    os.killpg(int(sys.argv[1]), 0)
+except ProcessLookupError:
+    raise SystemExit(1)
+except PermissionError:
+    pass' "$1"
+}
+
+# Terminate every process in a dedicated session, poll briefly, then force any
+# survivors down. A detached child would need to create a new session explicitly
+# to escape this boundary; the nix/cabal/app chain does not do that.
+kill_session() {
+  local pgid="$1" i
+  python3 -c 'import os, signal, sys
+try: os.killpg(int(sys.argv[1]), signal.SIGTERM)
+except ProcessLookupError: pass' "$pgid"
+  for i in 1 2 3 4 5; do
+    session_alive "$pgid" || return 0
+    sleep 0.1
+  done
+  python3 -c 'import os, signal, sys
+try: os.killpg(int(sys.argv[1]), signal.SIGKILL)
+except ProcessLookupError: pass' "$pgid"
+}
+
+# Run a command with a bounded wall-clock in a dedicated process session.
+# Python owns the child synchronously, so no shell watcher can race startup or
+# inherit the caller's EXIT trap. Exit 124 means and only means timeout.
+run_with_timeout() {
+  local secs="$1"; shift
+  python3 -c 'import os, signal, subprocess, sys
+limit = float(sys.argv[1])
+child = subprocess.Popen(sys.argv[2:], start_new_session=True)
+try:
+    rc = child.wait(timeout=limit)
+except subprocess.TimeoutExpired:
+    try:
+        os.killpg(child.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        child.wait(timeout=0.5)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(child.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        child.wait()
+    raise SystemExit(124)
+raise SystemExit(128 - rc if rc < 0 else rc)' "$secs" "$@"
+}
+
+# Poll an HTTP endpoint until it answers 200, or the bounded deadline elapses.
+# Never a fixed readiness sleep: it returns as soon as the server is actually
+# serving. Any non-200 / connection error is "not ready yet — retry". Returns 0
+# when ready, 1 on deadline. All args are quoted so a URL/path with odd chars is
+# safe.
+poll_http_200() {
+  local url="$1" deadline="$2" interval="${3:-1}"
+  local waited=0 code
+  while [ "$waited" -lt "$deadline" ]; do
+    code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null || true)"
+    if [ "$code" = "200" ]; then
+      return 0
+    fi
+    sleep "$interval"
+    waited=$((waited + interval))
+  done
+  return 1
+}
+
+# Assertion helpers — every path is quoted, so a workdir containing spaces is safe.
+assert_file()    { [ -f "$1" ] || die "expected file is missing: $1 ($2)"; }
+assert_absent()  { [ ! -e "$1" ] || die "file must NOT be present: $1 ($2)"; }
+assert_contains() {
+  local file="$1" needle="$2" desc="$3"
+  [ -f "$file" ] || die "cannot check '$needle' — $file is missing ($desc)"
+  grep -qF -- "$needle" "$file" || die "expected '$needle' in $file ($desc)"
+}
+
+# --------------------------------------------------------------------------- #
+# Full contract.                                                              #
+# --------------------------------------------------------------------------- #
+
+APP_PORT="${CONTRACT_APP_PORT:-8080}"
+READY_DEADLINE="${CONTRACT_READY_DEADLINE:-240}"
+BUILD_TIMEOUT="${CONTRACT_BUILD_TIMEOUT:-5400}"
+TEST_TIMEOUT="${CONTRACT_TEST_TIMEOUT:-3600}"
+APP_NAME="neo-consumer-probe"
+
+WORK=""          # scratch world (project + build); always removed
+LOGDIR=""        # phase logs; kept on failure for triage
+declare -a BG_PIDS=()
+OWNER_PID="$BASHPID"
+
+cleanup() {
+  local rc=$?
+  # Bash subshells inherit EXIT traps. Only the top-level contract invocation
+  # owns scratch data and process-session teardown.
+  [ "$BASHPID" = "$OWNER_PID" ] || return "$rc"
+  # Terminate every dedicated process session we started.
+  local pid
+  for pid in "${BG_PIDS[@]:-}"; do
+    [ -n "$pid" ] || continue
+    kill_session "$pid"
+  done
+  if [ -n "$WORK" ] && [ -d "$WORK" ]; then
+    if [ "$rc" -ne 0 ] && [ "${CONTRACT_KEEP_LOGS_ON_FAIL:-1}" = "1" ]; then
+      printf 'neo-consumer-contract: scratch world preserved in %s\n' "$WORK" >&2
+    else
+      rm -rf "$WORK" 2>/dev/null || true
+    fi
+  fi
+  if [ -n "$LOGDIR" ] && [ -d "$LOGDIR" ]; then
+    if [ "$rc" -ne 0 ] && [ "${CONTRACT_KEEP_LOGS_ON_FAIL:-1}" = "1" ]; then
+      printf 'neo-consumer-contract: logs preserved for triage in %s\n' "$LOGDIR" >&2
+    else
+      rm -rf "$LOGDIR" 2>/dev/null || true
+    fi
+  fi
+}
+
+run_contract() {
+  trap cleanup EXIT INT TERM
+
+  # -- Phase 0: preflight ---------------------------------------------------- #
+  phase "0. preflight"
+  command -v nix  >/dev/null 2>&1 || die "nix is required (this contract builds .#neo and a Haskell project)"
+  command -v git  >/dev/null 2>&1 || die "git is required (neo new git-inits the generated project)"
+  command -v curl >/dev/null 2>&1 || die "curl is required (health poll + smoke request)"
+  command -v python3 >/dev/null 2>&1 || die "python3 is required (portable process-session isolation)"
+
+  local repo_root
+  repo_root="$(cd "$(dirname "$0")/.." && pwd -P)"
+  [ -f "$repo_root/flake.nix" ] || die "not at the monorepo root (no flake.nix at $repo_root)"
+  info "checkout under test: $repo_root"
+
+  WORK="$(mktemp -d "${TMPDIR:-/tmp}/neo-consumer-contract.XXXXXX")"
+  LOGDIR="$(mktemp -d "${TMPDIR:-/tmp}/neo-consumer-contract-logs.XXXXXX")"
+  info "scratch world (outside the checkout): $WORK"
+  case "$WORK" in
+    "$repo_root"|"$repo_root"/*) die "scratch world must live OUTSIDE the checkout" ;;
+  esac
+
+  # Use an isolated local clone at exactly HEAD. Nix consumes it through a
+  # `git+file:` URL (clean store export), while Cabal consumes the matching
+  # `file:` Git URL and revision. This avoids both mutable upstream and a
+  # worktree `.git` pointer escaping into a sandbox.
+  if ! git -C "$repo_root" diff --quiet HEAD -- core integrations; then
+    die "core/ or integrations/ has uncommitted changes; commit them before running the consumer contract"
+  fi
+  local source_snapshot="$WORK/neohaskell-source"
+  git clone --quiet --no-local "$repo_root" "$source_snapshot"
+  local source_rev
+  source_rev="$(git -C "$repo_root" rev-parse HEAD)"
+  git -C "$source_snapshot" checkout --quiet --detach "$source_rev"
+  info "NeoHaskell source snapshot: $source_rev"
+
+  # -- Phase 1: build the installed package ---------------------------------- #
+  local neo_bin
+  if [ -n "${NEO_BIN:-}" ]; then
+    phase "1. package (reuse NEO_BIN)"
+    neo_bin="$NEO_BIN"
+    assert_file "$neo_bin" "provided NEO_BIN must exist"
+  else
+    phase "1. package — nix build .#neo"
+    nix build "$repo_root#neo" --print-build-logs --out-link "$WORK/neo-result" \
+      2>&1 | tee "$LOGDIR/1-package.log"
+    neo_bin="$WORK/neo-result/bin/neo"
+    assert_file "$neo_bin" "nix build .#neo must produce bin/neo"
+  fi
+  info "neo binary: $neo_bin"
+  info "version: $("$neo_bin" --version 2>&1 | head -1)"
+
+  # -- Phase 2: generate offline from the embedded starter ------------------- #
+  phase "2. generate — neo new (offline, embedded starter)"
+  local proj="$WORK/$APP_NAME"
+  (
+    cd "$WORK"
+    NEO_SKIP_NETWORK=1 "$neo_bin" --ci new "$APP_NAME"
+  ) 2>&1 | tee "$LOGDIR/2-generate.log"
+  assert_file "$proj/neo.json"               "neo.json is the project manifest"
+  assert_file "$proj/flake.nix"              "generated dev flake"
+  assert_file "$proj/cabal.project"          "generated cabal.project"
+  assert_file "$proj/src/App.hs"             "application entry module"
+  assert_file "$proj/launcher/Launcher.hs"   "executable launcher"
+  # A real starter domain module (not a stub) — proves the embedded functional
+  # starter was scaffolded, not a placeholder.
+  assert_file "$proj/src/Starter/Counter/Event.hs" "starter counter domain"
+  assert_file "$proj/tests/integration/smoke.hurl" "starter smoke scenario"
+  # Internal-only provenance must never leak into a user's project.
+  assert_absent "$proj/IMPORT.md" "starter provenance file is internal-only"
+  info "generated surfaces present; internal provenance absent"
+
+  # -- Phase 3: build against the checkout under test ------------------------ #
+  phase "3. build — neo build (neohaskell → committed checkout snapshot)"
+  info "readiness/build bind host stays product-default (0.0.0.0); tested via loopback"
+  local ovr_env=(NEO_SKIP_NETWORK=1 "NEO_NEOHASKELL_SOURCE=$source_snapshot")
+  local build_rc=0
+  (
+    cd "$proj"
+    run_with_timeout "$BUILD_TIMEOUT" env "${ovr_env[@]}" \
+      "$neo_bin" --ci build --skip-lock-check
+  ) 2>&1 | tee "$LOGDIR/3-build.log" || build_rc="${PIPESTATUS[0]}"
+  [ "$build_rc" -eq 0 ] || die "neo build failed (see $LOGDIR/3-build.log)"
+  # Prove the override actually landed in the regenerated flake (reconcile runs
+  # on every neo build, so this confirms the redirect survives regeneration).
+  assert_contains "$proj/flake.nix" "git+file://" \
+    "neo build must regenerate flake.nix with the local-checkout override"
+  assert_contains "$proj/cabal.project" "file://" \
+    "neo build must regenerate cabal.project with the matching local Git source"
+  assert_contains "$proj/flake.nix" "?rev=$source_rev" \
+    "Nix input revision must equal the isolated checkout HEAD"
+  assert_contains "$proj/flake.nix" "neohaskellCommit = \"$source_rev\"" \
+    "inputMap revision must equal the isolated checkout HEAD"
+  assert_contains "$proj/cabal.project" "tag: $source_rev" \
+    "Cabal revision must equal the isolated checkout HEAD"
+  info "override confirmed in regenerated flake.nix"
+
+  # -- Phase 4: the generated project's own blocking test suite -------------- #
+  phase "4. test — neo test --ci (Haskell specs + Hurl scenarios)"
+  local test_rc=0
+  (
+    cd "$proj"
+    run_with_timeout "$TEST_TIMEOUT" env "${ovr_env[@]}" "$neo_bin" --ci test
+  ) 2>&1 | tee "$LOGDIR/4-test.log" || test_rc="${PIPESTATUS[0]}"
+  [ "$test_rc" -eq 0 ] || die "neo test failed (see $LOGDIR/4-test.log)"
+  info "generated project's unit/property/integration + Hurl suites passed"
+
+  # -- Phase 5: run, health poll, smoke, clean teardown ---------------------- #
+  phase "5. run + health — neo run, poll /health, smoke, terminate"
+  local run_log="$LOGDIR/5-run.log"
+  start_session bash -c 'cd "$1"; shift; exec "$@"' _ "$proj" \
+    env "${ovr_env[@]}" "$neo_bin" --ci run >"$run_log" 2>&1
+  local run_pid="$SESSION_PID"
+  BG_PIDS+=("$run_pid")
+
+  local health_url="http://127.0.0.1:${APP_PORT}/health"
+  info "polling $health_url (deadline ${READY_DEADLINE}s, no fixed sleeps)"
+  if ! poll_http_200 "$health_url" "$READY_DEADLINE"; then
+    log "----- neo run log (tail) -----"; tail -n 40 "$run_log" >&2 || true
+    die "the app did not answer 200 on /health within ${READY_DEADLINE}s"
+  fi
+  local health_body
+  health_body="$(curl -s --max-time 5 "$health_url" || true)"
+  case "$health_body" in
+    *'"status":"ok"'*) info "health: 200 $health_body" ;;
+    *) die "/health answered 200 but with an unexpected body: $health_body" ;;
+  esac
+
+  # Starter smoke scenario against the RUNNING app: create a counter, expect a
+  # 200 and a UUID entity id.
+  info "smoke: POST /commands/create-counter"
+  local smoke_resp
+  smoke_resp="$(curl -s --max-time 10 -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"label":"neo-consumer-contract"}' \
+    "http://127.0.0.1:${APP_PORT}/commands/create-counter" || true)"
+  case "$smoke_resp" in
+    *'"entityId"'*) info "smoke ok: $smoke_resp" ;;
+    *) log "----- neo run log (tail) -----"; tail -n 40 "$run_log" >&2 || true
+       die "smoke command did not return an entityId: $smoke_resp" ;;
+  esac
+
+  # Clean teardown of the whole app tree (also enforced by the trap).
+  kill_session "$run_pid"
+  BG_PIDS=()
+  info "app terminated cleanly"
+
+  phase "PASS — generated project built, tested, ran, and answered /health against $repo_root"
+}
+
+# --------------------------------------------------------------------------- #
+# Self-test: exercise the orchestration helpers fast, without building a world. #
+# Covers timeout, process-session cleanup, path quoting, failure propagation,  #
+# the readiness poll (both success and bounded-deadline failure).               #
+# --------------------------------------------------------------------------- #
+
+self_test() {
+  local fails=0
+  ok()   { printf '  ok   %s\n' "$1"; }
+  bad()  { printf '  FAIL %s\n' "$1" >&2; fails=$((fails + 1)); }
+  check(){ if eval "$2"; then ok "$1"; else bad "$1"; fi; }
+
+  # 1. run_with_timeout kills an over-running command and reports 124.
+  local start end
+  start="$(date +%s)"
+  if run_with_timeout 1 sleep 30; then
+    bad "timeout: an over-running command must not report success"
+  else
+    local rc=$?
+    [ "$rc" -eq 124 ] && ok "timeout: over-run reported as 124" \
+      || bad "timeout: expected 124, got $rc"
+  fi
+  end="$(date +%s)"
+  check "timeout: fired promptly (< 8s wall clock)" "[ $((end - start)) -lt 8 ]"
+
+  # 2. run_with_timeout lets a fast command through with its real status.
+  if run_with_timeout 10 true; then ok "timeout: fast success passes through"
+  else bad "timeout: fast success wrongly failed"; fi
+  if run_with_timeout 10 false; then bad "timeout: failure wrongly reported success"
+  else ok "timeout: real failure propagates"; fi
+  if run_with_timeout 10 bash -c 'kill -TERM $$'; then
+    bad "timeout: independently SIGTERM-ed command wrongly reported success"
+  else
+    rc=$?
+    [ "$rc" -eq 143 ] && ok "timeout: independent SIGTERM remains 143" \
+      || bad "timeout: independent SIGTERM was misclassified as $rc"
+  fi
+
+  # 3. A dedicated session remains killable after the direct parent exits and
+  #    its child is reparented.
+  local child_file="$LOGDIR_ST/reparented.pid"
+  start_session bash -c 'sleep 300 & echo $! > "$1"' _ "$child_file"
+  local parent="$SESSION_PID"
+  local i
+  for i in $(seq 1 50); do
+    [ -s "$child_file" ] && break
+    sleep 0.02
+  done
+  local grandchild
+  grandchild="$(cat "$child_file" 2>/dev/null || true)"
+  if [ -z "$grandchild" ]; then
+    bad "cleanup: reparented descendant PID was not captured"
+  fi
+  kill_session "$parent"
+  if [ -n "$grandchild" ] && kill -0 "$grandchild" 2>/dev/null; then
+    kill -KILL "$grandchild" 2>/dev/null || true
+    bad "cleanup: reparented descendant survived its process session"
+  else
+    ok "cleanup: reparented descendant terminated with its session"
+  fi
+
+  # 4. Path quoting: assertions operate correctly inside a dir with a space.
+  local spaced="$LOGDIR_ST/dir with space"
+  mkdir -p "$spaced"
+  printf 'neohaskell = true\n' > "$spaced/flake.nix"
+  ( assert_file "$spaced/flake.nix" "spaced path" ) >/dev/null 2>&1 \
+    && ok "quoting: assert_file handles spaces" \
+    || bad "quoting: assert_file broke on a spaced path"
+  ( assert_contains "$spaced/flake.nix" "neohaskell = true" "spaced grep" ) >/dev/null 2>&1 \
+    && ok "quoting: assert_contains handles spaces" \
+    || bad "quoting: assert_contains broke on a spaced path"
+  ( assert_absent "$spaced/nope" "spaced absent" ) >/dev/null 2>&1 \
+    && ok "quoting: assert_absent handles spaces" \
+    || bad "quoting: assert_absent broke on a spaced path"
+
+  # 5. Failure propagation: a failing assertion exits nonzero (subshell).
+  if ( assert_file "$LOGDIR_ST/definitely-missing" "should fail" ) >/dev/null 2>&1; then
+    bad "failure: a missing-file assertion wrongly succeeded"
+  else
+    ok "failure: assertion failure propagates a nonzero exit"
+  fi
+
+  # 6a. Readiness poll SUCCESS against a live server. Requires binding a loopback
+  #     port; in a restricted sandbox that forbids bind() this degrades to a
+  #     reported skip (CI, where the contract actually runs, is not restricted).
+  if command -v python3 >/dev/null 2>&1; then
+    local srvroot="$LOGDIR_ST/srv"
+    mkdir -p "$srvroot"; printf 'ok\n' > "$srvroot/index.html"
+    start_session bash -c 'cd "$1" && exec env PYTHONUNBUFFERED=1 python3 -m http.server 0' _ "$srvroot" >"$LOGDIR_ST/srv.log" 2>&1
+    local srv_pid="$SESSION_PID"
+    # Discover the ephemeral port the server actually bound.
+    local port="" tries=0
+    while [ -z "$port" ] && [ "$tries" -lt 25 ]; do
+      port="$(grep -oiE 'port [0-9]+' "$LOGDIR_ST/srv.log" 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)"
+      sleep 0.2; tries=$((tries + 1))
+    done
+    if [ -n "$port" ]; then
+      if poll_http_200 "http://127.0.0.1:${port}/" 10; then ok "readiness: live server reported ready"
+      else bad "readiness: failed to detect a live server"; fi
+    else
+      ok "readiness: (skipped live-server success check — could not bind a loopback port here)"
+    fi
+    kill_session "$srv_pid"
+    wait "$srv_pid" 2>/dev/null || true
+  else
+    ok "readiness: (skipped live-server check — python3 absent)"
+  fi
+  # Bounded failure: a closed port must return non-ready within the deadline.
+  start="$(date +%s)"
+  if poll_http_200 "http://127.0.0.1:1/" 2; then
+    bad "readiness: a dead endpoint was wrongly reported ready"
+  else
+    ok "readiness: dead endpoint fails within the deadline"
+  fi
+  end="$(date +%s)"
+  check "readiness: bounded (dead-endpoint poll < 6s)" "[ $((end - start)) -lt 6 ]"
+
+  if [ "$fails" -ne 0 ]; then
+    printf 'neo-consumer-contract self-test: FAILED (%s)\n' "$fails" >&2
+    return 1
+  fi
+  printf 'neo-consumer-contract self-test: OK — timeout, cleanup, quoting, failure-propagation, readiness\n'
+  return 0
+}
+
+main() {
+  case "${1:-}" in
+    --self-test)
+      LOGDIR_ST="$(mktemp -d "${TMPDIR:-/tmp}/neo-consumer-contract-selftest.XXXXXX")"
+      trap '[ "$BASHPID" != "$OWNER_PID" ] || rm -rf "$LOGDIR_ST" 2>/dev/null || true' EXIT
+      self_test
+      ;;
+    ""|--run)
+      run_contract
+      ;;
+    -h|--help)
+      sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+      ;;
+    *)
+      die "unknown argument '${1}' (use --self-test, --run, or --help)"
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -22,6 +22,17 @@ Two contracts, both learned from real breakage:
      (core/, testbed/, integrations/) so a real code change can never read
      compiled=false and let ci-gate accept a green no-op skip.
 
+  5. Generated-project consumer contract (neo-ci.yml): the neo component gate
+     also carries ONE blocking end-to-end job (`consumer-contract`) that proves
+     the Nix-packaged `neo` generates a project from the embedded starter and
+     that the generated project builds/tests/runs/answers /health against the
+     monorepo checkout under test. It is unreviewable-by-eye that this job stays
+     (a) present, (b) blocking (never continue-on-error / report-only), (c) on
+     Linux, (d) required through neo-ci-gate, and (e) triggered for every
+     relevant surface (neo/, core/, integrations/). This freezes all five so a
+     regression that silently removes, weakens, or de-scopes the contract fails
+     loudly.
+
   4. Neo CLI component gate (neo-ci.yml): now that neo has its own crate CI, the
      Neo CLI is gated by neo-ci.yml, NOT by the Haskell Test gate (test.yml no
      longer classifies neo/** as compiled; see contract 3). Two invariants keep
@@ -56,6 +67,15 @@ COMPILED_SURFACES = ("core/", "testbed/", "integrations/")
 # contract 4. It intentionally has NO base-branch allowlist (stacked PRs).
 COMPONENT_GATE = "neo-ci.yml"
 COMPONENT_SURFACES = ("neo/",)
+
+# The generated-project consumer-contract job (contract 5) + the surfaces its
+# broader classifier must route. It covers the component surfaces PLUS the
+# monorepo Haskell sources the generated project compiles against, because a
+# change there can break the starter->upstream contract.
+CONSUMER_CONTRACT_JOB = "consumer-contract"
+CONTRACT_GATE_JOB = "neo-ci-gate"
+CONTRACT_SURFACES = ("neo/", "core/", "integrations/")
+CONTRACT_VERB = "neo-consumer-contract"
 
 
 def _indent(line):
@@ -371,6 +391,13 @@ def classifier_pattern(text):
     return m.group(1) if m else None
 
 
+def contract_classifier_pattern(text):
+    """The broader consumer-contract classifier regex (CONTRACT='…') in the
+    `changes` job — routes the surfaces that trigger the end-to-end contract."""
+    m = re.search(r"CONTRACT='([^']*)'", text)
+    return m.group(1) if m else None
+
+
 def check_required_gate(name, text):
     """test.yml is the required merge gate. Two bootstrap invariants (contract 3):
     it must trigger on PRs to every GATE_BASE_BRANCHES base, and its classifier
@@ -426,6 +453,82 @@ def check_component_gate(name, text):
     return errs
 
 
+def check_consumer_contract(name, text):
+    """The generated-project consumer contract (contract 5) is one blocking
+    end-to-end job in the neo component gate. Freeze five invariants so it cannot
+    be silently removed, weakened to report-only, moved off Linux, decoupled from
+    the required gate, or de-scoped for a relevant surface."""
+    errs = []
+    E = errs.append
+    jobs = job_blocks(text)
+    job = jobs.get(CONSUMER_CONTRACT_JOB, "")
+    gate = jobs.get(CONTRACT_GATE_JOB, "")
+
+    # (a) present.
+    if not job:
+        E(f"{name}: missing the `{CONSUMER_CONTRACT_JOB}` job (the end-to-end "
+          "generated-project contract) — it must run in the neo component gate")
+        return errs  # nothing else is checkable without the job
+
+    # (b) blocking — never report-only.
+    if re.search(r"continue-on-error:\s*true", job):
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` sets continue-on-error: true — the "
+          "contract is a blocking gate, not report-only")
+
+    # (c) on Linux.
+    if not re.search(r"runs-on:\s*ubuntu", job):
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` does not run on Linux (runs-on: ubuntu-*)")
+
+    # The contract clones the checkout into a git+file Nix input. Nix rejects a
+    # local input inherited from actions/checkout's default shallow clone.
+    if not re.search(r"uses:\s*actions/checkout[^\n]*\n\s+with:\s*\n\s+fetch-depth:\s*0", job):
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` checkout must set `fetch-depth: 0` "
+          "— its local git+file Nix input cannot be shallow")
+
+    # It actually runs the contract: both the orchestration self-test and the
+    # full contract (a bare `./dev neo-consumer-contract`, not only --self-test).
+    if f"{CONTRACT_VERB} --self-test" not in job:
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` never runs `./dev {CONTRACT_VERB} "
+          "--self-test` (the orchestration-logic self-test)")
+    if not re.search(rf"\./dev {re.escape(CONTRACT_VERB)}\s*$", job, re.M):
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` never runs the FULL contract "
+          f"(`./dev {CONTRACT_VERB}` with no flags) — a self-test-only job would "
+          "not prove a generated project builds/tests/runs")
+
+    # It is triggered by real change detection, not always-on/decoupled: the job
+    # must gate on the `contract` surface signal.
+    if "contract == 'true'" not in job:
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` is not gated on "
+          "`needs.changes.outputs.contract == 'true'` — it must run exactly when a "
+          "relevant surface changed (not always, not never)")
+
+    # (d) required through neo-ci-gate: the gate must both `needs` it and evaluate
+    #     its result, so a skip/failure is enforced rather than ignored.
+    if not gate:
+        E(f"{name}: missing the `{CONTRACT_GATE_JOB}` required gate")
+    else:
+        if not re.search(rf"^    needs:.*\b{re.escape(CONSUMER_CONTRACT_JOB)}\b", gate, re.M):
+            E(f"{name}: `{CONTRACT_GATE_JOB}` does not `needs: {CONSUMER_CONTRACT_JOB}` "
+              "— the contract would not block the required gate")
+        if f"needs.{CONSUMER_CONTRACT_JOB}.result" not in gate:
+            E(f"{name}: `{CONTRACT_GATE_JOB}` never evaluates "
+              f"`needs.{CONSUMER_CONTRACT_JOB}.result` — a contract failure/skip "
+              "would pass unnoticed")
+
+    # (e) routed for every relevant surface via the broader CONTRACT classifier.
+    pat = contract_classifier_pattern(text)
+    if pat is None:
+        E(f"{name}: no consumer-contract classifier (CONTRACT='...') found — cannot "
+          "confirm the contract runs for the relevant surfaces")
+    else:
+        for surface in CONTRACT_SURFACES:
+            if surface not in pat:
+                E(f"{name}: consumer-contract classifier lacks '{surface}' — a "
+                  f"'{surface}' change would not trigger the end-to-end contract "
+                  "(the starter->upstream break it exists to catch)")
+    return errs
+
+
 def run(root=WORKFLOWS):
     errs = []
     for wf in sorted(root.glob("*.yml")):
@@ -439,6 +542,7 @@ def run(root=WORKFLOWS):
             errs += check_required_gate(wf.name, text)
         if wf.name == COMPONENT_GATE:
             errs += check_component_gate(wf.name, text)
+            errs += check_consumer_contract(wf.name, text)
     retro = root / "retrospect.yml"
     if not retro.exists():
         errs.append("retrospect.yml is missing (deterministic learning-loop digest)")
@@ -690,6 +794,70 @@ def self_test():
                   "    types: [opened, synchronize]\n")))
     check("component gate missing neo/** routing is flagged",
           check_component_gate("neo-ci.yml", good_component.replace("neo/|", "")))
+
+    # ── consumer-contract job (contract 5) ───────────────────────────────────
+    cc_block = (
+        "  consumer-contract:\n"
+        "    needs: changes\n"
+        "    if: needs.changes.outputs.contract == 'true'\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7.0.0\n"
+        "        with:\n"
+        "          fetch-depth: 0\n"
+        "      - run: ./dev neo-consumer-contract --self-test\n"
+        "      - run: ./dev neo-consumer-contract\n"
+    )
+    good_contract = (
+        "on:\n  pull_request:\n    types: [opened]\n"
+        "jobs:\n"
+        "  changes:\n"
+        "    steps:\n      - run: |\n"
+        "          PATTERN='^(neo/|nix/neo-package\\.nix)'\n"
+        "          CONTRACT='^(neo/|core/|integrations/|nix/neo-package\\.nix|scripts/neo-consumer-contract)'\n"
+        + cc_block +
+        "  neo-ci-gate:\n"
+        "    if: always()\n"
+        "    needs: [changes, rust, ide, nix-package, consumer-contract]\n"
+        "    steps:\n"
+        "      - run: echo ${{ needs.consumer-contract.result }}\n"
+    )
+
+    def cc_bad(name_, mutated):
+        check(name_, bool(check_consumer_contract("neo-ci.yml", mutated)))
+
+    check("well-wired consumer contract passes",
+          not check_consumer_contract("neo-ci.yml", good_contract))
+    cc_bad("removing the consumer-contract job is flagged",
+           good_contract.replace(cc_block, ""))
+    cc_bad("making the contract report-only (continue-on-error) is flagged",
+           good_contract.replace(
+               "    runs-on: ubuntu-latest\n",
+               "    runs-on: ubuntu-latest\n    continue-on-error: true\n"))
+    cc_bad("moving the contract off Linux is flagged",
+           good_contract.replace("runs-on: ubuntu-latest", "runs-on: macos-latest"))
+    cc_bad("a shallow checkout is flagged",
+           good_contract.replace("          fetch-depth: 0\n", ""))
+    cc_bad("a self-test-only contract (no full run) is flagged",
+           good_contract.replace("      - run: ./dev neo-consumer-contract\n", ""))
+    cc_bad("dropping the --self-test step is flagged",
+           good_contract.replace("      - run: ./dev neo-consumer-contract --self-test\n", ""))
+    cc_bad("decoupling the contract from change detection is flagged",
+           good_contract.replace("    if: needs.changes.outputs.contract == 'true'\n",
+                                 "    if: always()\n"))
+    cc_bad("gate not needing the contract is flagged",
+           good_contract.replace(
+               "    needs: [changes, rust, ide, nix-package, consumer-contract]\n",
+               "    needs: [changes, rust, ide, nix-package]\n"))
+    cc_bad("gate not evaluating the contract result is flagged",
+           good_contract.replace("      - run: echo ${{ needs.consumer-contract.result }}\n",
+                                 "      - run: echo done\n"))
+    cc_bad("consumer-contract classifier lacking core/ is flagged",
+           good_contract.replace("core/|", ""))
+    cc_bad("missing consumer-contract classifier is flagged",
+           good_contract.replace(
+               "          CONTRACT='^(neo/|core/|integrations/|nix/neo-package\\.nix|scripts/neo-consumer-contract)'\n",
+               ""))
 
     print("workflow-check: self-test", "OK" if ok else "FAILED")
     return 0 if ok else 1


### PR DESCRIPTION
## What

Adds one blocking generated-project consumer contract for the packaged Neo CLI.

- Builds the Nix-packaged `neo` binary.
- Generates a project offline from the embedded starter outside the monorepo checkout.
- Redirects both Nix and Cabal to an isolated local Git clone at the exact checkout revision under test.
- Runs the generated project's build, Haskell tests, Hurl scenarios, application, health endpoint, and command smoke path.
- Adds bounded phase timeouts, readiness polling, process-tree cleanup, failure evidence preservation, and orchestration self-tests.
- Routes `neo/`, `core/`, and `integrations/` changes through the blocking contract in `neo-ci.yml`.
- Extends `workflow-check` so the job cannot silently become report-only, skip relevant surfaces, or fall out of `neo-ci-gate`.

## Revision coherence

Normal user generation remains pinned to upstream as before. The opt-in `NEO_NEOHASKELL_SOURCE` contract hook:

- requires an absolute, existing Git checkout;
- resolves and validates its immutable HEAD revision;
- emits a percent-encoded `git+file:` input for Nix;
- emits the matching `file:` source and revision for Cabal;
- keeps both generated artifacts coherent across repeated reconciliation.

The contract uses an isolated clone rather than a worktree path so `.git` indirection cannot escape into a Nix sandbox. Local runs reject uncommitted changes under the Haskell source surfaces instead of silently testing an older revision.

## Diagnostics

Hurl failures print bounded, redacted stdout and stderr in CI. This preserves the underlying assertion or transport error while removing lines likely to contain credentials and preventing unbounded log output.

## Verification

- The full packaged-binary consumer contract passed locally from generation through health and command smoke.
- The complete Rust binary test suite passed.
- Contract orchestration self-tests passed, including timeout, process cleanup, quoting, failure propagation, and live readiness polling.
- `workflow-check`, its self-test, `neo-skills-check`, `doctor`, and `git diff --check` passed.

## Boundaries

- Linux is the blocking generated-project contract platform; package builds remain cross-platform.
- Neo remains Rust and keeps independent package/version/release boundaries.
- This PR does not merge or publish releases.
