### PR TITLE
feat(slo): pin generated projects to compat rev + prime its closure (v0.1.3)

### DIFF
--- a/.github/workflows/neo-ci.yml
+++ b/.github/workflows/neo-ci.yml
@@ -330,12 +330,24 @@ jobs:
         with:
           name: neohaskell
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Populate the cache from the EXACT consumer path
+      # Populate the cache from BOTH real paths, using the same verified,
+      # release-installed binary:
+      #  1. neo-consumer-contract — the EXACT-CHECKOUT closure (neohaskell ->
+      #     path:<checkout>), retained coverage.
+      #  2. cache-prime — the DEFAULT released generated-project closure (no
+      #     override; pinned to the compatibility revision), which is the closure
+      #     the clean-machine onboarding SLO actually substitutes. Without this the
+      #     SLO builds an unprimed closure from source and misses its 600 s
+      #     deadline. The Cachix post-hook pushes everything both build.
+      - name: Populate the cache from the EXACT consumer path + the default released closure
         if: ${{ env.CACHIX_AUTH_TOKEN != '' }}
         env:
           CONTRACT_BUILD_TIMEOUT: "5400"
           CONTRACT_TEST_TIMEOUT: "2400"
           CONTRACT_READY_DEADLINE: "300"
+          PRIME_BUILD_TIMEOUT: "5400"
+          PRIME_TEST_TIMEOUT: "2400"
+          PRIME_RUN_TIMEOUT: "300"
         run: |
           set -euo pipefail
           cargo build --release --locked --manifest-path neo/Cargo.toml --target "$REHEARSAL_TARGET"
@@ -344,6 +356,7 @@ jobs:
           ./scripts/neo-release checksums "$RUNNER_TEMP/neo-artifacts"
           ./scripts/neo-release install "$RUNNER_TEMP/neo-artifacts" "$REHEARSAL_TARGET" "$RUNNER_TEMP/neo-bin/neo"
           NEO_BIN="$RUNNER_TEMP/neo-bin/neo" ./dev neo-consumer-contract
+          NEO_BIN="$RUNNER_TEMP/neo-bin/neo" ./dev cache-prime
 
   # THE REQUIRED CHECK for the neo component. `if: always()` + no workflow-level
   # paths filter => it always reports a conclusion on every PR, so it is safe to

--- a/dev
+++ b/dev
@@ -76,6 +76,9 @@ usage: ./dev <verb> [args]
                           from the embedded starter offline, then build/test/run it
                           against THIS checkout (neohaskell -> path:<checkout>) and
                           poll /health (--self-test for the orchestration logic)
+  cache-prime           trusted-only warmer: build the DEFAULT released
+                          generated-project closure (no checkout override) so the
+                          clean-machine SLO substitutes it (--self-test)
   neo-release <cmd>     native `neo` release-asset contract (single source of
                           truth for naming/checksums shared by the release
                           workflow + rehearsal): targets, asset-name, package,
@@ -127,6 +130,7 @@ case "${VERB}" in
   neo-skills-check) exec scripts/neo-skills-check "$@" ;;
   neo-dist-check) exec scripts/neo-dist-check "$@" ;;
   neo-consumer-contract) exec scripts/neo-consumer-contract "$@" ;;
+  cache-prime) exec scripts/cache-prime "$@" ;;
   neo-release) exec scripts/neo-release "$@" ;;
   onboarding-slo) exec scripts/onboarding-slo "$@" ;;
   doctor)   exec scripts/doctor "$@" ;;

--- a/installer/Cargo.lock
+++ b/installer/Cargo.lock
@@ -404,7 +404,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "neo-install"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -4,7 +4,7 @@ license = "MIT"
 repository = "https://github.com/neohaskell/NeoHaskell"
 
 name = "neo-install"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/neo/AGENTS.md
+++ b/neo/AGENTS.md
@@ -116,6 +116,16 @@ version is compatible with.
   same revision. (`neo new` offline renders a deterministic placeholder rev; the
   real fetched revision is proven against the checkout in phase 3.) The gate
   never hardcodes a revision, so nothing drifts.
+- **Generated projects PIN this revision** (not the moving `main` ref). `neo new`
+  writes `neo.json` `neo-version` = the revision the embedded starter is locked to
+  (`starter_neohaskell_rev()`), and `fetch_neo_sha` returns a 40-hex version
+  as-is. So a fresh project builds the exact, immutable closure the contract
+  declares — reproducible and cacheable.
+- **Cache priming:** the trusted `cache-populate` job (neo-ci.yml) also runs
+  `./dev cache-prime`, which builds the DEFAULT released generated-project closure
+  (no checkout override) and pushes it to the public Cachix, so the clean-machine
+  onboarding SLO substitutes it within 600 s. This is separate from the
+  exact-checkout `neo-consumer-contract` closure (both are primed).
 - **To bump the compatible NeoHaskell revision:** update all three starter pins
   together (see the comment in `neo/starter/flake.nix`); the drift self-test
   (`scripts/neo-release --self-test`, run by `./dev doctor` + CI) refuses a

--- a/neo/Cargo.lock
+++ b/neo/Cargo.lock
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "neo"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/neo/Cargo.toml
+++ b/neo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neo"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]

--- a/neo/src/commands/new.rs
+++ b/neo/src/commands/new.rs
@@ -306,7 +306,19 @@ pub async fn run(
     Ok(())
 }
 
-async fn do_scaffold(config: ProjectConfig) -> miette::Result<()> {
+async fn do_scaffold(mut config: ProjectConfig) -> miette::Result<()> {
+    // Pin the generated project to the EXACT NeoHaskell revision the embedded
+    // starter is locked to (which the published compatibility contract records),
+    // rather than the moving `main` ref. This makes a generated project build a
+    // stable, cache-primable closure that matches the compat contract. Only the
+    // untouched default `"main"` is replaced, so an explicitly requested version
+    // is preserved. A `None` (corrupt embed) leaves `"main"` — that packaging
+    // defect surfaces via `write_starter_template` below.
+    if config.neo_version == "main" {
+        if let Some(rev) = crate::network::starter_neohaskell_rev() {
+            config.neo_version = rev;
+        }
+    }
     let project_path = PathBuf::from(&config.name);
     if project_path.exists() {
         return Err(crate::errors::NeoError::DirectoryExists { name: config.name }.into());

--- a/neo/src/network.rs
+++ b/neo/src/network.rs
@@ -15,7 +15,21 @@ struct GitHubRelease {
 
 
 
+/// True when `version` is a full 40-hex commit SHA (already a resolved revision).
+pub fn is_commit_sha(version: &str) -> bool {
+    version.len() == 40 && version.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
 pub async fn fetch_neo_sha(version: &str) -> miette::Result<String> {
+    // A full 40-hex commit SHA is already a resolved revision. `git ls-remote`
+    // matches refs (branches/tags), not bare commits, so it cannot resolve one —
+    // return it directly. This is what lets a generated project pin the exact,
+    // immutable NeoHaskell revision the starter is locked to (see `neo new`)
+    // instead of the moving `main` ref, so its build closure is stable + cacheable.
+    if is_commit_sha(version) {
+        return Ok(version.to_string());
+    }
+
     if std::env::var("NEO_SKIP_NETWORK").is_ok() {
         return Ok("deadbeef".to_string());
     }
@@ -257,6 +271,29 @@ pub async fn check_for_updates() -> miette::Result<Option<String>> {
 #[folder = "starter/"]
 #[exclude = "IMPORT.md"]
 struct StarterTemplate;
+
+/// The NeoHaskell source revision the EMBEDDED starter is locked to
+/// (`neo/starter/flake.lock`, node `neohaskell` → `locked.rev`). This is the
+/// single source of truth for the revision a freshly generated project pins —
+/// the same value the released compatibility contract (`neo-release compat`)
+/// publishes — so a generated project consumes the exact, immutable revision the
+/// starter was tested against rather than a moving `main`. Returns `None` only if
+/// the embedded lock is missing/corrupt (a packaging defect surfaced elsewhere).
+pub fn starter_neohaskell_rev() -> Option<String> {
+    let lock = StarterTemplate::get("flake.lock")?;
+    let json: serde_json::Value = serde_json::from_slice(lock.data.as_ref()).ok()?;
+    let rev = json
+        .get("nodes")?
+        .get("neohaskell")?
+        .get("locked")?
+        .get("rev")?
+        .as_str()?;
+    if is_commit_sha(rev) {
+        Some(rev.to_string())
+    } else {
+        None
+    }
+}
 
 /// Write the embedded starter template into `dest`, creating parent directories
 /// as needed. Path-traversal safe: every embedded entry is resolved through

--- a/neo/tests/e2e.rs
+++ b/neo/tests/e2e.rs
@@ -209,7 +209,16 @@ fn new_ci_creates_full_project() {
 
     let neo_json = read_neo_json(&project);
     assert_eq!(neo_json["name"], "my-app");
-    assert_eq!(neo_json["neo-version"], "main");
+    // `neo new` pins the generated project to the EXACT NeoHaskell revision the
+    // embedded starter is locked to (an immutable 40-hex SHA, matching the
+    // compatibility contract), never the moving `main` ref.
+    let neo_version = neo_json["neo-version"].as_str().unwrap_or_default();
+    assert_ne!(neo_version, "main", "generated neo-version must be a pinned SHA, not `main`");
+    assert_eq!(neo_version.len(), 40, "generated neo-version must be a 40-hex commit SHA");
+    assert!(
+        neo_version.bytes().all(|b| b.is_ascii_hexdigit()),
+        "generated neo-version must be hex: {neo_version}"
+    );
     for field in ["version", "description", "author", "license"] {
         assert!(
             neo_json.get(field).is_some(),

--- a/neo/tests/integration_tests.rs
+++ b/neo/tests/integration_tests.rs
@@ -83,10 +83,19 @@ fn test_neo_new_ci() {
         cabal_project
     );
 
-    // Verify neo.json content
+    // Verify neo.json content. `neo new` pins the generated project to the exact
+    // immutable NeoHaskell revision the embedded starter is locked to (a 40-hex
+    // SHA matching the compatibility contract), never the moving `main` ref.
     let config_content = std::fs::read_to_string(project_path.join("neo.json")).unwrap();
     assert!(config_content.contains(project_name));
-    assert!(config_content.contains("\"neo-version\": \"main\""));
+    assert!(
+        !config_content.contains("\"neo-version\": \"main\""),
+        "generated neo-version must be a pinned SHA, not `main`: {config_content}"
+    );
+    let neo_json: serde_json::Value = serde_json::from_str(&config_content).unwrap();
+    let neo_version = neo_json["neo-version"].as_str().unwrap();
+    assert_eq!(neo_version.len(), 40, "generated neo-version must be a 40-hex SHA");
+    assert!(neo_version.bytes().all(|b| b.is_ascii_hexdigit()));
 
     // Verify git commit exists
     let git_log = std::process::Command::new("git")

--- a/scripts/cache-prime
+++ b/scripts/cache-prime
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# cache-prime — trusted-only warmer for the DEFAULT released generated-project
+# closure.
+#
+# The clean-machine onboarding SLO measures a REAL released `neo`, which generates
+# a project pinned to the compatibility revision (the NeoHaskell rev the embedded
+# starter is locked to) and then `neo build`/`neo test`/`neo run` it. That build
+# closure — INCLUDING test/run dependencies — must already be in the public Cachix
+# for the SLO to meet its 600 s deadline. This script realizes exactly that
+# closure by running the SAME default path (NO `NEO_NEOHASKELL_SOURCE` override),
+# so the caller's Cachix post-hook pushes the store paths a real user would fetch.
+#
+# This is DELIBERATELY SEPARATE from `neo-consumer-contract`, which builds the
+# EXACT-CHECKOUT closure via the `NEO_NEOHASKELL_SOURCE` override (that coverage
+# is retained, unchanged). cache-prime builds the DEFAULT (released) closure; the
+# two closures differ by the pinned NeoHaskell revision, and the SLO needs THIS
+# one.
+#
+# Trust: this script holds NO secret. The caller (neo-ci.yml `cache-populate`)
+# owns the CACHIX_AUTH_TOKEN + push and invokes cache-prime ONLY on a trusted push
+# (exact-ref main/integration, same repo, never a pull_request). cache-prime must
+# never set NEO_NEOHASKELL_SOURCE (that would prime the wrong closure) — the
+# --self-test freezes that.
+#
+#   cache-prime            build+realize the default generated-project closure
+#                          (NEO_BIN=<path> required; reuses the already-built neo)
+#   cache-prime --self-test  freeze the orchestration seam (no network/build)
+#
+# Env: NEO_BIN (required), PRIME_BUILD_TIMEOUT (default 5400),
+#      PRIME_TEST_TIMEOUT (default 2400), PRIME_RUN_TIMEOUT (default 300),
+#      NEO_APP_PORT (default 8080).
+set -euo pipefail
+
+info() { printf '  - %s\n' "$*"; }
+phase() { printf '\n=== [cache-prime] %s ===\n' "$*"; }
+die() { printf 'cache-prime: FAIL — %s\n' "$*" >&2; exit 1; }
+
+BUILD_TIMEOUT="${PRIME_BUILD_TIMEOUT:-5400}"
+TEST_TIMEOUT="${PRIME_TEST_TIMEOUT:-2400}"
+RUN_TIMEOUT="${PRIME_RUN_TIMEOUT:-300}"
+APP_PORT="${NEO_APP_PORT:-8080}"
+APP_NAME="prime-app"
+
+# Run a command in its own process session under a hard timeout; TERM→KILL the
+# whole group on expiry so a hung nix/cabal build cannot outlive the warmer.
+# Python-based for macOS+Linux portability (no GNU `timeout`/`setsid` needed).
+# Exit 124 on timeout, else the command's real status.
+bounded() {
+  local secs="$1"; shift
+  python3 - "$secs" "$@" <<'PY'
+import os, signal, subprocess, sys
+secs = float(sys.argv[1]); argv = sys.argv[2:]
+p = subprocess.Popen(argv, start_new_session=True)
+try:
+    sys.exit(p.wait(timeout=secs))
+except subprocess.TimeoutExpired:
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(p.pid, sig)
+        except ProcessLookupError:
+            break
+        try:
+            p.wait(timeout=10)
+            break
+        except subprocess.TimeoutExpired:
+            continue
+    sys.exit(124)
+PY
+}
+
+prime() {
+  command -v nix >/dev/null 2>&1 || die "nix is required on PATH (the caller installs it)"
+  command -v python3 >/dev/null 2>&1 || die "python3 is required (bounded timeout wrapper)"
+  local neo_bin="${NEO_BIN:-}"
+  [ -n "$neo_bin" ] || die "NEO_BIN must point at the neo binary to prime with"
+  [ -x "$neo_bin" ] || die "NEO_BIN is not executable: $neo_bin"
+
+  # A scratch world OUTSIDE any repo checkout, cleaned up unconditionally.
+  local work; work="$(mktemp -d "${TMPDIR:-/tmp}/neo-cache-prime.XXXXXX")"
+  trap 'rm -rf "$work" 2>/dev/null || true' EXIT
+  local proj="$work/$APP_NAME"
+
+  phase "generate — neo new (DEFAULT: released path, no override)"
+  # NEVER set NEO_NEOHASKELL_SOURCE here: that override would prime the
+  # exact-checkout closure (that is the consumer-contract's job), not the default
+  # released closure the SLO needs.
+  ( cd "$work" && "$neo_bin" --ci new "$APP_NAME" )
+  [ -f "$proj/flake.nix" ] || die "neo new did not scaffold $proj/flake.nix"
+  local pinned
+  pinned="$(sed -nE 's/.*neohaskellCommit = "([0-9a-fA-F]+)".*/\1/p' "$proj/flake.nix" | head -1)"
+  info "generated project pins NeoHaskell revision: ${pinned:-<none>}"
+
+  phase "build — realize the default build closure"
+  ( cd "$proj" && bounded "$BUILD_TIMEOUT" "$neo_bin" --ci build ) \
+    || die "neo build failed while priming the default closure"
+
+  phase "test — realize the test-dependency closure"
+  ( cd "$proj" && bounded "$TEST_TIMEOUT" "$neo_bin" --ci test ) \
+    || die "neo test failed while priming the test closure"
+
+  phase "run — realize the run-dependency closure (brief)"
+  # Start the app so its run closure is realized, then tear the session down.
+  ( cd "$proj" && bounded "$RUN_TIMEOUT" "$neo_bin" --ci run ) >/dev/null 2>&1 || true
+
+  phase "done — default closure realized (caller's Cachix hook pushes it)"
+  info "prime complete for $APP_NAME (port ${APP_PORT})"
+}
+
+self_test() {
+  local fails=0
+  ok() { printf '  ok   %s\n' "$1"; }
+  bad() { printf '  FAIL %s\n' "$1" >&2; fails=$((fails + 1)); }
+
+  # 1. A hung command is bounded and killed within its budget.
+  local start end
+  start="$(date +%s)"
+  if bounded 1 sleep 30; then bad "bounded: an over-running command wrongly succeeded"
+  else ok "bounded: over-running command is killed"; fi
+  end="$(date +%s)"
+  [ $((end - start)) -lt 8 ] && ok "bounded: fired promptly (<8s)" || bad "bounded: too slow"
+
+  # 2. A fast command passes through with its real status.
+  bounded 10 true && ok "bounded: fast success passes" || bad "bounded: fast success failed"
+  if bounded 10 false; then bad "bounded: failure wrongly reported success"; else ok "bounded: real failure propagates"; fi
+
+  # 3. The warmer builds the DEFAULT closure — it must NEVER assign the
+  #    exact-checkout override (that would prime the wrong closure). The needle is
+  #    split so this very guard line does not self-match.
+  local ovr="NEO_NEOHASKELL""_SOURCE="
+  if grep -F "$ovr" "$0" | grep -vqE '^\s*#'; then
+    bad "cache-prime assigns the exact-checkout override — it must build the DEFAULT closure"
+  else
+    ok "cache-prime never sets the exact-checkout override (default closure only)"
+  fi
+
+  # 4. It realizes the full closure: new + build + test + run phases present.
+  for verb in new build test run; do
+    if grep -qE -- "--ci $verb" "$0"; then
+      ok "cache-prime runs neo $verb"
+    else
+      bad "cache-prime missing neo $verb"
+    fi
+  done
+
+  if [ "$fails" -ne 0 ]; then
+    printf 'cache-prime self-test: FAILED (%d)\n' "$fails" >&2
+    return 1
+  fi
+  printf 'cache-prime self-test: OK — bounded timeout, default-closure (no override), new/build/test/run\n'
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "") prime ;;
+  *) die "usage: cache-prime [--self-test]" ;;
+esac

--- a/scripts/doctor
+++ b/scripts/doctor
@@ -92,6 +92,7 @@ scripts/revert --self-test || fail=1
 scripts/retrospect --self-test || fail=1
 scripts/workflow-check --self-test || fail=1
 scripts/neo-release --self-test >/dev/null || fail=1
+scripts/cache-prime --self-test >/dev/null || fail=1
 # Quiet on success, but surface the captured output on failure.
 if ! crg_out=$(scripts/codemap-regen-guard.py --self-test 2>&1); then
   printf '%s\n' "${crg_out}"

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -76,6 +76,7 @@ CONSUMER_CONTRACT_JOB = "consumer-contract"
 CONTRACT_GATE_JOB = "neo-ci-gate"
 CONTRACT_SURFACES = ("neo/", "core/", "integrations/")
 CONTRACT_VERB = "neo-consumer-contract"
+CACHE_PRIME_VERB = "cache-prime"
 
 
 def _indent(line):
@@ -757,6 +758,14 @@ def check_cache_populate(name, text):
     if CONTRACT_VERB not in job:
         E(f"{name}: `{CACHE_POPULATE_JOB}` does not run the exact consumer path "
           f"(`./dev {CONTRACT_VERB}`) — the cache must be populated from real execution")
+    # It must ALSO prime the DEFAULT released generated-project closure — the one
+    # the clean-machine onboarding SLO actually substitutes (pinned to the
+    # compatibility revision, not the exact-checkout override). Without this the
+    # SLO builds an unprimed closure from source and misses its 600 s deadline.
+    if CACHE_PRIME_VERB not in job:
+        E(f"{name}: `{CACHE_POPULATE_JOB}` does not prime the DEFAULT released closure "
+          f"(`./dev {CACHE_PRIME_VERB}`) — the SLO substitutes that closure, not only "
+          "the exact-checkout consumer path; retain both")
     # Honest skip: a step gated on an EMPTY token (skip, don't fail/pretend).
     if "CACHIX_AUTH_TOKEN == ''" not in job:
         E(f"{name}: `{CACHE_POPULATE_JOB}` has no honest-skip path for a missing token "
@@ -1409,7 +1418,7 @@ def self_test():
         "      - name: skip\n        if: ${{ env.CACHIX_AUTH_TOKEN == '' }}\n        run: echo skip\n"
         "      - uses: cachix/cachix-action@v17\n        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}\n"
         "      - name: populate\n        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}\n"
-        "        run: NEO_BIN=x ./dev neo-consumer-contract\n"
+        "        run: |\n          NEO_BIN=x ./dev neo-consumer-contract\n          NEO_BIN=x ./dev cache-prime\n"
     )
 
     def cp_bad(name_, mutated):
@@ -1417,6 +1426,8 @@ def self_test():
 
     check("well-wired cache-populate passes",
           not check_cache_populate("neo-ci.yml", good_cache))
+    cp_bad("cache-populate not priming the default released closure is flagged",
+           good_cache.replace("          NEO_BIN=x ./dev cache-prime\n", ""))
     cp_bad("missing cache-populate job is flagged",
            good_cache.replace("  cache-populate:\n", "  other:\n"))
     cp_bad("cache-populate not gated to the main ref is flagged",
@@ -1438,8 +1449,7 @@ def self_test():
            good_cache.replace(
                "      - name: skip\n        if: ${{ env.CACHIX_AUTH_TOKEN == '' }}\n        run: echo skip\n", ""))
     cp_bad("cache-populate not running the consumer path is flagged",
-           good_cache.replace("        run: NEO_BIN=x ./dev neo-consumer-contract\n",
-                              "        run: echo nothing\n"))
+           good_cache.replace("          NEO_BIN=x ./dev neo-consumer-contract\n", ""))
     cp_bad("an unguarded cachix push step is flagged",
            good_cache.replace(
                "      - uses: cachix/cachix-action@v17\n        if: ${{ env.CACHIX_AUTH_TOKEN != '' }}\n",


### PR DESCRIPTION
Remediation for SLO run 31104982253 (both legs 600s timeout in `neo test`, observed_use=false). Root cause: default `neo_version=main` resolved to mutable `NeoHaskell/neohaskell` main (8d5642ec ≠ starter lock 3fd3d132), so the SLO built an unprimed, non-contract closure from source. Fix: generated projects now pin the immutable compat revision (starter's locked rev; `fetch_neo_sha` returns a 40-hex as-is); new trusted-only `scripts/cache-prime` builds+pushes the DEFAULT released closure (no override) in the isolated cache-populate job, keeping exact-checkout consumer-contract coverage separate. RED/GREEN self-tests + adversarial review (MERGE-SAFE). Crates → 0.1.3 (0.1.0/0.1.1/0.1.2 immutable, unmoved). Folds into integration (#758) via FF once green.