### PR TITLE
spec: make NameOf the single type identity and add the Descriptor primitive (#801)

### DIFF
--- a/docs/changes/007-nameof-single-identity-descriptor.md
+++ b/docs/changes/007-nameof-single-identity-descriptor.md
@@ -1,0 +1,157 @@
+# Change 007: Make `NameOf` the single type identity and add the `Descriptor` primitive
+
+Issue #801 asks for two things that are really one thing. First, a type must
+have **one** identity: today `NameOf` (type-level, drives `emitCommand`,
+`makeCommandPayload`, `buildHandler`, `withTransport` and the `KnownHash`
+command registry) and `Documented.name` (value-level `Text`, defaulting to
+`TypeName.reflect`) both claim to name a type, and they already disagree —
+`Integration.Agent.TestFixtures.AddItemCommand` has
+`type instance NameOf AddItemCommand = "AddItem"`, so `Documented.name` would
+answer `"AddItemCommand"` while dispatch expects `"AddItem"`. `Documented.name`
+has zero call sites in `core/`, `testbed/` and `integrations/`, and no instance
+anywhere overrides it, so it is a trap with no users: it is removed, and
+`NameOf` becomes the single identity. Second, the "name + description + schema"
+triple that ADR-0013 section 6 sketched as `DocumentedInfo` and never
+implemented is shipped for real as a provider-neutral `Descriptor`, whose name
+comes from `NameOf` — so a type that cannot route cannot get a descriptor
+either, at compile time rather than at runtime.
+
+```yaml spec
+issue: issue#801                # issue#NNN or adhoc:<slug>
+kind: refactor                  # feature | bug | refactor
+touches: [traits, schema]       # capability IDs from codemap/capabilities.yaml (closed list)
+breaking: true                  # MUST be true if the contract delta has any `-` line
+new-dependency: false           # any new build-depends / flake input
+new-capability: false           # this change adds a row to codemap/capabilities.yaml
+new-extension-point: false      # this change adds a row to codemap/extension-points.yaml
+```
+
+## Contract delta
+
+One removal, one new module. **The constructor function is `Descriptor.describe`,
+not `Descriptor.of` as the issue writes it — `of` is a Haskell reserved word
+(`case … of`) and cannot be a function name.** `describe` was chosen to read at
+the call site (`Descriptor.describe @AddItem`) alongside the existing nullary
+type-applied primitives `Schema.toSchema @value` and `TypeName.reflect @value`;
+`Descriptor.reflect` and `Descriptor.forType` are the alternatives, and renaming
+is a one-line change at this gate.
+
+The signature also carries **`ToJSON value`**, which the issue's sketch omits.
+It is not optional: `Documented.examples :: Array value` is type-indexed, and
+flattening it to the monomorphic `Array Json.Value` the record holds is exactly
+a `ToJSON` call. Every concept type that reaches a descriptor already has a
+`ToJSON` instance (the TH markers derive it), so the constraint costs existing
+callers nothing.
+
+`Descriptor` is deliberately **not** added to the `Core` re-export list. Its
+field labels (`name`, `description`, `schema`) would collide with the
+`Documented (..)` and `Schema (..)` re-exports already there; it is a
+qualified-import module (`import Descriptor qualified`), and with
+`NoFieldSelectors` its fields are reached through `descriptor.name` anyway. That
+also settles the import-cycle caveat in the issue: `Descriptor` imports
+`Documented`, `Schema` and `Service.Command.Core` directly and never imports
+`Core`, so no cycle can form.
+
+```diff signatures
+- Documented: name :: Documented value => Text
++ Descriptor: data Descriptor
++ Descriptor: Descriptor :: Text -> Text -> Schema -> Array Value -> Bool -> Descriptor
++ Descriptor: [name] :: Descriptor -> Text
++ Descriptor: [description] :: Descriptor -> Text
++ Descriptor: [schema] :: Descriptor -> Schema
++ Descriptor: [examples] :: Descriptor -> Array Value
++ Descriptor: [deprecated] :: Descriptor -> Bool
++ Descriptor: describe :: forall value (name :: Symbol). (Documented value, ToSchema value, ToJSON value, NameOf value ~ name, KnownSymbol name) => Descriptor
++ Descriptor: instance GHC.Classes.Eq Descriptor.Descriptor
++ Descriptor: instance GHC.Show.Show Descriptor.Descriptor
+```
+
+## Criteria
+
+Every criterion is `unit`: nothing here crosses a filesystem, a database or a
+socket — the whole change is a typeclass shape and a pure type-directed
+function, and the one criterion that *is* about a boundary (C5, the compile-time
+rejection) is proven inside GHC by the existing
+`Test.CompileTime.shouldNotTypecheck` helper rather than by a runtime effect.
+
+C2 is the criterion that pins the *point* of the issue, and it is written so it
+cannot pass by accident: the fixture's `NameOf` (`"AddItem"`) is deliberately
+different from its type name (`AddItemCommand`), and the test asserts **both**
+sides — that the descriptor answers the routable `NameOf` symbol *and* that
+`TypeName.reflect` still answers the type name. An implementation that quietly
+kept the old `TypeName.reflect` default would flip exactly this test red.
+
+C5 is the compile-time half of the same guarantee: without it, "the name comes
+from `NameOf`" is only true for the types we happened to test. `KnownSymbol
+(NameOf value)` on an un-instantiated type family is unsolvable, so
+`Descriptor.describe @NoNameCommand` is a type error, and
+`shouldNotTypecheck` (already wired into `nhcore` via
+`core/testlib/Test/CompileTime.hs` and the `should-not-typecheck` dependency)
+turns that into an assertion.
+
+| ID | Behavior | Proving test | Level |
+|----|----------|--------------|-------|
+| C1 | `Documented` exposes only `description`, `examples` and `deprecated`: a bare instance still yields the documented defaults (`""`, empty array, `False`), and an instance that overrides `description` is honored — the behavior of the surviving members is unchanged by the removal of `name` | `DocumentedSpec` "the reduced class keeps its defaults and honors overrides" | unit |
+| C2 | `Descriptor.describe` takes `name` from `NameOf`, never from a value-level fallback: for a fixture whose `NameOf` is `"AddItem"` but whose type is `AddItemCommand`, the descriptor's `name` is `"AddItem"` while `TypeName.reflect @AddItemCommand` is still `"AddItemCommand"` | `DescriptorSpec` "name comes from NameOf, not from the type name" | unit |
+| C3 | `Descriptor.describe` carries `Documented.description` verbatim, including the empty case: a fixture with a description gets it unchanged, and a fixture whose description is `""` gets `""` — the descriptor never substitutes the name, because the empty-description fallback is a rendering decision that belongs to the renderer | `DescriptorSpec` "description is carried verbatim, including empty" | unit |
+| C4 | `Descriptor.describe` carries `Schema.toSchema @value` unchanged, flattens `Documented.examples` to `Array Json.Value` through `ToJSON` preserving order, yields the empty array when there are no examples, and carries `deprecated` through in both states | `DescriptorSpec` "schema, examples and deprecated are carried through" | unit |
+| C5 | A type with no `NameOf` instance is rejected at the call site, at compile time: `Descriptor.describe @NoNameCommand` does not typecheck even though the type has `Documented`, `ToSchema` and `ToJSON` instances | `DescriptorSpec` "a type without a NameOf instance is rejected at compile time" | unit |
+| C6 | The descriptor stays provider-neutral — it holds a `Schema`, not a rendering: the same descriptor feeds `Schema.JsonSchema.toJsonSchema` and `Schema.OpenApi.toOpenApiSchema` downstream, and `toJsonSchema descriptor.schema` equals the `parameters` payload shape that a tool definition needs, with no provider field anywhere in the record | `DescriptorSpec` "the schema field renders through both existing renderers" | unit |
+
+## User impact
+
+**Breaking, for a member with no known users.** `Documented (..)` is re-exported
+from `Core`, so any downstream application that wrote
+
+```haskell
+instance Documented AddItem where
+  name = "AddItem"
+  description = "Add an item to a shopping cart"
+```
+
+stops compiling with *`name` is not a (visible) method of class `Documented`*.
+
+**Migration.** Identity moves to the type level, and a display string comes from
+`TypeName`:
+
+```haskell
+-- identity (what routing, dispatch and the command registry use)
+type instance NameOf AddItem = "AddItem"
+
+-- a display string for a type that is NOT a concept (no NameOf instance)
+TypeName.reflect @AddItem
+```
+
+`TypeName.reflect @value` is *exactly* the expression the deleted default ran,
+so a caller that relied on the default gets identical text by calling it
+directly. A caller that overrode `name` was, by definition, disagreeing with
+`NameOf` — which is the bug this change removes — and must move the override to
+`type instance NameOf`.
+
+**No call sites are being fixed up in this repo.** `Documented.name` has zero
+references across `core/`, `testbed/` and `integrations/`; the only consumer of
+`Documented` at all is `Documented.description` at `Integration.Agent:93`, and
+`Integration.Agent.commandTool` already sources its name from `NameOf`. Nothing
+in the monorepo changes behavior.
+
+**Testbed effect: none.** No testbed command, query or `.hurl` file changes, and
+no existing test expectation is touched — the change is additive plus one
+removal with no callers.
+
+**What this change deliberately does not do.** `Schema.FieldSchema`,
+`Service.Transport.EndpointSchema`, `QueryDefinition` and
+`Integration.Agent.CommandTool` are *not* migrated onto `Descriptor`; that is
+the follow-up the issue names, and it is only sound once the primitive exists.
+`Integration.Agent` is left untouched on purpose: its `CommandTool` carries a
+pre-rendered OpenRouter payload, and the boundary that replaces it belongs to
+#798. Nothing about `ToSchema` derivation or the `Schema` ADT moves.
+
+## ADR
+
+[ADR-0075](../decisions/0075-nameof-single-type-identity.md) — why `NameOf` is
+the single identity of a type rather than one of two, why the value-level
+`Documented.name` is removed instead of being redefined in terms of `NameOf`,
+why `Descriptor` requires `KnownSymbol (NameOf value)` (scoping the primitive to
+concept types, so an unroutable type fails to compile rather than emitting an
+undispatchable name), why the record is provider-neutral, and how it supersedes
+the unimplemented `DocumentedInfo` sketch in ADR-0013 section 6.

--- a/docs/decisions/0075-nameof-single-type-identity.md
+++ b/docs/decisions/0075-nameof-single-type-identity.md
@@ -1,0 +1,207 @@
+# ADR-0075: `NameOf` is the single identity of a type; `Descriptor` is the shared name+description+schema primitive
+
+> Implements #801. Supersedes the unimplemented `DocumentedInfo` sketch in
+> [ADR-0013](0013-automatic-schema-generation.md) section 6, and narrows the
+> `Documented` class that ADR-0013 introduced. Relates to
+> [ADR-0045](0045-integration-agent.md) (the Agent integration, the only current
+> consumer of `Documented`).
+
+## Status
+
+Proposed
+
+## Context
+
+Two mechanisms in `nhcore` claim to answer "what is this type called".
+
+**`NameOf`** — `type family NameOf (t :: Type) :: Symbol`, declared in
+`core/service/Service/Command/Core.hs` and re-exported from `Core`. It is
+type-level, so GHC can match on it, and that is what makes it load-bearing:
+`emitCommand`, `makeCommandPayload`, `buildHandler`, `withTransport` and the
+`KnownHash` command registry all route on it, and the TH concept markers
+generate it as the literal type name (`Service/CommandExecutor/TH.hs`), leaving
+it hand-overridable.
+
+**`Documented.name`** — a class method on `Documented` (`core/traits/Documented.hs`)
+defaulting to `TypeName.reflect @value`, user-overridable, producing a
+value-level `Text`.
+
+They are not two views of one fact; they are two facts that can disagree, and in
+the repository they already do. `integrations/test/Integration/Agent/TestFixtures.hs`
+declares `type instance NameOf AddItemCommand = "AddItem"` for a type named
+`AddItemCommand`, so `NameOf` says `"AddItem"` and `Documented.name` says
+`"AddItemCommand"`.
+
+The consequence is not hypothetical, it is just currently unexercised.
+`Integration.Agent.commandTool` builds an LLM tool definition from a command
+type and needs exactly the triple *name + description + schema*. It takes the
+name from `NameOf`, the description from `Documented`, and the schema from
+`ToSchema` — sidestepping `Documented.name` entirely. It has to: the tool name
+it emits is the string the model sends back, `Integration.Agent.Internal.validateToolName`
+matches that string against the registered tools, and dispatch then routes on
+`NameOf`. A descriptor that innocently read `Documented.name` would emit tools
+that fail validation and never dispatch — a runtime failure, invisible at
+compile time, occurring only for the subset of types whose `NameOf` differs from
+their type name. That is the worst shape a bug can have.
+
+Meanwhile the triple itself exists four times, in four incompatible partial
+shapes: `Schema.FieldSchema` (field name, schema, required, description),
+`Service.Transport.EndpointSchema` (request/response schema, description,
+deprecated), `QueryDefinition` (name as `Text`, schema), and
+`Integration.Agent.CommandTool` (tool name, description, pre-rendered
+OpenRouter JSON). ADR-0013 section 6 planned the shared version —
+`commandSchema :: Schema` plus `commandDocumentation :: Maybe DocumentedInfo`
+with `DocumentedInfo { docName, docDescription, docDeprecated }`, captured at
+`Service.command` time. `DocumentedInfo` was never implemented; there are zero
+occurrences of it in the codebase. `Documented` shipped as the surviving shell
+of that plan, and `Documented.name` is the part of the shell that was never
+needed: it has **zero call sites** across `core/`, `testbed/` and
+`integrations/`, and no instance anywhere overrides it. The only member of
+`Documented` anyone calls is `description`, on one line.
+
+## Decision
+
+**1. `NameOf` is the single identity of a type. `Documented.name` is removed.**
+
+`Documented` keeps `description`, `examples` and `deprecated` — human-facing
+text only, no identity. Where a *non-concept* type needs a display string, the
+caller writes `TypeName.reflect @value`, which is character-for-character the
+expression the deleted default ran.
+
+**2. A new provider-neutral primitive `Descriptor` bundles the triple**, in
+`core/schema/Descriptor.hs`:
+
+```haskell
+data Descriptor = Descriptor
+  { name :: Text            -- from NameOf
+  , description :: Text     -- from Documented
+  , schema :: Schema        -- from ToSchema
+  , examples :: Array Json.Value
+  , deprecated :: Bool
+  }
+
+describe ::
+  forall value name.
+  ( Documented value
+  , ToSchema value
+  , Json.ToJSON value
+  , NameOf value ~ name
+  , GhcSymbol.KnownSymbol name
+  ) =>
+  Descriptor
+```
+
+**3. `KnownSymbol (NameOf value)` is a required constraint, not a convenience.**
+It scopes the primitive to concept types — commands, queries, entities,
+transports — the types that actually route. A type with no `NameOf` instance
+leaves `NameOf value` stuck, `KnownSymbol` unsolvable, and the call a *compile
+error*, instead of silently receiving a reflected name that cannot route.
+
+**4. Rendering lives outside and downstream of the descriptor.** The record
+holds a `Schema`, never a rendered payload. `Schema.JsonSchema.toJsonSchema`,
+`Schema.OpenApi.toOpenApiSchema` and the OpenRouter adapter (#798) are the
+renderers; the descriptor knows about none of them.
+
+**5. `Descriptor` supersedes `DocumentedInfo`.** ADR-0013 section 6's sketch is
+withdrawn: the shared shape is this record, and it carries the schema and the
+examples too, not just the three text fields.
+
+## Rationale
+
+**Why remove `name` rather than redefine it as `NameOf`.** The tempting middle
+road is to keep the method and give it the default
+`symbolVal (Proxy @(NameOf value))`. It is worse than either end. It would force
+`KnownSymbol (NameOf value)` as a superclass of `Documented`, making the *whole*
+documentation class unusable for any type that is not a routable concept — the
+plain data types that legitimately carry a description and examples. And it
+would leave the override in place, so an instance could still declare a
+value-level name that disagrees with the type-level one, which is precisely the
+divergence being removed. One identity means one mechanism, and the mechanism
+has to be the type-level one because that is the one GHC can dispatch on.
+
+**Why the removal is safe to make breaking.** Zero call sites, zero overriding
+instances, and the replacement is a mechanical one-liner in both directions
+(`type instance NameOf T = "…"` for identity, `TypeName.reflect @T` for a
+display string). The alternative — deprecating the method and removing it a
+release later — buys a migration window for a member that, as far as the
+monorepo can see, nobody uses, at the cost of keeping the divergence trap armed
+for that whole window.
+
+**Why `ToJSON` is in the signature even though the issue's sketch omits it.**
+`Documented.examples :: Array value` is type-indexed and cannot live in a
+monomorphic record; flattening it to `Array Json.Value` *is* a `ToJSON` call.
+The flattened form is also what both consumers need — OpenApi example fields and
+AI few-shot prompts take JSON, not the original values. Every concept type that
+can reach a descriptor already has `ToJSON` (the TH markers derive it), so the
+constraint is free at every real call site.
+
+**Why the descriptor does not fall back to the name when the description is
+empty.** `Integration.Agent.commandTool` does exactly that today, because
+OpenRouter wants a non-empty description. That is a *provider* requirement, and
+putting it in the shared primitive would silently give every other consumer —
+OpenApi, docs generation — a description that is really a name. The descriptor
+carries `Documented.description` verbatim, including `""`, and each renderer
+applies its own policy.
+
+**Why the module is not in the `Core` re-export.** `Descriptor`'s field labels
+(`name`, `description`, `schema`) would collide with the `Documented (..)` and
+`Schema (..)` re-exports already in `Core`. It is a qualified-import module, and
+under `NoFieldSelectors` its fields are reached through `descriptor.name`
+anyway. This also disposes of the import-cycle caveat raised in the issue:
+`Descriptor` imports `Documented`, `Schema` and `Service.Command.Core` directly
+and never imports `Core`, so `Core -> Descriptor -> Core` cannot form. (`Core`
+already imports `Service.Command` for the `NameOf` re-export, so the
+service-layer dependency is not new.)
+
+**Why `describe` and not `of`.** The issue names the constructor
+`Descriptor.of`. `of` is a Haskell reserved word (`case … of`) and cannot be a
+function name. `describe` reads at the call site — `Descriptor.describe @AddItem` —
+alongside the existing nullary type-applied primitives `Schema.toSchema @value`
+and `TypeName.reflect @value`.
+
+## Consequences
+
+**Positive.** A type has one name, and it is the one that routes. The
+name+description+schema triple has a single shared shape, so the four partial
+versions have something to converge on. The compile-time `KnownSymbol` guard
+turns "this descriptor's name will not dispatch" from a runtime mystery into a
+type error at the call site. ADR-0013's unimplemented sketch stops being a
+dangling promise.
+
+**Negative / constraints.** This is a **breaking** change to a `Core`-re-exported
+class: a downstream application that overrode `Documented.name` stops compiling
+and must move the identity to `type instance NameOf`. `Descriptor` cannot
+describe a type that has no `NameOf` instance — by design, but it does mean
+"give me the description and schema of this plain data type" is not what this
+primitive is for; that caller composes `Documented.description` and
+`Schema.toSchema` directly.
+
+**Non-goals.** `Schema.FieldSchema`, `Service.Transport.EndpointSchema`,
+`QueryDefinition` and `Integration.Agent.CommandTool` are **not** migrated onto
+`Descriptor` here — that is the follow-up the primitive unblocks, and
+`Integration.Agent`'s pre-rendered `CommandTool` in particular belongs to the
+boundary rework in #798. No change to `ToSchema` derivation or to the `Schema`
+ADT.
+
+## Alternatives considered
+
+- **Keep `Documented.name`, default it to `NameOf`.** Rejected: forces
+  `KnownSymbol (NameOf value)` onto every `Documented` instance, including plain
+  data types that will never route, and leaves the disagreeing override in place.
+- **Keep `Documented.name`, and have `Descriptor` read `NameOf` anyway.**
+  Rejected: the trap stays armed. The class would advertise a name that the
+  framework ignores, and the next consumer to reach for the obvious method gets
+  the runtime dispatch failure described above.
+- **Deprecate `name` with a `DEPRECATED` pragma and remove it next release.**
+  Rejected: no known users to protect, and the cost is keeping a
+  compile-time-invisible divergence live for a release cycle.
+- **Put `Descriptor` in the service layer (`core/service/`).** Rejected: it is a
+  type-metadata primitive built on `Schema` and `Documented`, and its only
+  service-layer touchpoint is the `NameOf` type family. `core/schema/` is where
+  the schema-side vocabulary already lives, and `nhcore`'s single-library,
+  many-`hs-source-dirs` layout makes the dependency legal from there.
+- **Implement `DocumentedInfo` as ADR-0013 wrote it** (`docName`,
+  `docDescription`, `docDeprecated`, hung off `CommandDefinition`). Rejected: it
+  reintroduces a value-level `docName` — the exact divergence being removed —
+  carries no schema or examples despite living next to `commandSchema`, and is
+  scoped to commands rather than to concepts generally.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -88,6 +88,7 @@ ADRs document significant architectural decisions made during the development of
 | [0072](0072-neo-cutover-and-onboarding-slo.md) | Neo CLI cutover — archive-as-human-gate and the clean-machine onboarding SLO | Accepted |
 | [0073](0073-deterministic-uuid-v5.md) | Deterministic UUID v5 as a Core primitive and a Decision combinator | Implemented |
 | [0074](0074-dependabot-auto-merge.md) | Dependabot patch/minor auto-merges; majors stop for a human | Accepted |
+| [0075](0075-nameof-single-type-identity.md) | `NameOf` is the single type identity; `Descriptor` is the shared name+description+schema primitive | Proposed |
 
 <!-- adr-index: this table is validated by scripts/adr-index-check (./dev adr-check,
      CI job `adr-index` in checks.yml) — every NNNN-*.md file must appear exactly

--- a/website/src/content/docs/adrs/index.mdx
+++ b/website/src/content/docs/adrs/index.mdx
@@ -87,3 +87,4 @@ ADRs are immutable: when a decision is reversed, a new ADR is written that refer
 | [0072](/adrs/0072-neo-cutover-and-onboarding-slo/) | Neo CLI cutover — archive-as-human-gate and the clean-machine onboarding SLO | Accepted |
 | [0073](/adrs/0073-deterministic-uuid-v5/) | Deterministic UUID v5 as a Core primitive and a Decision combinator | Implemented |
 | [0074](/adrs/0074-dependabot-auto-merge/) | Dependabot patch/minor auto-merges; majors stop for a human | Accepted |
+| [0075](/adrs/0075-nameof-single-type-identity/) | `NameOf` is the single type identity; `Descriptor` is the shared name+description+schema primitive | Proposed |


### PR DESCRIPTION
**Gate 1 — spec only.** This PR's diff is the contract, not the implementation. Implementation starts once a maintainer approves.

Closes #801 (on merge of the implemented change).

## What is being proposed

- Remove `name` from the `Documented` class. `Documented` keeps `description`, `examples`, `deprecated` — human-facing text, no identity.
- `NameOf` becomes the single identity of a type. Display strings for non-concept types come from `TypeName.reflect @value`, which is exactly what the deleted default ran.
- Add `Descriptor` (`core/schema/Descriptor.hs`): the provider-neutral name + description + schema + examples + deprecated record, built by `Descriptor.describe @value`.

## Two deviations from the issue, both deliberate

1. **`Descriptor.describe`, not `Descriptor.of`** — `of` is a Haskell reserved word (`case … of`) and cannot be a function name. `Descriptor.reflect` / `Descriptor.forType` are the alternatives; renaming is a one-line change at this gate.
2. **`ToJSON value` is in the constraint set**, which the issue's sketch omits. `Documented.examples :: Array value` is type-indexed; flattening it to the record's `Array Json.Value` *is* a `ToJSON` call. Every concept type already has the instance.

## Why the compile-time guard matters

`KnownSymbol (NameOf value)` is required, so a type with no `NameOf` instance fails at the call site instead of silently getting a reflected name that cannot route. Without it, a descriptor that read the old `Documented.name` would emit tool names that fail `Integration.Agent.Internal.validateToolName` and never dispatch — a runtime failure, invisible at compile time, only for types whose `NameOf` differs from their type name (`AddItemCommand` / `"AddItem"` in the existing fixtures).

## Breaking

`Documented (..)` is re-exported from `Core`, so a downstream app overriding `name` stops compiling. Migration: `type instance NameOf T = "…"`. Inside this monorepo the blast radius is zero — `Documented.name` has no call sites and no overriding instances.

## Contents of this PR

| File | |
|---|---|
| `docs/changes/007-nameof-single-identity-descriptor.md` | the spec: contract delta + 6 criteria (all `unit`), each naming its proving test |
| `docs/decisions/0075-nameof-single-type-identity.md` | ADR (breaking-change trigger); supersedes the `DocumentedInfo` sketch in ADR-0013 §6 |

`./dev spec-check` and `./dev adr-check` are green. `./dev spec-check --plan` routes to **no** design reviews (`traits` and `schema` carry no risk tags); test impact is `core/test-core/**`.

## Not in scope

Migrating `FieldSchema` / `EndpointSchema` / `QueryDefinition` / `CommandTool` onto `Descriptor` (follow-up), the `Integration.Agent` → `CommandRouter` rename and OpenRouter adapter boundary (#798), and any change to `ToSchema` derivation or the `Schema` ADT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)