### PR TITLE
fix(slo): installer owns Nix; driver puts it on PATH (v0.1.2)

### DIFF
--- a/.github/workflows/neo-onboarding-slo.yml
+++ b/.github/workflows/neo-onboarding-slo.yml
@@ -97,19 +97,13 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           persist-credentials: false
-      # Clean-machine prerequisite: install Nix and configure the PUBLIC Cachix +
-      # IOG substituters TOKENLESSLY (read-only, secretless — no authToken, no
-      # cache WRITE, no cachix-action). This models the real user prerequisite and
-      # its time is counted against the deadline. No magic-nix-cache, so actual
-      # substitution from neohaskell.cachix.org stays observable (the driver
-      # requires observed_use=true) rather than being masked by the GitHub cache.
-      - name: Install Nix + configure public substituters (tokenless, read-only)
-        uses: DeterminateSystems/determinate-nix-action@v3.21.7
-        with:
-          extra-conf: |
-            accept-flake-config = true
-            extra-substituters = https://neohaskell.cachix.org https://cache.iog.io
-            extra-trusted-public-keys = neohaskell.cachix.org-1:mo2cLaGbwqbrxs9xhqKK8jeNsn3osi7t6XoAmxSZssc= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+      # NOTE: do NOT install Nix here. The measured release installer provisions
+      # Nix itself (Determinate), and a second Determinate install in a workflow
+      # step collides with it (`/nix/receipt.json` planner mismatch), failing the
+      # install phase. The clean runner therefore stays Nix-free; the installer's
+      # Nix install is part of the measured path (inside the 600 s deadline). The
+      # driver (scripts/onboarding-slo) reproduces the post-install Nix login env
+      # and configures the public caches tokenlessly for the measured commands.
       - name: Measure clean-machine onboarding (immutable inputs, checksum-verified, fail-closed)
         env:
           SLO_INSTALLER_VERSION: ${{ inputs.installer_version }}

--- a/installer/Cargo.lock
+++ b/installer/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neo-install"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -4,7 +4,7 @@ license = "MIT"
 repository = "https://github.com/neohaskell/NeoHaskell"
 
 name = "neo-install"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/neo/Cargo.lock
+++ b/neo/Cargo.lock
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "neo"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/neo/Cargo.toml
+++ b/neo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neo"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/scripts/onboarding-slo
+++ b/scripts/onboarding-slo
@@ -141,6 +141,57 @@ def fetch(deadline: float, url: str, destination: Path | None = None) -> bytes:
     return data
 
 
+NEOHASKELL_CACHE = "https://neohaskell.cachix.org"
+NEOHASKELL_CACHE_KEY = "neohaskell.cachix.org-1:mo2cLaGbwqbrxs9xhqKK8jeNsn3osi7t6XoAmxSZssc="
+IOG_CACHE = "https://cache.iog.io"
+IOG_CACHE_KEY = "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+
+
+def nix_login_env(base_env: dict) -> dict:
+    """Reproduce the post-install 'next login shell' environment for the measured
+    `neo` subprocesses, and configure the public caches tokenlessly.
+
+    The release installer provisions Nix itself (Determinate), but only wires it
+    into a FUTURE login shell via profile edits — this process (and the `neo test`
+    subprocess it spawns) never sees it, which is why a bare run fails
+    `nix_missing`. So DO NOT pre-install Nix in the workflow: a second Determinate
+    install collides with the installer's (`/nix/receipt.json` planner mismatch).
+    Instead, source the Nix daemon profile the installer created to pick up PATH +
+    NIX_* exactly as the user's next shell would, always ensure the default
+    profile bin is on PATH, and set the public NeoHaskell + IOG substituters via
+    NIX_CONFIG (accept-flake-config) so the generated-project build is
+    cache-accelerated within the deadline. All read-only/public — no secret."""
+    env = dict(base_env)
+    profiles = [
+        "/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh",
+        "/etc/profile.d/nix.sh",
+    ]
+    profile = next((p for p in profiles if os.path.exists(p)), None)
+    if profile:
+        probe = subprocess.run(
+            ["bash", "-c",
+             f'. "{profile}" >/dev/null 2>&1 && '
+             'python3 -c "import os, json; print(json.dumps(dict(os.environ)))"'],
+            capture_output=True, text=True, timeout=60,
+        )
+        if probe.returncode == 0 and probe.stdout.strip():
+            try:
+                for key, value in json.loads(probe.stdout).items():
+                    if key == "PATH" or key.startswith("NIX_"):
+                        env[key] = value
+            except ValueError:
+                pass
+    nix_bin = "/nix/var/nix/profiles/default/bin"
+    if nix_bin not in env.get("PATH", "").split(os.pathsep):
+        env["PATH"] = nix_bin + os.pathsep + env.get("PATH", "")
+    env["NIX_CONFIG"] = (
+        "accept-flake-config = true\n"
+        f"extra-substituters = {NEOHASKELL_CACHE} {IOG_CACHE}\n"
+        f"extra-trusted-public-keys = {NEOHASKELL_CACHE_KEY} {IOG_CACHE_KEY}\n"
+    )
+    return env
+
+
 def resolve_tag(deadline: float, repo: str, tag: str) -> str:
     """Resolve a release tag to the exact commit it points to, IMMUTABLY and
     TOKENLESSLY via the anonymous git protocol (`git ls-remote`). This replaces
@@ -282,12 +333,16 @@ def run_gate() -> None:
             "installed_neo_sha256": installed_sha,
         }
 
+        # The installer just provisioned Nix but only for a future login shell;
+        # reproduce that env (+ public caches) for the measured `neo` commands.
+        run_env = nix_login_env(env)
+
         phase = "new"
         bounded(deadline, [str(neo), "--ci", "new", "proj"],
-                cwd=work, log=work / "neo-new.log")
+                cwd=work, env=run_env, log=work / "neo-new.log")
         phase = "test"
         bounded(deadline, [str(neo), "--ci", "test"],
-                cwd=work / "proj", log=work / "neo-test.log")
+                cwd=work / "proj", env=run_env, log=work / "neo-test.log")
         cache_pattern = re.compile(
             r"(?:copying (?:path|\d+ paths?)|substituting path).*from.*https://neohaskell\.cachix\.org",
             re.IGNORECASE,
@@ -303,7 +358,7 @@ def run_gate() -> None:
         phase = "run-health"
         server_log = (work / "neo-run.log").open("wb")
         server = subprocess.Popen(
-            [str(neo), "--ci", "run"], cwd=work / "proj",
+            [str(neo), "--ci", "run"], cwd=work / "proj", env=run_env,
             stdout=server_log, stderr=subprocess.STDOUT, start_new_session=True,
         )
         health_url = f"http://127.0.0.1:{os.getenv('SLO_APP_PORT', '8080')}/health"
@@ -429,6 +484,15 @@ def self_test() -> None:
         if saved is not None:
             os.environ["SLO_MONOTONIC_START"] = saved
 
+    # nix_login_env always yields a usable Nix env for the measured commands: the
+    # default profile bin on PATH and the tokenless public substituters, even on a
+    # host with no Nix profile yet (the pre-install state on a clean runner).
+    augmented = nix_login_env({"PATH": "/usr/bin"})
+    assert "/nix/var/nix/profiles/default/bin" in augmented["PATH"].split(os.pathsep)
+    assert "neohaskell.cachix.org" in augmented["NIX_CONFIG"]
+    assert "accept-flake-config" in augmented["NIX_CONFIG"]
+    assert "CACHIX_AUTH_TOKEN" not in augmented.get("NIX_CONFIG", "")  # tokenless
+
     source = Path(__file__).read_text()
     banned = ("gh release " + "create", "cachix " + "push", "git " + "push")
     assert not any(token in source for token in banned)
@@ -436,6 +500,14 @@ def self_test() -> None:
     # unauthenticated GitHub REST API (which returned HTTP 403 on hosted runners).
     assert ("api.github" + ".com") not in source, "tag resolution must not use the GitHub REST API"
     assert "ls-remote" in source, "tag resolution must use immutable `git ls-remote`"
+    # The driver (not a workflow step) provisions the measured commands' Nix env:
+    # it puts the installer-provisioned Nix on PATH and configures the public
+    # caches TOKENLESSLY. Pre-installing Nix in the workflow collides with the
+    # installer, so that responsibility lives here.
+    assert "/nix/var/nix/profiles/default" in source, \
+        "the driver must put the installer-provisioned Nix on PATH for measured commands"
+    assert "NIX_CONFIG" in source and "neohaskell.cachix.org" in source and "accept-flake-config" in source, \
+        "the driver must configure the public Cachix substituter tokenlessly (accept-flake-config)"
     print("onboarding-slo self-test: OK - strict refs, pass/failure evidence, checksum rejection, monotonic deadline (same-host start), tokenless git tag resolution, descendant cleanup, non-publication")
 
 

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -918,42 +918,27 @@ def check_onboarding_slo(name, text):
             E(f"{name}: `slo` job must upload the evidence SHA256 sidecar and fail when evidence is missing")
         # (e) the ONE global deadline starts BEFORE the prerequisite install: the
         # workflow captures a same-host monotonic start and threads it into the
-        # driver, so Nix/Cachix install + checkout time is inside the 600 s budget
-        # (not silently excluded by starting the clock inside the driver).
+        # driver, so the (installer-provisioned) Nix install + checkout time is
+        # inside the 600 s budget (not silently excluded by starting the clock in
+        # the driver). Capture is the first step, so it precedes everything.
         threaded = "SLO_MONOTONIC_START: ${{ env.SLO_MONOTONIC_START }}" in slo
         captured = "GITHUB_ENV" in slo and "monotonic" in slo
         if not (threaded and captured):
             E(f"{name}: `slo` job does not start the deadline before the prerequisite "
-              "install — it must capture `time.monotonic()` into GITHUB_ENV (before the "
-              "Nix install) AND thread it as `SLO_MONOTONIC_START: ${{ env.SLO_MONOTONIC_START }}` "
-              "so prerequisite/cache/download/install time is counted")
-        # The capture must PRECEDE the Nix install: capturing after it would omit
-        # the install from the budget (a fabrication direction — it under-counts).
-        if captured:
-            nix_positions = [p for p in (slo.find("determinate-nix-action"),
-                                         slo.find("install-nix-action")) if p != -1]
-            if nix_positions and slo.find("monotonic") > min(nix_positions):
-                E(f"{name}: `slo` job captures the monotonic deadline start AFTER installing "
-                  "Nix — the start must precede the prerequisite install, else install time "
-                  "is silently excluded from the 600 s budget")
-        # (f) the clean machine installs Nix: the measured `neo test`/`neo run`
-        # build the generated project via nix, so a runner without Nix fails
-        # closed with nix_missing (the observed prior failure).
-        if not re.search(r"(determinate-nix-action|install-nix-action)", slo):
-            E(f"{name}: `slo` job does not install Nix "
-              "(DeterminateSystems/determinate-nix-action or nixos/install-nix-action) "
-              "— the measured build needs it (else `neo test` fails: nix_missing)")
-        # (g) the public Cachix substituter is configured TOKENLESSLY via nix
-        # read-config (never a write-capable cachix action — that is already
-        # banned above), so the 600 s path is cache-accelerated and the driver's
-        # observed_use can be genuinely true.
-        if "neohaskell.cachix.org" not in slo:
-            E(f"{name}: `slo` job does not configure the public neohaskell.cachix.org "
-              "substituter — the measured build cannot meet 600 s and real "
-              "substitution (observed_use) cannot be proven")
-        if "extra-substituters" not in slo and "accept-flake-config" not in slo:
-            E(f"{name}: `slo` job does not configure the substituter via read-only nix "
-              "config (extra-substituters / accept-flake-config) — it must be tokenless")
+              "install — it must capture `time.monotonic()` into GITHUB_ENV (first step) "
+              "AND thread it as `SLO_MONOTONIC_START: ${{ env.SLO_MONOTONIC_START }}` "
+              "so prerequisite/download/install time is counted")
+        # (f) the slo job must NOT pre-install Nix. The measured RELEASE installer
+        # provisions Nix itself (Determinate); a second Determinate install in a
+        # workflow step collides with it (`/nix/receipt.json` planner mismatch) and
+        # fails the install phase. The driver puts the installer-provisioned Nix on
+        # PATH and configures the public caches tokenlessly for the measured
+        # commands (frozen by `onboarding-slo --self-test`).
+        if re.search(r"(determinate-nix-action|install-nix-action)", slo):
+            E(f"{name}: `slo` job pre-installs Nix "
+              "(DeterminateSystems/determinate-nix-action or nixos/install-nix-action) — "
+              "the release installer provisions Nix itself and a second install collides "
+              "(`/nix/receipt.json`); let the installer do it and put Nix on PATH in the driver")
     return errs
 
 
@@ -1530,9 +1515,6 @@ def self_test():
         "    steps:\n"
         "      - name: start deadline\n        run: python3 -c \"import time,os; open(os.environ['GITHUB_ENV'],'a').write('SLO_MONOTONIC_START=%r' % time.monotonic())\"\n"
         "      - uses: actions/checkout@v7.0.1\n"
-        "      - uses: DeterminateSystems/determinate-nix-action@v3.21.7\n"
-        "        with:\n          extra-conf: |\n            accept-flake-config = true\n"
-        "            extra-substituters = https://neohaskell.cachix.org https://cache.iog.io\n"
         "      - name: measure\n"
         "        env:\n"
         "          SLO_INSTALLER_VERSION: ${{ inputs.installer_version }}\n"
@@ -1600,15 +1582,9 @@ def self_test():
             good_slo.replace("          SLO_MONOTONIC_START: ${{ env.SLO_MONOTONIC_START }}\n", ""))
     slo_bad("slo job not capturing the pre-prerequisite monotonic start is flagged",
             good_slo.replace("      - name: start deadline\n        run: python3 -c \"import time,os; open(os.environ['GITHUB_ENV'],'a').write('SLO_MONOTONIC_START=%r' % time.monotonic())\"\n", ""))
-    _cap_step = "      - name: start deadline\n        run: python3 -c \"import time,os; open(os.environ['GITHUB_ENV'],'a').write('SLO_MONOTONIC_START=%r' % time.monotonic())\"\n"
-    slo_bad("slo job capturing the monotonic start AFTER the Nix install is flagged (under-counts)",
-            good_slo.replace(_cap_step, "").replace(
-                "        run: ./dev onboarding-slo run\n",
-                "        run: ./dev onboarding-slo run\n" + _cap_step))
-    slo_bad("slo job not installing Nix is flagged (else neo test → nix_missing)",
-            good_slo.replace("      - uses: DeterminateSystems/determinate-nix-action@v3.21.7\n", ""))
-    slo_bad("slo job not configuring the public neohaskell.cachix.org substituter is flagged",
-            good_slo.replace("            extra-substituters = https://neohaskell.cachix.org https://cache.iog.io\n", ""))
+    slo_bad("slo job pre-installing Nix is flagged (collides with the release installer)",
+            good_slo.replace("      - uses: actions/checkout@v7.0.1\n",
+                             "      - uses: actions/checkout@v7.0.1\n      - uses: DeterminateSystems/determinate-nix-action@v3.21.7\n"))
 
     print("workflow-check: self-test", "OK" if ok else "FAILED")
     return 0 if ok else 1


### PR DESCRIPTION
Remediation for SLO run 31101631965 (both legs failed at install: `/nix/receipt.json` planner mismatch). The release installer provisions Nix itself; the v0.1.1 workflow-step Nix pre-install collided with it. Fix: remove the pre-install; the driver reproduces the post-install Nix login env (PATH + NIX_*) and sets tokenless public substituters (NIX_CONFIG accept-flake-config) for the measured `neo new/test/run`. workflow-check now forbids pre-installing Nix; driver self-test freezes the substituter/PATH invariant. Crates bump to 0.1.2 (v0.1.1 immutable, not moved). RED/GREEN + adversarial-reviewed lineage. Folds into integration (#758) via FF once green.