### PR TITLE
chore: prepare Neo cutover and clean-machine gate

### DIFF
--- a/.github/workflows/neo-ci.yml
+++ b/.github/workflows/neo-ci.yml
@@ -17,7 +17,12 @@ on:
     # skipped (same reasoning as the Haskell Test gate).
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [main]
+    # main plus the migration integration branch: the trusted-push cache
+    # populate job (below) must warm the public Cachix from the integration
+    # branch too, so the clean-machine onboarding SLO has a populated cache
+    # before the final merge to main. Both are exact, same-repo refs; PRs still
+    # never receive the token (see the `cache-populate` trust guard).
+    branches: [main, integration/neo-monorepo]
     paths:
       - "neo/**"
       - "nix/neo-package.nix"
@@ -216,7 +221,7 @@ jobs:
   #
   # This job holds NO secret and is reachable by PR-controlled code, so it must
   # never touch Cachix write. READ acceleration is automatic via the flake's
-  # nixConfig substituter; WRITE happens only in the isolated, main-only
+  # nixConfig substituter; WRITE happens only in the isolated, trusted-push-only
   # `cache-populate` job below.
   consumer-contract:
     needs: changes
@@ -270,18 +275,22 @@ jobs:
         run: ./dev neo-consumer-contract
 
   # Trusted cache population — ISOLATED from any PR-controlled code. Runs ONLY on
-  # a push to main of THIS repository, so the CACHIX_AUTH_TOKEN it holds is never
-  # exposed to a job that checks out or executes a pull request's code. It runs
-  # the EXACT consumer path (the same ./dev neo-consumer-contract) so the cache is
-  # populated from real contract execution, then Cachix pushes what that built.
-  # A missing token skips honestly (job succeeds, nothing pushed, no pretense).
-  # NOT part of the required gate: it is a best-effort warmer, never a merge
-  # blocker, and the cache only ACCELERATES — it never replaces execution.
+  # a push to an EXACT trusted ref (main OR the migration integration branch) of
+  # THIS repository, so the CACHIX_AUTH_TOKEN it holds is never exposed to a job
+  # that checks out or executes a pull request's code. A pull_request event never
+  # matches this guard, so a PR — even from a fork — can neither receive nor write
+  # the token. It runs the EXACT consumer path (the same ./dev
+  # neo-consumer-contract) so the cache is populated from real contract execution,
+  # then Cachix pushes what that built. A missing token skips honestly (job
+  # succeeds, nothing pushed, no pretense). NOT part of the required gate: it is a
+  # best-effort warmer, never a merge blocker, and the cache only ACCELERATES — it
+  # never replaces execution. `scripts/workflow-check` (check_cache_populate)
+  # freezes this exact-ref, same-repo, never-PR trust guard.
   cache-populate:
     needs: changes
     if: >-
       github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
+      && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/integration/neo-monorepo')
       && github.repository == 'neohaskell/NeoHaskell'
       && needs.changes.outputs.contract == 'true'
     runs-on: ubuntu-latest
@@ -312,8 +321,8 @@ jobs:
             accept-flake-config = true
       - uses: DeterminateSystems/magic-nix-cache-action@v14
         if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
-      # Cachix push is set up only now — after the trust guard (main-only + token
-      # present) — so the token is never present alongside PR-controlled code. Its
+      # Cachix push is set up only now — after the trust guard (trusted push ref +
+      # token present) — so the token is never present alongside PR-controlled code. Its
       # post-job hook pushes the store paths the consumer path builds below.
       - name: Configure Cachix push
         if: ${{ env.CACHIX_AUTH_TOKEN != '' }}

--- a/.github/workflows/neo-onboarding-slo.yml
+++ b/.github/workflows/neo-onboarding-slo.yml
@@ -1,0 +1,111 @@
+# Clean-machine onboarding SLO gate (PR 7 cutover) — see ADR 0071.
+#
+# Proves the one user-facing invariant of the neo→monorepo migration: on a clean,
+# supported, GitHub-hosted machine a user reaches a generated, tested, running
+# project in AT MOST 600 seconds via the REAL path
+#
+#     install -> neo new -> neo test -> neo run -> GET /health
+#
+# where `neo` is a checksum-verified RELEASE artifact obtained through the
+# installer's own semantics — never a source `cargo build`, never `nix build
+# .#neo`. The orchestration lives in `scripts/onboarding-slo` (its `--self-test`
+# freezes the logic); this workflow only wires the two modes and is itself frozen
+# by `scripts/workflow-check` (check_onboarding_slo).
+#
+# TWO MODES, deliberately separated so a PR can never masquerade as SLO proof:
+#   * self-test (every PR + dispatch): structurally exercises the orchestration
+#     OFFLINE — no download of a mutable `latest`, no secret, no publication. It
+#     proves the gate is wired, NOT an SLO number.
+#   * slo (workflow_dispatch ONLY): consumes IMMUTABLE `installer-v*` + `neo-v*`
+#     release inputs, measures the path on the two supported runners, and uploads
+#     an immutable evidence artifact (source SHA, tags, target, elapsed seconds,
+#     verified checksums, result). This is the ONLY producer of real SLO evidence.
+#
+# SECURITY: contents:read only; no `contents: write`; NO secret anywhere (Cachix
+# READ is public and tokenless; there is no cache WRITE and no publication here).
+# PR-controlled code therefore never sees a release/cache credential.
+name: Neo Onboarding SLO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      installer_version:
+        description: "IMMUTABLE installer release tag to measure (installer-vX.Y.Z — never 'latest')"
+        type: string
+        required: true
+      neo_version:
+        description: "IMMUTABLE neo CLI release tag to measure (neo-vX.Y.Z — never 'latest')"
+        type: string
+        required: true
+      expected_source_sha:
+        description: "Required reviewed commit SHA; must equal dispatched github.sha and both peeled release-tag SHAs"
+        type: string
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: neo-onboarding-slo-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # SAFE rehearsal — runs on every PR and on dispatch. Downloads nothing mutable,
+  # holds no secret, publishes nothing. Freezes the orchestration + workflow
+  # wiring so a regression to the gate itself fails loudly on a normal PR.
+  self-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - name: Freeze workflow wiring (includes this workflow)
+        run: ./dev workflow-check
+      - name: Onboarding orchestration self-test (offline — no download, no secret, no publish)
+        run: ./dev onboarding-slo --self-test
+
+  # REAL SLO evidence — ONLY on manual dispatch with IMMUTABLE version inputs.
+  # A PR event never reaches this job, so real SLO evidence can only come from an
+  # explicit, tag-pinned dispatch consuming published artifacts. Fail-closed and
+  # non-publishing behavior lives in the driver; this job just supplies inputs.
+  slo:
+    if: github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - name: Measure clean-machine onboarding (immutable inputs, checksum-verified, fail-closed)
+        env:
+          SLO_INSTALLER_VERSION: ${{ inputs.installer_version }}
+          SLO_NEO_VERSION: ${{ inputs.neo_version }}
+          SLO_TARGET: ${{ matrix.target }}
+          SLO_SOURCE_SHA: ${{ github.sha }}
+          SLO_EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+          SLO_DISPATCHED_SOURCE_SHA: ${{ github.sha }}
+          SLO_WORKFLOW_RUN_ID: ${{ github.run_id }}
+          SLO_WORKFLOW_REF: ${{ github.ref }}
+          SLO_DEADLINE: "600"
+          SLO_EVIDENCE: ${{ runner.temp }}/onboarding-slo-${{ matrix.target }}.json
+        run: ./dev onboarding-slo run
+      - name: Upload immutable SLO evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: onboarding-slo-evidence-${{ matrix.target }}-${{ github.run_id }}-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/onboarding-slo-${{ matrix.target }}.json
+            ${{ runner.temp }}/onboarding-slo-${{ matrix.target }}.json.sha256
+          if-no-files-found: error

--- a/dev
+++ b/dev
@@ -80,6 +80,11 @@ usage: ./dev <verb> [args]
                           truth for naming/checksums shared by the release
                           workflow + rehearsal): targets, asset-name, package,
                           checksums, verify, install, --self-test
+  onboarding-slo <cmd>  clean-machine onboarding gate: run the real
+                          install->new->test->run->/health path from IMMUTABLE
+                          released, checksum-verified artifacts under a 600s
+                          deadline and record evidence JSON (run); --self-test
+                          exercises the orchestration offline (no download/secret)
   doctor                harness self-check: every script has a verb or a
                           reasoned exemption; no dangling verbs (CI-enforced)
   exec <cmd> [args]     run any command with the pinned toolchain
@@ -123,6 +128,7 @@ case "${VERB}" in
   neo-dist-check) exec scripts/neo-dist-check "$@" ;;
   neo-consumer-contract) exec scripts/neo-consumer-contract "$@" ;;
   neo-release) exec scripts/neo-release "$@" ;;
+  onboarding-slo) exec scripts/onboarding-slo "$@" ;;
   doctor)   exec scripts/doctor "$@" ;;
   exec)     exec scripts/with-toolchain "$@" ;;
   ""|help|-h|--help) usage ;;

--- a/docs/cutover-checklist.md
+++ b/docs/cutover-checklist.md
@@ -46,7 +46,9 @@ by this PR.
       (`.github/workflows/neo-release.yml`, tag-gated). Produces `neo-<target>` +
       `SHA256SUMS`, each portability-gated and native-smoked before publish.
 - [ ] Confirm the public Cachix cache (`https://neohaskell.cachix.org`) is
-      populated for the consumer path (main-only `cache-populate` job). Without
+      populated for the consumer path (trusted-push `cache-populate` job — it
+      warms the cache from a push to an exact trusted ref: `main` or the
+      migration `integration/neo-monorepo` branch, never from a PR). Without
       it the first project build cannot meet the 600 s deadline and the SLO run
       fails closed rather than fabricating a pass.
 

--- a/docs/cutover-checklist.md
+++ b/docs/cutover-checklist.md
@@ -1,0 +1,126 @@
+# Neo CLI cutover & archive checklist (PR 7)
+
+The operator runbook for retiring the standalone `neohaskell/neo` and
+`neohaskell/neo-starter` repositories in favour of the NeoHaskell monorepo.
+Governed by [ADR-0071](decisions/0071-neo-cutover-and-onboarding-slo.md).
+
+**Hard rules for this checklist**
+
+- **Every destructive-adjacent step is a HUMAN GATE.** Nothing here is automated
+  by this PR. Archiving is a manual GitHub action taken by a maintainer.
+- **Archive, never delete.** The standalone repos are made read-only (history
+  intact). They are **not** deleted, and they are **preserved until post-cutover
+  verification passes**.
+- **Nick approves twice, explicitly:** once before the final merge to `main`, and
+  again before archiving the standalone repos. Neither approval is implied by the
+  other.
+- **No SLO claim without hosted evidence.** The onboarding SLO is "passed" only
+  when an immutable, tag-pinned hosted run produced a green evidence artifact (see
+  §2). Durable prose must never assert a pass.
+
+---
+
+## 0. Preconditions (green before starting)
+
+- [ ] The final integration PR is green: `Test`, `Test macOS`, `neo-ci`,
+      `installer-ci`, `checks` (incl. `./dev workflow-check`), `spec`.
+- [ ] `./dev workflow-check` and `./dev workflow-check --self-test` pass locally.
+- [ ] `./dev onboarding-slo --self-test` passes locally (orchestration frozen).
+- [ ] `./dev neo-consumer-contract --self-test` passes; the blocking
+      `consumer-contract` job is green (Fact 1: mutual compatibility).
+- [ ] No durable doc, install instruction, issue/source link, bootstrap
+      reference, Cargo metadata, or AGENTS guidance still treats standalone
+      `neohaskell/neo` or `neohaskell/neo-starter` as authoritative. (Historical
+      provenance in `neo/starter/IMPORT.md` and the installer's anti-pattern
+      guard-rails are intentionally preserved.)
+
+## 1. Publish the immutable release inputs (human gate — maintainer)
+
+Real SLO evidence needs published, immutable artifacts. These are **not** created
+by this PR.
+
+- [ ] Tag and publish an installer release `installer-vX.Y.Z`
+      (`.github/workflows/installer-ci.yml`, tag-gated). Produces
+      `installer-neo-install-<target>` + `SHA256SUMS`.
+- [ ] Tag and publish a Neo CLI release `neo-vA.B.C`
+      (`.github/workflows/neo-release.yml`, tag-gated). Produces `neo-<target>` +
+      `SHA256SUMS`, each portability-gated and native-smoked before publish.
+- [ ] Confirm the public Cachix cache (`https://neohaskell.cachix.org`) is
+      populated for the consumer path (main-only `cache-populate` job). Without
+      it the first project build cannot meet the 600 s deadline and the SLO run
+      fails closed rather than fabricating a pass.
+
+Record the exact tags: `installer-vX.Y.Z`, `neo-vA.B.C`.
+
+## 2. Obtain hosted onboarding-SLO evidence (human gate — maintainer dispatch)
+
+- [ ] Dispatch **Neo Onboarding SLO** (`workflow_dispatch`) with the immutable
+      inputs from §1:
+      - `installer_version = installer-vX.Y.Z`
+      - `neo_version       = neo-vA.B.C`
+      - `expected_source_sha = <the reviewed 40-hex cutover commit>`
+- [ ] Both matrix legs pass (`ubuntu-latest`/`x86_64-unknown-linux-gnu` and
+      `macos-latest`/`aarch64-apple-darwin`), each within 600 s.
+- [ ] Download the evidence artifacts (`onboarding-slo-evidence-<target>`) and
+      confirm each records: `source_sha`, both release tags, target,
+      `elapsed_seconds ≤ 600`, both peeled tag SHAs equal the reviewed source SHA,
+      the installed Neo hash equals the release manifest, `cachix.reachable = true`,
+      `cachix.observed_use = true`, and `result = "pass"`.
+- [ ] Attach the evidence artifacts (or their URLs) to the final PR as the SLO
+      proof. **Do not** transcribe the number into durable prose as the source of
+      truth — the artifact is the evidence.
+
+> If §1 is not yet done, this step is BLOCKED. That is expected: finish all safe
+> preparation, keep the PR draft, and state this exact gate. The SLO is not
+> "passed" until this step is green.
+
+## 3. Final review & merge (human gate — Nick approval #1)
+
+- [ ] Nick reviews the full diff, green CI, and the §2 evidence artifacts.
+- [ ] Nick gives **explicit** approval to merge (e.g. a maintainer `@claude`
+      approval comment / recorded sign-off), per the plan's two-touchpoint model.
+- [ ] Squash-merge the integration PR to `main` (one merge; `main` receives only
+      the reviewed result).
+- [ ] Post-merge, confirm `main` is green (`Test`/`Test macOS`); `dod.yml` flags a
+      failure as a revert-candidate (notify-only).
+
+## 4. Archive the standalone repos (human gate — Nick approval #2)
+
+Only after §3 is merged AND post-cutover verification (§5) has begun succeeding.
+
+- [ ] Nick gives **explicit, separate** approval to archive.
+- [ ] In `neohaskell/neo`: replace the README top with a deprecation banner
+      pointing at `neohaskell/NeoHaskell` (CLI at `neo/`, installer at
+      `installer/`, releases under `neo-v*`/`installer-v*`, install via the
+      verified installer). Then **Settings → Archive this repository** (read-only;
+      history preserved). **Do not delete.**
+- [ ] In `neohaskell/neo-starter`: same deprecation banner pointing at the
+      internalized starter (`neo/starter/`, provenance in `neo/starter/IMPORT.md`).
+      Then archive read-only. **Do not delete.**
+- [ ] Redirect any external references (org README, website, docs) to the
+      monorepo. (In-repo durable docs are already routed — verified in §0.)
+
+## 5. Post-cutover verification & rollback readiness
+
+- [ ] From a clean machine, run the published `curl … bootstrap.sh | sh` path and
+      confirm `neo new → test → run → /health` works end-to-end against the
+      published releases (mirrors the §2 automated evidence, by hand).
+- [ ] Keep the standalone repos **archived, not deleted**, through the
+      verification window so nothing is lost if a rollback is needed.
+- [ ] **Rollback plan (to the previous exact release):** if a regression surfaces,
+      re-pin consumers to the previous immutable tags (`NEO_VERSION=neo-v<prev>`,
+      `NEO_INSTALLER_VERSION=installer-v<prev>`) and, if a merged change is at
+      fault, use the kill switch: a maintainer comments `/revert` on the merged PR
+      → `revert.yml` opens a revert PR (`./dev revert <sha>`; never auto-merged).
+      Un-archiving is not required for rollback — the archived repos stay readable
+      and their releases remain downloadable.
+
+## Human gates at a glance
+
+| Gate | Owner | Blocks |
+|------|-------|--------|
+| Publish `installer-v*` + `neo-v*`, populate Cachix (§1) | maintainer | §2 |
+| Dispatch + collect hosted SLO evidence (§2) | maintainer | §3 |
+| Approve final merge (§3) | **Nick** | merge to `main` |
+| Approve archiving standalone repos (§4) | **Nick** | archive |
+| Post-cutover verification before letting archives settle (§5) | maintainer | closing the cutover |

--- a/docs/decisions/0071-neo-cutover-and-onboarding-slo.md
+++ b/docs/decisions/0071-neo-cutover-and-onboarding-slo.md
@@ -1,0 +1,131 @@
+# ADR-0071: Neo CLI cutover — archive-as-human-gate and the clean-machine onboarding SLO
+
+> Closes the neo → NeoHaskell-monorepo migration (PR 7 in the project plan). The
+> earlier PRs internalized the CLI, its starter, packaging, the consumer
+> contract, and the native release/installer train. This ADR governs the final
+> cutover: how the one user-facing SLO is proven, and how the standalone
+> `neo`/`neo-starter` repositories are retired. Changes no library API.
+
+## Status
+
+Accepted
+
+<!-- The GATE infrastructure (the onboarding SLO workflow + driver + wiring
+     freeze, the doc/link re-routing, this ADR and the cutover checklist) is
+     implemented by this PR. The cutover EXECUTION — obtaining real hosted SLO
+     evidence, the final merge, and archiving the standalone repos — are HUMAN
+     GATES that this PR deliberately does not automate. See
+     docs/cutover-checklist.md for the operator runbook and the exact commands. -->
+
+## Context
+
+The migration must end with two facts durably true (project plan, "Completion"):
+
+1. `NeoHaskell + neo + template + installer are mutually compatible`.
+2. `clean supported machine → install → new → test → run ≤ 600 seconds`.
+
+Fact 1 is already gated continuously: the generated-project consumer contract
+(`neo-ci.yml` `consumer-contract`, [ADR-0068]-adjacent) proves a checksum-verified,
+portable release binary generates and builds a project against **this** checkout.
+
+Fact 2 — the onboarding SLO — is different in kind. It is a measurement of the
+**real user path from published, immutable artifacts** on a **clean, supported,
+GitHub-hosted machine**, not a test against the working tree. Proving it honestly
+raises three hazards this ADR resolves:
+
+- **Fabrication.** A source `cargo build` or `nix build .#neo` would measure the
+  wrong thing (a dev binary / a `/nix/store`-linked binary) and could "pass" while
+  the artifact a user actually downloads does not.
+- **Mutable inputs.** Measuring `latest` records a number that pins to nothing —
+  it cannot be reproduced or audited later.
+- **A PR masquerading as proof.** PR CI runs on untrusted code and cannot be
+  allowed to publish, hold secrets, or emit an SLO number that reads as evidence.
+
+Separately, the standalone `neohaskell/neo` and `neohaskell/neo-starter`
+repositories are still the historical homes of the code. Retiring them is
+destructive-adjacent and irreversible-in-spirit, so it must be a reviewed human
+action, not automation buried in a merge.
+
+## Decision
+
+### 1. The onboarding SLO is measured by one executable path, two modes
+
+`scripts/onboarding-slo` is the single source of truth for the measured path
+(`install → neo new → neo test → neo run → GET /health`, hard 600 s deadline). It
+is wired by `.github/workflows/neo-onboarding-slo.yml` with a deliberate split:
+
+- **Safe rehearsal (every PR + dispatch)** — the `self-test` job runs
+  `./dev onboarding-slo --self-test` and `./dev workflow-check`. It downloads
+  nothing mutable, holds no secret, and publishes nothing. It proves the gate is
+  wired and the orchestration logic is correct — **not** an SLO number.
+- **Real evidence (`workflow_dispatch` only)** — the `slo` job consumes
+  **immutable** `installer-v*` and `neo-v*` release tags supplied as inputs,
+  measures the path on the two supported clean-machine runners
+  (`ubuntu-latest`/`x86_64-unknown-linux-gnu` and `macos-latest`/
+  `aarch64-apple-darwin`), and uploads an **evidence JSON** artifact recording the
+  source SHA, both release tags, target, elapsed seconds, verified checksums,
+  peeled release-tag commit SHAs, Cachix reachability and separately observed
+  substitution use, a SHA256 sidecar, and the pass/fail result. This is the
+  ONLY producer of real SLO evidence; a PR event never reaches it.
+
+### 2. The measured binary is a real, checksum-verified release artifact
+
+The driver obtains `neo` through the installer's own semantics: it downloads the
+immutable `installer-v*` asset + `SHA256SUMS`, **verifies before install**, then
+runs the installer with `NEO_VERSION=<neo-v*>` so the installer performs its own
+verified native `neo` download. No `cargo build`, no `nix build .#neo`. The gate
+independently hashes the installed `neo` and requires it to match the pinned
+`neo-v*` manifest.
+
+### 3. Fail closed; never fabricate
+
+A missing/mutable/foreign version tag, a missing or mismatched checksum, or an
+unreachable public Cachix substituter aborts the run — it never emits a pass. The
+600 s deadline starts before cache/API/download/install work and is enforced
+against one monotonic global deadline. Every subprocess has the remaining budget,
+a new process session, TERM→KILL process-group cleanup, and wait. The driver
+publishes nothing and pushes nothing (self-test-enforced); failures still produce
+valid JSON and a SHA256 sidecar, and cleanup never overwrites a pass.
+
+### 4. Both layers are frozen executably
+
+- `scripts/onboarding-slo --self-test` freezes the orchestration: strict reviewed
+  SHA/tag validation, bounded timeout and descendant cleanup, checksum/hash
+  mismatch handling, pass/failure evidence plus sidecars, and non-publication.
+- `scripts/workflow-check` (`check_onboarding_slo`) freezes the workflow wiring:
+  both supported runners+targets, the 600 s bound, immutable dispatch inputs (no
+  `latest`), a real measured `run` (never a source/nix build), dispatch-only real
+  evidence, least privilege (`contents: read`, no secret, no publication).
+
+Both run in CI (the `self-test` job and `checks.yml`), so a regression to either
+layer fails loudly on a normal PR.
+
+### 5. Archiving the standalone repos is a human gate, not automation
+
+This PR does **not** archive or delete anything. `docs/cutover-checklist.md` is
+the operator runbook: it requires Nick's explicit approval before the final merge
+and, separately, before archiving (never deleting) `neohaskell/neo` and
+`neohaskell/neo-starter`. The standalone repos are **preserved** (read-only
+archive, history intact) until post-cutover verification succeeds, and the
+checklist records a rollback to the previous exact release.
+
+## Consequences
+
+- The SLO can only ever be claimed from a reviewed-SHA-bound, content-hashed hosted
+  run — never from durable prose and never from a PR. GitHub release assets remain
+  administratively mutable, so each run records the peeled tag SHAs and actual
+  asset hashes rather than claiming tags alone make bytes immutable.
+- Real SLO evidence cannot be produced until the `neo-v*`/`installer-v*` releases
+  and the public Cachix paths exist. Until then the safe rehearsal is green and
+  the checklist names the exact blocking human gate and commands. This is the
+  intended state, not a gap.
+- Retiring the standalone repos stays reversible-until-verified and reviewed.
+
+## References
+
+- Project plan: "neo CLI → NeoHaskell monorepo + starter", PR 7 and "Completion".
+- `docs/cutover-checklist.md` — the human-gated cutover/archive runbook.
+- `.github/workflows/neo-onboarding-slo.yml`, `scripts/onboarding-slo`,
+  `scripts/workflow-check` (`check_onboarding_slo`).
+- Release/installer contract: [ADR-adjacent] `installer/README.md`,
+  `.github/workflows/neo-release.yml`, `scripts/neo-release`.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -84,6 +84,7 @@ ADRs document significant architectural decisions made during the development of
 | [0068](0068-failure-asset-delta-and-learning-loop.md) | Failure→asset-delta protocol and the learning loop | Accepted |
 | [0069](0069-security-reviews-are-local.md) | Security design-review records are local-only, never pushed | Accepted |
 | [0070](0070-maintainer-codemap-regeneration.md) | Maintainer-triggered codemap regeneration onto a contributor PR | Accepted |
+| [0071](0071-neo-cutover-and-onboarding-slo.md) | Neo CLI cutover — archive-as-human-gate and the clean-machine onboarding SLO | Accepted |
 
 <!-- adr-index: this table is validated by scripts/adr-index-check (./dev adr-check,
      CI job `adr-index` in checks.yml) — every NNNN-*.md file must appear exactly

--- a/neo/src/errors.rs
+++ b/neo/src/errors.rs
@@ -91,7 +91,7 @@ pub enum NeoError {
     #[diagnostic(
         code(neo::template_error),
         url(docsrs),
-        help("This is an internal templating error in `neo`. Re-run with `RUST_BACKTRACE=1`. If it reproduces on a fresh `neo new` checkout, file a bug at https://github.com/NeoHaskell/neocli/issues with the full backtrace — the bundled `{template}` template should not fail to render with valid input.")
+        help("This is an internal templating error in `neo`. Re-run with `RUST_BACKTRACE=1`. If it reproduces on a fresh `neo new` checkout, file a bug at https://github.com/neohaskell/NeoHaskell/issues with the full backtrace — the bundled `{template}` template should not fail to render with valid input.")
     )]
     TemplateError { template: String, reason: String },
 
@@ -111,7 +111,7 @@ pub enum NeoError {
     #[diagnostic(
         code(neo::subprocess_raw),
         url(docsrs),
-        help("We didn't recognise this failure mode.\n\nThe full failure has been appended to your local log:\n  {log_path}\n\nThis file is the central backlog of every unrecognized error `neo` has hit on this machine — each line is one JSON record (operation, tail, full output, timestamp, cwd). When you have a moment, open an issue so we can add a fix recipe:\n  https://github.com/neohaskell/neo/issues/new?template=uninterpreted-subprocess-error.md\nYou can paste one record per issue, or attach the file and let us batch them.")
+        help("We didn't recognise this failure mode.\n\nThe full failure has been appended to your local log:\n  {log_path}\n\nThis file is the central backlog of every unrecognized error `neo` has hit on this machine — each line is one JSON record (operation, tail, full output, timestamp, cwd). When you have a moment, open an issue so we can add a fix recipe:\n  https://github.com/neohaskell/NeoHaskell/issues/new?template=uninterpreted-subprocess-error.md\nYou can paste one record per issue, or attach the file and let us batch them.")
     )]
     SubprocessRaw {
         operation: String,
@@ -171,7 +171,7 @@ pub enum NeoError {
         url(docsrs),
         help("The embedded axum server returned an unexpected I/O error mid-flight. This is a bug in `neo`. \
               Re-run with `--verbose` to capture details, then file an issue at \
-              https://github.com/NeoHaskell/neo/issues with the full output.")
+              https://github.com/neohaskell/NeoHaskell/issues with the full output.")
     )]
     IdeServe {
         #[source]
@@ -578,7 +578,7 @@ mod tests {
         let err = stub_subprocess_raw();
         let help = err.help().map(|h| h.to_string()).unwrap_or_default();
         assert!(
-            help.contains("github.com/neohaskell/neo/issues/new"),
+            help.contains("github.com/neohaskell/NeoHaskell/issues/new"),
             "help missing GH issue URL: {}",
             help
         );
@@ -1059,7 +1059,7 @@ mod tests {
         assert!(display.contains("unexpected EOF"), "missing source cause: {}", display);
 
         let help = err.help().map(|h| h.to_string()).unwrap_or_default();
-        assert!(help.contains("github.com/NeoHaskell/neo/issues"), "help missing issue link: {}", help);
+        assert!(help.contains("github.com/neohaskell/NeoHaskell/issues"), "help missing issue link: {}", help);
     }
 
     #[test]

--- a/neo/src/network.rs
+++ b/neo/src/network.rs
@@ -185,12 +185,29 @@ fn parse_ls_remote_tags(stdout: &str) -> Vec<PackageTag> {
         .collect()
 }
 
+/// The newest `neo-v*` release version from a GitHub releases list, or None if
+/// no entry carries a parseable `neo-v*` tag. Pure (offline unit-tested). The
+/// `neo-v` prefix is the release train's disambiguator: `neo` ships from the
+/// NeoHaskell monorepo on its own `neo-v*` tags, independent of the library and
+/// `installer-v*` trains, so the repo-wide `releases/latest` must never be used
+/// here (it could surface some OTHER train's newest release). Mirrors the
+/// newest-tag resolution in installer/src/release.rs.
+fn newest_neo_release(releases: &[GitHubRelease]) -> Option<Version> {
+    releases
+        .iter()
+        .filter_map(|r| r.tag_name.strip_prefix("neo-v"))
+        .filter_map(|v| Version::parse(v).ok())
+        .max()
+}
+
 pub async fn check_for_updates() -> miette::Result<Option<String>> {
     if std::env::var("NEO_SKIP_NETWORK").is_ok() {
         return Ok(None);
     }
 
-    let url = "https://api.github.com/repos/NeoHaskell/neocli/releases/latest";
+    // List the monorepo's releases and pick the newest `neo-v*` explicitly —
+    // NEVER the repo-wide `releases/latest` (see newest_neo_release).
+    let url = "https://api.github.com/repos/neohaskell/NeoHaskell/releases?per_page=100";
 
     let client = reqwest::Client::builder()
         .user_agent("NeoCLI")
@@ -203,13 +220,13 @@ pub async fn check_for_updates() -> miette::Result<Option<String>> {
         return Ok(None);
     }
 
-    let release: GitHubRelease = response.json().await
+    let releases: Vec<GitHubRelease> = response.json().await
         .into_diagnostic()
         .wrap_err_with(|| format!("parsing the GitHub Releases JSON response from `{}` while checking for `neo` updates", url))?;
-    let latest_version_str = release.tag_name.trim_start_matches('v');
-    let latest_version = Version::parse(latest_version_str)
-        .into_diagnostic()
-        .wrap_err_with(|| format!("parsing the latest `neo` release tag `{}` from GitHub as semver", release.tag_name))?;
+    let latest_version = match newest_neo_release(&releases) {
+        Some(v) => v,
+        None => return Ok(None),
+    };
 
     let current_version = Version::parse(env!("CARGO_PKG_VERSION"))
         .into_diagnostic()
@@ -469,6 +486,29 @@ mod tests {
     async fn test_check_for_updates() {
         unsafe { std::env::set_var("NEO_SKIP_NETWORK", "1"); }
         let _ = check_for_updates().await;
+    }
+
+    #[test]
+    fn newest_neo_release_picks_highest_neo_v_ignoring_other_trains() {
+        let rel = |t: &str| GitHubRelease { tag_name: t.to_string() };
+        // A realistic mixed list: the monorepo carries installer-v*, library and
+        // neo-v* tags together. Only neo-v* count, and the HIGHEST semver wins
+        // (not merely the first entry), never a repo-wide "latest".
+        let releases = vec![
+            rel("installer-v9.9.9"),
+            rel("v2.0.0"),
+            rel("neo-v0.1.0"),
+            rel("neo-v0.3.2"),
+            rel("neo-v0.2.5"),
+            rel("not-a-release"),
+        ];
+        assert_eq!(
+            newest_neo_release(&releases),
+            Some(Version::parse("0.3.2").unwrap())
+        );
+        // No neo-v* tag => no update signal (rather than misreading another train).
+        assert_eq!(newest_neo_release(&[rel("installer-v1.0.0"), rel("v1.0.0")]), None);
+        assert_eq!(newest_neo_release(&[]), None);
     }
 
     #[test]

--- a/neo/src/subprocess/ghci.rs
+++ b/neo/src/subprocess/ghci.rs
@@ -26,7 +26,7 @@ impl GhciSession {
             NeoError::SubprocessFailed {
                 operation: "starting `cabal repl`".to_string(),
                 cause: "failed to attach to child stdin (piped stdin was not available)".to_string(),
-                fix: "This is an internal `neo` bug — `Stdio::piped()` should always provide a stdin handle. Re-run with `RUST_BACKTRACE=1` and file an issue at https://github.com/NeoHaskell/neocli/issues.".to_string(),
+                fix: "This is an internal `neo` bug — `Stdio::piped()` should always provide a stdin handle. Re-run with `RUST_BACKTRACE=1` and file an issue at https://github.com/neohaskell/NeoHaskell/issues.".to_string(),
             }
         })?;
 

--- a/scripts/onboarding-slo
+++ b/scripts/onboarding-slo
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Fail-closed clean-machine Neo onboarding SLO gate."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import signal
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+DEADLINE_DEFAULT = 600.0
+REPO_DEFAULT = "neohaskell/NeoHaskell"
+CACHIX_DEFAULT = "https://neohaskell.cachix.org"
+TARGETS = {"x86_64-unknown-linux-gnu", "aarch64-apple-darwin"}
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class GateError(Exception):
+    pass
+
+
+class DeadlineExceeded(GateError):
+    pass
+
+
+def mono() -> float:
+    return time.monotonic()
+
+
+def strict_sha(value: str | None, name: str) -> str:
+    if not SHA_RE.fullmatch(value or ""):
+        raise GateError(f"{name} must be a strict 40-hex commit SHA")
+    return value.lower()
+
+
+def immutable_tag(value: str | None, prefix: str) -> str:
+    if not value or value in {"latest", "main", "HEAD"}:
+        raise GateError(f"missing or mutable {prefix} tag")
+    if not re.fullmatch(re.escape(prefix) + r"[A-Za-z0-9._-]+", value):
+        raise GateError(f"invalid immutable {prefix} tag")
+    return value
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def terminate_group(pid: int, deadline: float | None = None) -> None:
+    for sig, default_grace in ((signal.SIGTERM, 2.0), (signal.SIGKILL, 1.0)):
+        try:
+            os.killpg(pid, sig)
+        except (ProcessLookupError, PermissionError):
+            return
+        remaining = default_grace if deadline is None else max(0.0, deadline - mono())
+        until = mono() + min(default_grace, remaining)
+        while mono() < until:
+            try:
+                os.killpg(pid, 0)
+            except (ProcessLookupError, PermissionError):
+                return
+            time.sleep(0.05)
+
+
+def bounded(deadline: float, argv: list[str], *, cwd: Path | None = None,
+            env: dict[str, str] | None = None, log: Path | None = None) -> bytes:
+    remaining = deadline - mono()
+    if remaining <= 0:
+        raise DeadlineExceeded("global 600-second deadline exceeded")
+    output = log.open("wb") if log else subprocess.PIPE
+    process = subprocess.Popen(
+        argv, cwd=cwd, env=env, stdout=output, stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    try:
+        stdout, _ = process.communicate(timeout=remaining)
+    except subprocess.TimeoutExpired:
+        terminate_group(process.pid, deadline)
+        try:
+            process.wait(timeout=max(0.0, min(0.1, deadline - mono())))
+        except subprocess.TimeoutExpired:
+            process.kill()
+            try:
+                process.wait(timeout=0.1)
+            except subprocess.TimeoutExpired:
+                pass
+        raise DeadlineExceeded(f"global deadline exceeded while running: {' '.join(argv)}")
+    finally:
+        if log:
+            output.close()
+    # A command may exit while leaving descendants behind. Clean its session too.
+    terminate_group(process.pid, deadline)
+    if process.returncode != 0:
+        if log and log.exists():
+            detail = log.read_bytes().decode(errors="replace")[-4000:]
+        else:
+            detail = (stdout or b"").decode(errors="replace")[-4000:]
+        raise GateError(f"command failed ({process.returncode}): {' '.join(argv)}\n{detail}")
+    return stdout or b""
+
+
+def fetch(deadline: float, url: str, destination: Path | None = None) -> bytes:
+    data = bounded(deadline, [
+        "curl", "--fail", "--silent", "--show-error", "--location", url,
+    ])
+    if destination:
+        destination.write_bytes(data)
+    return data
+
+
+def resolve_tag(deadline: float, repo: str, tag: str) -> str:
+    ref = json.loads(fetch(deadline, f"https://api.github.com/repos/{repo}/git/ref/tags/{tag}"))
+    obj = ref.get("object", {})
+    # Peel annotated tags, including nested annotated tags, to the commit.
+    for _ in range(8):
+        sha = strict_sha(obj.get("sha"), f"resolved tag {tag}")
+        if obj.get("type") == "commit":
+            return sha
+        if obj.get("type") != "tag":
+            raise GateError(f"tag {tag} does not resolve to a commit")
+        tag_obj = json.loads(fetch(deadline, f"https://api.github.com/repos/{repo}/git/tags/{sha}"))
+        obj = tag_obj.get("object", {})
+    raise GateError(f"tag {tag} has excessive indirection")
+
+
+def manifest_hash(path: Path, asset: str) -> str:
+    for line in path.read_text().splitlines():
+        fields = line.split()
+        if len(fields) >= 2 and fields[1].lstrip("*") == asset:
+            value = fields[0].lower()
+            if re.fullmatch(r"[0-9a-f]{64}", value):
+                return value
+            raise GateError(f"invalid checksum for {asset}")
+    raise GateError(f"missing checksum manifest entry for {asset}")
+
+
+def require_matching_hash(actual: str, expected: str, label: str) -> None:
+    if actual != expected:
+        raise GateError(f"{label} checksum mismatch: expected {expected}, got {actual}")
+
+
+def write_evidence(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    raw = json.dumps(record, sort_keys=True, indent=2) + "\n"
+    # A hosted evidence record is append-only by run identity: never replace a
+    # previous pass/failure or its diagnostic details.
+    with path.open("x") as handle:
+        handle.write(raw)
+    digest = hashlib.sha256(raw.encode()).hexdigest()
+    with Path(str(path) + ".sha256").open("x") as handle:
+        handle.write(f"{digest}  {path.name}\n")
+
+
+def run_gate() -> None:
+    started = mono()  # Includes validation, cache probe, downloads, and installation.
+    deadline_seconds = float(os.getenv("SLO_DEADLINE", str(DEADLINE_DEFAULT)))
+    deadline = started + deadline_seconds
+    evidence_value = os.getenv("SLO_EVIDENCE")
+    if not evidence_value:
+        raise GateError("SLO_EVIDENCE is required")
+    evidence = Path(evidence_value)
+    phase = "validate"
+    work: Path | None = None
+    server: subprocess.Popen | None = None
+    server_log = None
+    source = os.getenv("SLO_SOURCE_SHA", "")
+    base = {
+        "schema": "neo-onboarding-slo/v3",
+        "workflow_run_id": os.getenv("SLO_WORKFLOW_RUN_ID", "local"),
+        "workflow_ref": os.getenv("SLO_WORKFLOW_REF", ""),
+        "source_sha": source,
+    }
+    try:
+        repo = os.getenv("SLO_REPO", REPO_DEFAULT)
+        installer_tag = immutable_tag(os.getenv("SLO_INSTALLER_VERSION"), "installer-v")
+        neo_tag = immutable_tag(os.getenv("SLO_NEO_VERSION"), "neo-v")
+        source = strict_sha(source, "SLO_SOURCE_SHA")
+        expected = strict_sha(os.getenv("SLO_EXPECTED_SOURCE_SHA"), "SLO_EXPECTED_SOURCE_SHA")
+        dispatched = strict_sha(os.getenv("SLO_DISPATCHED_SOURCE_SHA"), "SLO_DISPATCHED_SOURCE_SHA")
+        if not source == expected == dispatched:
+            raise GateError("reviewed, expected, and dispatched source SHAs do not agree")
+        target = os.getenv("SLO_TARGET") or (
+            "aarch64-apple-darwin" if sys.platform == "darwin" else "x86_64-unknown-linux-gnu"
+        )
+        if target not in TARGETS:
+            raise GateError(f"unsupported clean-machine target: {target}")
+        base.update(source_sha=source, installer_version=installer_tag,
+                    neo_version=neo_tag, target=target,
+                    deadline_seconds=deadline_seconds)
+
+        phase = "resolve-tags"
+        installer_tag_sha = resolve_tag(deadline, repo, installer_tag)
+        neo_tag_sha = resolve_tag(deadline, repo, neo_tag)
+        if not installer_tag_sha == neo_tag_sha == source:
+            raise GateError("release tag SHAs do not equal the reviewed source SHA")
+        base["release_tag_shas"] = {"installer": installer_tag_sha, "neo": neo_tag_sha}
+
+        phase = "cache-probe"
+        cachix = os.getenv("SLO_CACHIX_HOST", CACHIX_DEFAULT)
+        fetch(deadline, cachix + "/nix-cache-info")
+        cache = {"substituter": cachix, "reachable": True, "observed_use": False}
+        base["cachix"] = cache
+
+        phase = "download"
+        work = Path(tempfile.mkdtemp(prefix="neo-slo-"))
+        bindir = work / "bin"
+        bindir.mkdir()
+        installer_asset = f"installer-neo-install-{target}"
+        neo_asset = f"neo-{target}"
+        installer_base = f"https://github.com/{repo}/releases/download/{installer_tag}"
+        neo_base = f"https://github.com/{repo}/releases/download/{neo_tag}"
+        fetch(deadline, f"{installer_base}/{installer_asset}", work / installer_asset)
+        fetch(deadline, f"{installer_base}/SHA256SUMS", work / "installer.SHA256SUMS")
+        fetch(deadline, f"{neo_base}/SHA256SUMS", work / "neo.SHA256SUMS")
+        installer_sha = manifest_hash(work / "installer.SHA256SUMS", installer_asset)
+        require_matching_hash(sha256_file(work / installer_asset), installer_sha, "installer")
+        neo_sha = manifest_hash(work / "neo.SHA256SUMS", neo_asset)
+        os.chmod(work / installer_asset, 0o755)
+
+        phase = "install"
+        env = os.environ.copy()
+        env.update(NEO_VERSION=neo_tag, NEO_BIN_DIR=str(bindir))
+        bounded(deadline, [str(work / installer_asset), "--force"],
+                env=env, log=work / "installer.log")
+        neo = bindir / "neo"
+        if not neo.is_file():
+            raise GateError("installer did not install neo")
+        installed_sha = sha256_file(neo)
+        require_matching_hash(installed_sha, neo_sha, "installed neo")
+        base["checksums"] = {
+            "installer_sha256": installer_sha,
+            "neo_manifest_sha256": neo_sha,
+            "installed_neo_sha256": installed_sha,
+        }
+
+        phase = "new"
+        bounded(deadline, [str(neo), "--ci", "new", "proj"],
+                cwd=work, log=work / "neo-new.log")
+        phase = "test"
+        bounded(deadline, [str(neo), "--ci", "test"],
+                cwd=work / "proj", log=work / "neo-test.log")
+        cache_pattern = re.compile(
+            r"(?:copying (?:path|\d+ paths?)|substituting path).*from.*https://neohaskell\.cachix\.org",
+            re.IGNORECASE,
+        )
+        observed = any(
+            cache_pattern.search(path.read_text(errors="ignore"))
+            for path in (work / "installer.log", work / "neo-new.log", work / "neo-test.log")
+        )
+        cache["observed_use"] = observed
+        if not observed:
+            raise GateError("no actual substitution from neohaskell.cachix.org was observed")
+
+        phase = "run-health"
+        server_log = (work / "neo-run.log").open("wb")
+        server = subprocess.Popen(
+            [str(neo), "--ci", "run"], cwd=work / "proj",
+            stdout=server_log, stderr=subprocess.STDOUT, start_new_session=True,
+        )
+        health_url = f"http://127.0.0.1:{os.getenv('SLO_APP_PORT', '8080')}/health"
+        while True:
+            if mono() >= deadline:
+                raise DeadlineExceeded("global deadline exceeded waiting for /health")
+            try:
+                body = fetch(deadline, health_url).decode(errors="replace")
+                if '"status":"ok"' in body:
+                    break
+            except GateError:
+                if server.poll() is not None:
+                    raise GateError("neo run exited before /health became ready")
+                time.sleep(min(1.0, max(0.0, deadline - mono())))
+
+        elapsed = mono() - started
+        if elapsed > deadline_seconds:
+            raise DeadlineExceeded("global 600-second deadline exceeded")
+        base.update(result="pass", phase="complete", elapsed_seconds=round(elapsed, 3))
+        write_evidence(evidence, base)
+    except Exception as error:
+        base.update(result="fail", phase=phase, reason=str(error),
+                    elapsed_seconds=round(mono() - started, 3),
+                    deadline_seconds=deadline_seconds)
+        write_evidence(evidence, base)
+        raise
+    finally:
+        if server is not None:
+            terminate_group(server.pid, deadline)
+            try:
+                server.wait(timeout=max(0.0, min(0.1, deadline - mono())))
+            except subprocess.TimeoutExpired:
+                pass
+        if server_log is not None:
+            server_log.close()
+        if work is not None:
+            shutil.rmtree(work, ignore_errors=True)
+
+
+def self_test() -> None:
+    assert strict_sha("a" * 40, "sha") == "a" * 40
+    assert immutable_tag("neo-v1.2.3", "neo-v") == "neo-v1.2.3"
+    for bad in (None, "latest", "main", "neo-v../x", "v1"):
+        try:
+            immutable_tag(bad, "neo-v")
+            raise AssertionError(f"accepted unsafe tag: {bad}")
+        except GateError:
+            pass
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        evidence = root / "evidence.json"
+        write_evidence(evidence, {"result": "pass"})
+        assert json.loads(evidence.read_text())["result"] == "pass"
+        assert re.fullmatch(r"[0-9a-f]{64}  evidence.json\n", Path(str(evidence) + ".sha256").read_text())
+        try:
+            write_evidence(evidence, {"result": "fail"})
+            raise AssertionError("existing evidence was overwritten")
+        except FileExistsError:
+            assert json.loads(evidence.read_text())["result"] == "pass"
+        failure = root / "failure.json"
+        write_evidence(failure, {"result": "fail", "phase": "test", "reason": "intentional"})
+        assert json.loads(failure.read_text())["result"] == "fail"
+        try:
+            require_matching_hash("a" * 64, "b" * 64, "installed neo")
+            raise AssertionError("hash mismatch was accepted")
+        except GateError:
+            pass
+        command_log = root / "failed-command.log"
+        try:
+            bounded(mono() + 5, [sys.executable, "-c", "print('diagnostic-marker'); raise SystemExit(7)"], log=command_log)
+            raise AssertionError("nonzero command was accepted")
+        except GateError as error:
+            assert "diagnostic-marker" in str(error)
+        cache_pattern = re.compile(
+            r"(?:copying (?:path|\d+ paths?)|substituting path).*from.*https://neohaskell\.cachix\.org",
+            re.IGNORECASE,
+        )
+        assert cache_pattern.search("copying path '/nix/store/x' from 'https://neohaskell.cachix.org'")
+        assert not cache_pattern.search("configured substituter https://neohaskell.cachix.org")
+        started = mono()
+        try:
+            bounded(mono() + 0.15, [sys.executable, "-c", "import time; time.sleep(30)"])
+            raise AssertionError("hung command was not timed out")
+        except DeadlineExceeded:
+            assert mono() - started < 5
+        marker = root / "descendant"
+        survivor = root / "survivor"
+        code = (
+            "import os,time; p=os.fork(); "
+            f"open({str(marker)!r},'w').write(str(p)); "
+            f"(time.sleep(1),open({str(survivor)!r},'w').write('alive'),os._exit(0)) if p==0 else time.sleep(30)"
+        )
+        try:
+            bounded(mono() + 0.15, [sys.executable, "-c", code])
+            raise AssertionError("descendant command was not timed out")
+        except DeadlineExceeded:
+            assert marker.read_text().isdigit()
+            time.sleep(1.1)
+            assert not survivor.exists(), "descendant survived process-group cleanup"
+    source = Path(__file__).read_text()
+    banned = ("gh release " + "create", "cachix " + "push", "git " + "push")
+    assert not any(token in source for token in banned)
+    print("onboarding-slo self-test: OK - strict refs, pass/failure evidence, checksum rejection, monotonic deadline, descendant cleanup, non-publication")
+
+
+if __name__ == "__main__":
+    try:
+        if "--self-test" in sys.argv:
+            self_test()
+        elif len(sys.argv) >= 2 and sys.argv[1] == "run":
+            run_gate()
+        else:
+            raise GateError("usage: onboarding-slo run | --self-test")
+    except Exception as error:
+        evidence_value = os.getenv("SLO_EVIDENCE")
+        if evidence_value and not Path(evidence_value).exists():
+            write_evidence(Path(evidence_value), {
+                "schema": "neo-onboarding-slo/v3", "result": "fail",
+                "phase": "startup", "reason": str(error),
+                "workflow_run_id": os.getenv("SLO_WORKFLOW_RUN_ID", "local"),
+            })
+        print(f"onboarding-slo: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -772,6 +772,119 @@ def check_installer_ci(name, text):
     return errs
 
 
+# ── neo-onboarding-slo.yml: clean-machine onboarding SLO gate (PR 7 cutover) ──
+# (ADR 0071) The gate measures install->new->test->run->/health on a clean,
+# supported machine under a 600s deadline, from IMMUTABLE checksum-verified
+# release artifacts. Two modes must stay separated and honest, and several
+# invariants are load-bearing + unreviewable-by-eye, so freeze them:
+#   (a) real SLO evidence is dispatch-ONLY: the `slo` job is gated on
+#       workflow_dispatch, so a PR event can never produce (or masquerade as) an
+#       SLO number. The dispatch inputs are the immutable version tags.
+#   (b) least privilege + NO secret + NO publication: contents:read only, never
+#       contents:write, no secret reference, no release/cache write anywhere.
+#   (c) the PR-safe `self-test` job runs the offline orchestration self-test AND
+#       the workflow-wiring freeze, and never the real measured `run`.
+#   (d) the `slo` job measures a REAL release artifact (never a source cargo /
+#       nix build), threads the immutable dispatch inputs, enforces the 600s
+#       deadline, covers BOTH supported runners+targets, and uploads evidence.
+ONBOARDING_SLO_GATE = "neo-onboarding-slo.yml"
+ONBOARDING_DRIVER = "onboarding-slo"
+ONBOARDING_RUNNERS = ("ubuntu-latest", "macos-latest")
+ONBOARDING_TARGETS = ("x86_64-unknown-linux-gnu", "aarch64-apple-darwin")
+
+
+def check_onboarding_slo(name, text):
+    errs = []
+    E = errs.append
+    code = strip_comments(text)
+    on = _on_block(code)
+    triggers = _on_trigger_keys(on)
+    jobs = job_blocks(code)
+    st = jobs.get("self-test", "")
+    slo = jobs.get("slo", "")
+
+    # (a) real evidence is dispatch-only + the immutable version inputs exist.
+    if "workflow_dispatch" not in triggers:
+        E(f"{name}: no workflow_dispatch trigger — real SLO evidence must come from "
+          "an explicit, tag-pinned dispatch (never an automatic/PR run)")
+    if "pull_request_target" in triggers:
+        E(f"{name}: has a pull_request_target trigger — forbidden (it must never run "
+          "with elevated PR-base permissions)")
+    for inp in ("installer_version", "neo_version", "expected_source_sha"):
+        if inp not in on:
+            E(f"{name}: workflow_dispatch is missing the `{inp}` immutable version input")
+
+    # (b) least privilege, no secret, no publication.
+    if "permissions:" not in code or "contents: read" not in code:
+        E(f"{name}: must declare least-privilege `permissions: contents: read`")
+    if "contents: write" in code:
+        E(f"{name}: declares `contents: write` — the SLO gate publishes nothing")
+    if _SECRETS_REF.search(code):
+        E(f"{name}: references a secret (secrets.X) — the gate is PR-reachable and "
+          "must hold none (Cachix READ is public/tokenless; there is no cache WRITE)")
+    for banned in ("action-gh-release", "gh release create", "gh release upload",
+                   "cachix push", "CACHIX_AUTH_TOKEN", "cachix/cachix-action"):
+        if banned in code:
+            E(f"{name}: contains '{banned}' — the SLO gate must be evidence-only "
+              "(no release publication, no cache write)")
+
+    # (c) the PR-safe self-test job.
+    if not st:
+        E(f"{name}: missing the `self-test` job (the PR-safe offline rehearsal)")
+    else:
+        if f"{ONBOARDING_DRIVER} --self-test" not in st:
+            E(f"{name}: `self-test` job never runs `./dev {ONBOARDING_DRIVER} --self-test` "
+              "(the offline orchestration freeze)")
+        if "workflow-check" not in st:
+            E(f"{name}: `self-test` job never runs `./dev workflow-check` (the wiring freeze)")
+        if re.search(rf"{re.escape(ONBOARDING_DRIVER)}\s+run\b", st):
+            E(f"{name}: `self-test` job runs the real measured path — a PR must not "
+              "attempt real evidence (that needs published immutable artifacts)")
+
+    # (d) the real-evidence slo job.
+    if not slo:
+        E(f"{name}: missing the `slo` job (the only real-evidence producer)")
+    else:
+        if "github.event_name == 'workflow_dispatch'" not in slo:
+            E(f"{name}: `slo` job is not gated to workflow_dispatch — a PR event could "
+              "produce an SLO number (no hidden PR proof allowed)")
+        if not re.search(rf"{re.escape(ONBOARDING_DRIVER)}\s+run\b", slo):
+            E(f"{name}: `slo` job never runs the real measured path "
+              f"(`./dev {ONBOARDING_DRIVER} run`)")
+        if "cargo build" in slo:
+            E(f"{name}: `slo` job builds neo from source (`cargo build`) — the SLO must "
+              "measure a checksum-verified RELEASE artifact, not a source binary")
+        if "nix build" in slo:
+            E(f"{name}: `slo` job builds neo via `nix build` — the SLO must measure a "
+              "portable release artifact (a nix build references /nix/store)")
+        for k in ("SLO_INSTALLER_VERSION", "SLO_NEO_VERSION",
+                  "SLO_EXPECTED_SOURCE_SHA", "SLO_DISPATCHED_SOURCE_SHA",
+                  "SLO_WORKFLOW_RUN_ID", "SLO_WORKFLOW_REF"):
+            if k not in slo:
+                E(f"{name}: `slo` job does not pass `{k}` (the immutable version input)")
+        if "inputs.installer_version" not in slo or "inputs.neo_version" not in slo:
+            E(f"{name}: `slo` job must consume the immutable dispatch version inputs "
+              "(inputs.installer_version / inputs.neo_version), never a mutable channel")
+        for mutable in ("SLO_INSTALLER_VERSION: latest", "SLO_NEO_VERSION: latest",
+                        "SLO_INSTALLER_VERSION: main", "SLO_NEO_VERSION: main"):
+            if mutable in slo:
+                E(f"{name}: `slo` job pins a MUTABLE input ('{mutable}') — SLO evidence "
+                  "must pin an immutable release tag")
+        if '"600"' not in slo and "SLO_DEADLINE: 600" not in slo:
+            E(f"{name}: `slo` job does not enforce the 600s deadline (SLO_DEADLINE: \"600\")")
+        for r in ONBOARDING_RUNNERS:
+            if r not in slo:
+                E(f"{name}: `slo` matrix is missing the supported runner '{r}'")
+        for t in ONBOARDING_TARGETS:
+            if t not in slo:
+                E(f"{name}: `slo` matrix is missing the supported target '{t}'")
+        if "upload-artifact" not in slo:
+            E(f"{name}: `slo` job does not upload the immutable evidence artifact")
+        if ".json.sha256" not in slo or "if-no-files-found: error" not in slo:
+            E(f"{name}: `slo` job must upload the evidence SHA256 sidecar and fail when evidence is missing")
+    return errs
+
+
 def run(root=WORKFLOWS):
     errs = []
     for wf in sorted(root.glob("*.yml")):
@@ -792,6 +905,8 @@ def run(root=WORKFLOWS):
             errs += check_neo_release(wf.name, text)
         if wf.name == INSTALLER_GATE:
             errs += check_installer_ci(wf.name, text)
+        if wf.name == ONBOARDING_SLO_GATE:
+            errs += check_onboarding_slo(wf.name, text)
     retro = root / "retrospect.yml"
     if not retro.exists():
         errs.append("retrospect.yml is missing (deterministic learning-loop digest)")
@@ -807,6 +922,8 @@ def run(root=WORKFLOWS):
         errs.append(f"{NEO_RELEASE_GATE} is missing (the Neo CLI native-release publication workflow)")
     if not (root / INSTALLER_GATE).exists():
         errs.append(f"{INSTALLER_GATE} is missing (the installer component gate)")
+    if not (root / ONBOARDING_SLO_GATE).exists():
+        errs.append(f"{ONBOARDING_SLO_GATE} is missing (the clean-machine onboarding SLO gate)")
     return errs
 
 
@@ -1295,6 +1412,95 @@ def self_test():
     ic_bad("installer gate not evaluating a component result is flagged",
            good_installer.replace("      - run: echo ${{ needs.build.result }}\n",
                                   "      - run: echo done\n"))
+
+    # ── neo-onboarding-slo.yml clean-machine SLO gate (PR 7 cutover) ──────────
+    good_slo = (
+        "name: Neo Onboarding SLO\n"
+        "on:\n"
+        "  pull_request:\n    types: [opened]\n"
+        "  workflow_dispatch:\n"
+        "    inputs:\n"
+        "      installer_version:\n        type: string\n        required: true\n"
+        "      neo_version:\n        type: string\n        required: true\n"
+        "      expected_source_sha:\n        type: string\n        required: true\n"
+        "permissions:\n"
+        "  contents: read\n"
+        "jobs:\n"
+        "  self-test:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: ./dev workflow-check\n"
+        "      - run: ./dev onboarding-slo --self-test\n"
+        "  slo:\n"
+        "    if: github.event_name == 'workflow_dispatch'\n"
+        "    strategy:\n      matrix:\n        include:\n"
+        "          - runner: ubuntu-latest\n            target: x86_64-unknown-linux-gnu\n"
+        "          - runner: macos-latest\n            target: aarch64-apple-darwin\n"
+        "    runs-on: ${{ matrix.runner }}\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v7.0.1\n"
+        "      - name: measure\n"
+        "        env:\n"
+        "          SLO_INSTALLER_VERSION: ${{ inputs.installer_version }}\n"
+        "          SLO_NEO_VERSION: ${{ inputs.neo_version }}\n"
+        "          SLO_EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}\n"
+        "          SLO_DISPATCHED_SOURCE_SHA: ${{ github.sha }}\n"
+        "          SLO_WORKFLOW_RUN_ID: ${{ github.run_id }}\n"
+        "          SLO_WORKFLOW_REF: ${{ github.ref }}\n"
+        "          SLO_DEADLINE: \"600\"\n"
+        "        run: ./dev onboarding-slo run\n"
+        "      - uses: actions/upload-artifact@v7\n"
+        "        with:\n          name: ev\n          path: |\n            x.json\n            x.json.sha256\n          if-no-files-found: error\n"
+    )
+
+    def slo_bad(name_, mutated):
+        check(name_, bool(check_onboarding_slo("neo-onboarding-slo.yml", mutated)))
+
+    check("well-wired onboarding SLO gate passes",
+          not check_onboarding_slo("neo-onboarding-slo.yml", good_slo))
+    slo_bad("missing workflow_dispatch is flagged",
+            good_slo.replace("  workflow_dispatch:\n", ""))
+    slo_bad("a pull_request_target trigger is flagged",
+            good_slo.replace("  pull_request:\n", "  pull_request_target:\n  pull_request:\n"))
+    slo_bad("a missing dispatch version input is flagged",
+            good_slo.replace("      neo_version:\n        type: string\n        required: true\n", ""))
+    slo_bad("contents: write is flagged (no publication)",
+            good_slo.replace("  contents: read\n", "  contents: write\n"))
+    slo_bad("a secret reference is flagged (holds none)",
+            good_slo.replace("        run: ./dev onboarding-slo run\n",
+                             "        run: echo ${{ secrets.GITHUB_TOKEN }} && ./dev onboarding-slo run\n"))
+    slo_bad("a release-publication step is flagged",
+            good_slo.replace("      - uses: actions/upload-artifact@v7\n",
+                             "      - uses: softprops/action-gh-release@v3\n"))
+    slo_bad("self-test job missing the offline self-test is flagged",
+            good_slo.replace("      - run: ./dev onboarding-slo --self-test\n", ""))
+    slo_bad("self-test job missing the workflow-check freeze is flagged",
+            good_slo.replace("      - run: ./dev workflow-check\n", ""))
+    slo_bad("self-test job running the real measured path is flagged",
+            good_slo.replace("      - run: ./dev onboarding-slo --self-test\n",
+                             "      - run: ./dev onboarding-slo run\n"))
+    slo_bad("slo job not gated to workflow_dispatch is flagged (no hidden PR proof)",
+            good_slo.replace("    if: github.event_name == 'workflow_dispatch'\n", ""))
+    slo_bad("slo job building neo from source (cargo build) is flagged",
+            good_slo.replace("        run: ./dev onboarding-slo run\n",
+                             "        run: cargo build --release && ./dev onboarding-slo run\n"))
+    slo_bad("slo job building neo via nix build is flagged",
+            good_slo.replace("        run: ./dev onboarding-slo run\n",
+                             "        run: nix build .#neo && ./dev onboarding-slo run\n"))
+    slo_bad("slo job with a mutable 'latest' input is flagged",
+            good_slo.replace("          SLO_NEO_VERSION: ${{ inputs.neo_version }}\n",
+                             "          SLO_NEO_VERSION: latest\n"))
+    slo_bad("slo job missing the 600s deadline is flagged",
+            good_slo.replace("          SLO_DEADLINE: \"600\"\n", ""))
+    slo_bad("slo matrix missing a supported runner is flagged",
+            good_slo.replace("          - runner: macos-latest\n            target: aarch64-apple-darwin\n",
+                             "          - runner: macos-13\n            target: aarch64-apple-darwin\n"))
+    slo_bad("slo matrix missing a supported target is flagged",
+            good_slo.replace("          - runner: ubuntu-latest\n            target: x86_64-unknown-linux-gnu\n",
+                             "          - runner: ubuntu-latest\n            target: x86_64-unknown-linux-musl\n"))
+    slo_bad("slo job not uploading evidence is flagged",
+            good_slo.replace("      - uses: actions/upload-artifact@v7\n"
+                             "        with:\n          name: ev\n          path: |\n            x.json\n            x.json.sha256\n          if-no-files-found: error\n", ""))
 
     print("workflow-check: self-test", "OK" if ok else "FAILED")
     return 0 if ok else 1

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -639,10 +639,18 @@ def check_neo_release(name, text):
 #     binary (pinned cargo, not nix), runs the portability gate, checksum-verifies
 #     + installs it, and drives the exact consumer path via NEO_BIN. Because it
 #     checks out and runs PR-controlled code it must hold NO Cachix secret at all.
-#   cache-populate — an ISOLATED, main-only job that alone holds CACHIX_AUTH_TOKEN,
-#     runs the exact consumer path, pushes to Cachix, and skips honestly when no
-#     token is configured (never fails, never pretends to push).
+#   cache-populate — an ISOLATED, trusted-push-only job that alone holds
+#     CACHIX_AUTH_TOKEN, runs the exact consumer path, pushes to Cachix, and skips
+#     honestly when no token is configured (never fails, never pretends to push).
+#     "Trusted push" = a push to an exact trusted ref (main OR the migration
+#     integration branch) in THIS repository, never a pull_request. A PR — even a
+#     fork PR — can never receive or write the token.
 CACHE_POPULATE_JOB = "cache-populate"
+
+# The token-bearing cache-populate job may run ONLY on trusted PUSHES to these
+# exact refs (never a pull_request, always the same repo). Kept in lockstep with
+# GATE_BASE_BRANCHES and the `if:` guard in neo-ci.yml.
+CACHE_POPULATE_TRUSTED_REFS = tuple(f"refs/heads/{b}" for b in GATE_BASE_BRANCHES)
 
 
 def _steps_of(job_text):
@@ -693,9 +701,11 @@ def check_release_rehearsal(name, text):
 
 
 def check_cache_populate(name, text):
-    """The isolated, main-only cache-population job (adversarial-review fix): it
-    alone holds the token, is unreachable by PR code, runs the exact consumer
-    path, and skips honestly when no token is set."""
+    """The isolated, trusted-push-only cache-population job (adversarial-review
+    fix): it alone holds the token, is unreachable by PR code, runs the exact
+    consumer path, and skips honestly when no token is set. The trust guard is
+    EXACT-ref (main or the integration branch), SAME-repository, and NEVER a
+    pull_request — a PR (even from a fork) can never receive or write the token."""
     errs = []
     E = errs.append
     jobs = job_blocks(strip_comments(text))
@@ -705,15 +715,28 @@ def check_cache_populate(name, text):
           "population must not live in a PR-reachable job")
         return errs
 
-    # main-only trust guard (push to refs/heads/main), never a pull_request.
+    # Trust guard: push-only, exact-ref (each trusted ref matched by EQUALITY on
+    # github.ref, never a prefix/glob), same-repository, never a pull_request.
     guard = re.search(r"if:\s*>-?\s*\n((?:\s+[^\n]*\n)+)", job)
     guard_text = guard.group(1) if guard else job
-    if "refs/heads/main" not in guard_text:
-        E(f"{name}: `{CACHE_POPULATE_JOB}` is not gated to `github.ref == 'refs/heads/main'` "
-          "— the token must only ever run on trusted main pushes")
+    if "github.event_name == 'push'" not in guard_text:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` is not gated to push events "
+          "(`github.event_name == 'push'`) — the token must only run on trusted pushes")
+    for ref in CACHE_POPULATE_TRUSTED_REFS:
+        if f"github.ref == '{ref}'" not in guard_text:
+            E(f"{name}: `{CACHE_POPULATE_JOB}` is not gated to the exact trusted ref "
+              f"`github.ref == '{ref}'` — the token must only ever run on trusted pushes "
+              "to an exact allowed ref (main or integration/neo-monorepo)")
+    if re.search(r"(startsWith|endsWith|contains)\(\s*github\.ref\b", guard_text):
+        E(f"{name}: `{CACHE_POPULATE_JOB}` uses a non-exact ref match "
+          "(startsWith/endsWith/contains on github.ref) — the trust guard must be "
+          "exact-ref so it can never be broadened to an untrusted ref")
+    if "github.repository ==" not in guard_text:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` is not gated to the same repository "
+          "(`github.repository == '...'`) — a fork must never reach the token")
     if "pull_request" in guard_text:
         E(f"{name}: `{CACHE_POPULATE_JOB}` gate references pull_request — it must be "
-          "main-push-only, never reachable from a PR")
+          "trusted-push-only, never reachable from a PR")
     # It holds the token and runs the exact consumer path.
     if "CACHIX_AUTH_TOKEN" not in job:
         E(f"{name}: `{CACHE_POPULATE_JOB}` does not use CACHIX_AUTH_TOKEN (it is the one "
@@ -1331,13 +1354,14 @@ def self_test():
            good_rehearsal.replace(
                "          ./scripts/neo-release install o x $RUNNER_TEMP/neo-bin/neo\n", ""))
 
-    # cache-populate: isolated, main-only, token-holding, honest-skip.
+    # cache-populate: isolated, trusted-push-only (exact-ref: main OR the
+    # integration branch), same-repo, token-holding, honest-skip.
     good_cache = (
         "jobs:\n"
         "  cache-populate:\n"
         "    if: >-\n"
         "      github.event_name == 'push'\n"
-        "      && github.ref == 'refs/heads/main'\n"
+        "      && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/integration/neo-monorepo')\n"
         "      && github.repository == 'neohaskell/NeoHaskell'\n"
         "    env:\n      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}\n"
         "    steps:\n"
@@ -1354,8 +1378,18 @@ def self_test():
           not check_cache_populate("neo-ci.yml", good_cache))
     cp_bad("missing cache-populate job is flagged",
            good_cache.replace("  cache-populate:\n", "  other:\n"))
-    cp_bad("cache-populate not gated to main is flagged",
-           good_cache.replace("      && github.ref == 'refs/heads/main'\n", ""))
+    cp_bad("cache-populate not gated to the main ref is flagged",
+           good_cache.replace("github.ref == 'refs/heads/main' || ", ""))
+    cp_bad("cache-populate not gated to the integration ref is flagged",
+           good_cache.replace(" || github.ref == 'refs/heads/integration/neo-monorepo'", ""))
+    cp_bad("cache-populate not gated to the same repository is flagged",
+           good_cache.replace("      && github.repository == 'neohaskell/NeoHaskell'\n", ""))
+    cp_bad("cache-populate with a non-exact (broadening) ref match is flagged",
+           good_cache.replace(
+               "(github.ref == 'refs/heads/main' || github.ref == 'refs/heads/integration/neo-monorepo')",
+               "startsWith(github.ref, 'refs/heads/')"))
+    cp_bad("cache-populate not gated to push events is flagged",
+           good_cache.replace("      github.event_name == 'push'\n", ""))
     cp_bad("cache-populate reachable from a PR is flagged",
            good_cache.replace("      github.event_name == 'push'\n",
                               "      github.event_name == 'pull_request'\n"))

--- a/website/src/content/docs/adrs/index.mdx
+++ b/website/src/content/docs/adrs/index.mdx
@@ -83,3 +83,4 @@ ADRs are immutable: when a decision is reversed, a new ADR is written that refer
 | [0068](/adrs/0068-failure-asset-delta-and-learning-loop/) | Failure→asset-delta protocol and the learning loop | Accepted |
 | [0069](/adrs/0069-security-reviews-are-local/) | Security design-review records are local-only, never pushed | Accepted |
 | [0070](/adrs/0070-maintainer-codemap-regeneration/) | Maintainer-triggered codemap regeneration onto a contributor PR | Accepted |
+| [0071](/adrs/0071-neo-cutover-and-onboarding-slo/) | Neo CLI cutover — archive-as-human-gate and the clean-machine onboarding SLO | Accepted |


### PR DESCRIPTION
## Summary

- adds a fail-closed clean-machine onboarding gate for Linux x86_64 and macOS ARM
- measures the real checksummed release path: install -> `neo new` -> `neo test` -> `neo run` -> `/health`
- enforces one monotonic 600-second deadline across tag resolution, cache probe, downloads, install, test and health readiness
- binds both release tags and workflow dispatch to the same reviewed 40-hex source SHA
- emits append-only pass/failure evidence JSON plus SHA256 sidecar, preserving bounded diagnostic tails
- requires independent installed-Neo checksum verification and observed Nix substitution from the public NeoHaskell Cachix
- routes stale standalone repository links to the monorepo and makes update discovery select only `neo-v*` releases
- adds ADR 0071 and a human-gated cutover/archive/rollback checklist

## Safety

- PR runs execute only offline structural/self-tests; they cannot produce real SLO evidence
- the real matrix is `workflow_dispatch` only, read-only and secretless
- no publication, cache write, merge, archive or deletion occurs in this PR
- standalone `neo` and `neo-starter` remain preserved until separate explicit post-cutover approval
- failures produce evidence and cannot overwrite an existing record
- subprocesses run in separate sessions with TERM/KILL descendant cleanup bounded by the global deadline

## Verification

- `python3 -m py_compile scripts/onboarding-slo scripts/workflow-check`
- `./dev onboarding-slo --self-test`
- `./dev workflow-check`
- `./dev workflow-check --self-test`
- `./dev adr-check`
- `./dev neo-skills-check`
- `nix develop ./neo -c cargo test --manifest-path neo/Cargo.toml --locked --bins 'network::tests'` (9 passed)
- `git diff --check`
- independent adversarial review: approved after four review/fix rounds

## Explicit remaining human gates

This PR prepares but does not claim the clean-machine SLO:

1. Publish exact `installer-v*` and `neo-v*` tags from this reviewed SHA.
2. Populate/confirm the public Cachix consumer paths.
3. Dispatch **Neo Onboarding SLO** with both tags and this exact SHA.
4. Require both hosted evidence artifacts to pass within 600 seconds.
5. Obtain Nick's explicit approval before final merge.
6. Obtain separate post-cutover approval before archiving, never deleting, the standalone repositories.

Stacked on #775.