### PR TITLE
spec(007): bd enters the devShell through hix's own extension point (#811)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,6 +37,8 @@ jobs:
       # Static workflow wiring: hidden-artifact upload opt-in + retrospect
       # loop stays deterministic/report-only (pure stdlib, no toolchain).
       - run: ./dev workflow-check
+      # Change 007 static proving tests (C1-C3, C8) — no nix needed.
+      - run: ./dev devshell-check --self-test
 
   codemap:
     name: codemap check (localization ontology)

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -76,5 +76,8 @@ jobs:
       - name: Build the project with cabal
         run: nix develop --command cabal build all --disable-documentation
 
+      - name: devShell proving tests (change 007 — C4-C6)
+        run: nix develop --command ./dev devshell-check
+
       - name: Run ${{ matrix.test-suite }}
         run: nix develop --command cabal test ${{ matrix.test-suite }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,8 @@ jobs:
             ${{ runner.os }}-cabal-
       - name: Build the project with cabal
         run: nix develop --command cabal build all --disable-documentation
+      - name: devShell proving tests (change 007 — C4-C6)
+        run: nix develop --command ./dev devshell-check
       - uses: actions/upload-artifact@v7
         with:
           name: dist-newstyle

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ cachix use neohaskell
 
 This dramatically speeds up the first `nix develop` (from ~30 min to ~2 min).
 
+### Adding a non-Haskell CLI tool to the dev shell
+
+`bd` (beads) is a Go binary that enters the dev shell this way, and it's the
+template for the next tool like it:
+
+1. Add a key under `neohaskellTools` in the overlay in `flake.nix` (e.g.
+   `neohaskellTools = { bd = beads.packages.${system}.bd; }`).
+2. List `pkgs.neohaskellTools.<key>` in `nix/hix.nix`'s `shell.buildInputs`.
+
+**Exception — a Haskell tool goes in `shell.tools`, not `neohaskellTools`.**
+`shell.tools` entries are resolved against the project's own GHC
+(haskell.nix); `neohaskellTools` entries are plain nixpkgs derivations. Mixing
+them up is why `doctest` (`nix/hix.nix`) is pinned as a `shell.tools` entry
+instead — it links the GHC lib API and only works built against the
+project's own GHC.
+
 The recommended IDE for any NeoHaskell project is [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Get the code

--- a/dev
+++ b/dev
@@ -70,6 +70,11 @@ usage: ./dev <verb> [args]
                           doctrine (see telemetry/SCHEMA.md); never for ad-hoc runs
   workflow-check        static wiring checks for .github/workflows (hidden
                           artifacts, retrospect loop; CI-enforced)
+  devshell-check         proving tests for change 007 (bd via hix's shell
+                          extension point): flake.nix/nix/hix.nix wiring +
+                          README doc-coherence (--self-test, no nix); bd
+                          store-path identity, tool inventory, fingerprint
+                          witness (default, run inside nix develop)
   neo-skills-check      validate the Rust `neo/**` agent-guidance layer:
                           neo-cli-* skills, neo/** routing, no stale state/plan
                           refs, one source of truth (via ./dev doctor + CI)
@@ -135,6 +140,7 @@ case "${VERB}" in
   retrospect) exec scripts/retrospect "$@" ;;
   telemetry) exec scripts/telemetry.py "$@" ;;
   workflow-check) exec scripts/workflow-check "$@" ;;
+  devshell-check) exec scripts/devshell-check "$@" ;;
   neo-skills-check) exec scripts/neo-skills-check "$@" ;;
   neo-dist-check) exec scripts/neo-dist-check "$@" ;;
   neo-consumer-contract) exec scripts/neo-consumer-contract "$@" ;;

--- a/docs/changes/007-bd-via-hix-shell-extension-point.md
+++ b/docs/changes/007-bd-via-hix-shell-extension-point.md
@@ -1,0 +1,315 @@
+# Change 007: Give `bd` a first-class devShell entry through hix's own extension point
+
+Issue #811 asks for `bd` (beads) to stop entering the dev shell through the
+`pkgs.mkShell { inputsFrom = [ flake.devShells.default ]; }` workaround
+(`flake.nix:66-71`) and to enter through the extension point hix actually
+documents for "add one more CLI tool to the dev shell", so the wiring survives a
+hix/haskell.nix input bump; and it asks that the procedure for adding the *next*
+non-Haskell CLI tool be written down. Nothing about the shell's contents changes:
+`bd` stays the same `flake.lock`-pinned derivation from beads' own flake, at the
+same version, on the same `PATH`. This is a rewiring plus a documented recipe —
+the caller-visible surface of `nix develop` is intended to be byte-for-byte the
+same set of tools, and the criteria below exist to prove exactly that.
+
+```yaml spec
+issue: issue#811
+kind: refactor
+touches: [ci-cd, governance-docs]
+breaking: false
+new-dependency: false
+new-capability: false
+new-extension-point: false
+```
+
+## Contract delta
+
+Infrastructure only. No `nhcore` / `nhintegrations` public API changes — no
+`codemap/signatures/` line is added or removed — so the promised diff is empty.
+
+```diff signatures
+```
+
+### The wiring, stated precisely (this is the reviewable contract)
+
+**Today** (`flake.nix:63-71`): hix builds `flake.devShells.default`; `flake.nix`
+then *replaces* it with `pkgs.mkShell { inputsFrom = [ flake.devShells.default ];
+packages = [ beads.packages.${system}.bd ]; }`. `inputsFrom` is a
+build-environment composition trick — it re-derives a shell from another shell's
+inputs. That is the fragility issue #811 names.
+
+**After**, two edits, per the binding localization (`nh-mol-b8b`):
+
+1. **`flake.nix`** — the `overlays` list gains one overlay that injects a single
+   new top-level attribute:
+
+   ```nix
+   (final: _prev: { neohaskellTools = { bd = beads.packages.${system}.bd; }; })
+   ```
+
+   and the whole `devShells = (flake.devShells or { }) // { default = pkgs.mkShell
+   {...}; }` block is **deleted**, so `devShells` comes straight from hix again.
+
+2. **`nix/hix.nix`** — `shell.buildInputs` gains `pkgs.neohaskellTools.bd`,
+   alongside the `git` / `nixfmt-classic` / `postgresql` / `hurl` /
+   `poppler_utils` / `python3.withPackages` / `haskellPackages.hoogle` entries it
+   already carries. `shell.tools` is **not** the route (haskell.nix resolves those
+   against the project's GHC; `bd` is a Go binary).
+
+3. **`README.md`** — the AC3 recipe: *add a key to `neohaskellTools` in
+   `flake.nix`, then list `pkgs.neohaskellTools.<key>` in `nix/hix.nix`
+   `shell.buildInputs`* — plus the rule that a **Haskell** tool goes to
+   `shell.tools` instead, and the `doctest` note (`nix/hix.nix:28-30`) explaining
+   why that distinction is load-bearing.
+
+**Why a namespaced `neohaskellTools` set and not a bare `bd` attribute.** An
+overlay that binds `bd` directly would silently *shadow* any same-named nixpkgs
+attribute, in a diff where the shadowing is invisible. Today's pin has no such
+attribute (`nix eval nixpkgs#bd` fails: "does not provide attribute"), so the
+collision is latent, not present — which is precisely the kind of thing that
+breaks a year later during an unrelated input bump. One namespaced attribute also
+makes AC3's recipe a real two-step recipe with an obvious place to put the next
+tool, and keeps the blast radius on `legacyPackages` down to one new name.
+
+**What stays out of contract** (restated from intake, because a "cleaner" wiring
+is exactly where these get lost): `beads.overlays.default` and
+`inputs.beads.inputs.nixpkgs.follows` stay **unused** — that overlay calls
+`final.buildGo126Module`, which our pin (`haskellNix/nixpkgs-unstable`) lacks, and
+an overlay always evaluates against the pkgs it is applied to. `bd` keeps coming
+from beads' self-contained `packages.${system}.bd`, built against beads' own
+nixpkgs. No version bump: `bd` stays whatever `flake.lock` pins today.
+
+## Criteria
+
+Eight criteria, in two shapes. **Static (`unit`)** — the wiring is text that must
+say specific things, and a static checker is the only thing that catches "someone
+re-introduced `inputsFrom`" or "someone pointed `bd` at `pkgs.beads`" during a
+future refactor; this mirrors how `./dev workflow-check` freezes CI wiring
+(change 003, C2/C3/C7). **In-shell (`integration`)** — the properties that only a
+real `nix develop` can prove: which store path `bd` resolves to, that every hix
+tool survived the rewiring, and that the fingerprint witness still matches.
+
+The proving tests are a new checker, `scripts/devshell-check` (registered as
+`./dev devshell-check`, per the "every pipeline asset registers a verb" rule
+`./dev doctor` enforces), in the two modes the repo already uses elsewhere:
+`--self-test` for the pure static assertions (no nix, seconds — it runs in the
+nix-free `checks.yml` job) and the default in-shell mode for the rest (invoked
+from inside `nix develop`, locally at verify and from the two CI jobs that
+already enter the shell). See **Edit-set delta** below.
+
+**No property-based criterion is declared, and that is a decision, not an
+omission.** The contract here is derivation *identity* and a fixed tool
+inventory — `bd` is this store path, these fifteen binaries resolve, the
+fingerprint is stable — not an algebraic law with a generator. The closest thing
+to a property is C5's universal quantification over the declared tool set, which
+is a finite enumeration and is written as one.
+
+| ID | Behavior | Proving test | Level |
+|----|----------|--------------|-------|
+| C1 | `flake.nix` composes no shell: no `mkShell`, no `inputsFrom`, and no `devShells` override anywhere in the file — `devShells.default` is hix's own shell, unwrapped | `./dev devshell-check --self-test` (flake-wiring case) | unit |
+| C2 | The overlay injects **exactly one** new top-level attribute, `neohaskellTools`, whose `bd` is `beads.packages.${system}.bd`; a bare `bd` (or any other bare top-level binding) is rejected as silent shadowing; `beads.overlays.default` and an `inputs.beads.inputs.nixpkgs.follows` override appear nowhere in `flake.nix` | `./dev devshell-check --self-test` (overlay-shape case) | unit |
+| C3 | `nix/hix.nix` reaches `bd` as `pkgs.neohaskellTools.bd` from `shell.buildInputs` and **not** from `shell.tools`; the pre-existing shell declarations are still present and unweakened — every `shell.tools` entry (`cabal`, `hlint`, `fourmolu`, `hspec-discover`, `haskell-language-server`, `cabal-gild`, `ghcid`, `hiedb`, `doctest`), every prior `shell.buildInputs` entry, `shell.withHoogle = false`, and a `shell.shellHook` still exporting both `NEOHASKELL_SHELL_FP` and `NEOHASKELL_SHELL_PATH` | `./dev devshell-check --self-test` (hix-wiring case) | unit |
+| C4 | Inside `nix develop`, `command -v bd` resolves into the **same store path** as `beads.packages.<current system>.bd` — not the host's `bd`, not nixpkgs' `beads` — and `bd --version` is unchanged from the pre-change shell and `>= 1.1.0` (the `.beads/formulas/*.toml` schema floor) | `./dev devshell-check` (bd store-path identity + version floor case), run in-shell | integration |
+| C5 | Inside `nix develop`, every declared tool still resolves to a `/nix/store` path — `cabal`, `hlint`, `fourmolu`, `hspec-discover`, `haskell-language-server`, `cabal-gild`, `ghcid`, `hiedb`, `doctest`, `git`, `nixfmt`, `psql`, `hurl`, `pdftotext`, `python3 -c 'import yaml'`, `hoogle` — and `hoogle` is still the nixpkgs build, not haskell.nix's `hoogle-with-packages` wrapper (which would silently re-break `./dev api --local`) | `./dev devshell-check` (tool-inventory case), run in-shell | integration |
+| C6 | The toolchain-fingerprint contract survives: `scripts/toolchain-fp` prints the same non-empty sha256 on two consecutive runs, in-shell `NEOHASKELL_SHELL_FP` equals that value, and `NEOHASKELL_SHELL_PATH` is non-empty and contains the `bin` directory `bd` resolves from (so `scripts/with-toolchain`'s fast path restores a PATH that still has `bd`) | `./dev devshell-check` (fingerprint-witness case), run in-shell | integration |
+| C7 | The checker is wired where it cannot rot: the two jobs that already enter the shell (`test.yml` `build`, `test-macos.yml` `build`) invoke `./dev devshell-check` in-shell, and the nix-free `checks.yml` job invokes `./dev devshell-check --self-test`; a regression that drops `bd` or a hix tool therefore fails a **required** check on both covered systems | `./dev workflow-check` (devshell-check wiring assertions, incl. its `--self-test` fixtures) | unit |
+| C8 | `README.md` carries the AC3 recipe and it cannot drift: it names the two steps (add a key under `neohaskellTools` in `flake.nix`; list `pkgs.neohaskellTools.<key>` in `nix/hix.nix` `shell.buildInputs`) and the Haskell-tool exception (`shell.tools`), and the checker asserts the recipe's anchors against the actual attribute name in the code, so renaming the attribute breaks the doc check | `./dev devshell-check --self-test` (doc-coherence case) | unit |
+
+## Edge cases and failure modes
+
+Each is named with its symptom, the thing that catches it, and what should
+happen. The first is the one that can invalidate the route.
+
+**F1 — hix's module `pkgs` does not see our overlay.** The route assumes the
+`pkgs` argument in `nix/hix.nix` is the fixpoint our overlays are applied to
+(`hixProject` is itself created inside an overlay, from `final.haskell-nix.hix`).
+If haskell.nix hands the module a differently-pinned pkgs, evaluation fails with
+`attribute 'neohaskellTools' missing`. That is a **contradiction of the binding
+localization, not an invitation to improvise**: the implement node must **park the
+run as `wrong-localization`** and re-enter at intake (where the recorded
+alternative — an `overrideAttrs` on `flake.devShells.default`, `flake.nix` only —
+gets weighed properly). Silently falling back to a `flake.nix`-only fix is the
+one outcome this spec forbids.
+
+**F2 — silent attribute shadowing.** A bare `bd` overlay attribute would override
+a same-named nixpkgs package for everything built from our `pkgs`, including
+`legacyPackages.<system>.bd`, with nothing in the diff to show it. Today's pin has
+no `bd` attribute, so this is latent; C2 rejects the shape outright rather than
+relying on that staying true.
+
+**F3 — wrong `bd` source.** `pkgs.beads` resolves (nixpkgs pins **1.0.3**) and
+would put a `bd` on `PATH` that passes "is bd available?" while being below the
+`>= 1.1.0` floor the `.beads/formulas/*.toml` schema needs. C4 asserts the store
+path, not merely the binary's presence, precisely because the weaker assertion
+passes here.
+
+**F4 — the beads overlay creeps back.** Applying `beads.overlays.default` (or
+setting `inputs.beads.inputs.nixpkgs.follows`) reaches `final.buildGo126Module`,
+which our pin lacks: evaluation fails on **every** system with a missing-attribute
+error. Out of contract by intake; C2 freezes it statically.
+
+**F5 — a supported system beads does not publish.** `beads.packages.${system}.bd`
+is referenced inside `flake-utils.lib.eachSystem` for all four supported systems.
+Nix attribute access is lazy, so a missing system fails only when that system's
+`devShells.default` (or `legacyPackages.<system>.neohaskellTools`) is forced —
+same failure surface as today's `flake.nix:69`, moved, not widened. Note the one
+real widening: `neohaskellTools` is now reachable through `legacyPackages`, so a
+`nix flake show`-style walk that forces it can surface this where it previously
+could not.
+
+**F6 — host `bd` shadowing in-shell `bd`.** The dispatcher host has its own `bd`
+on `PATH` (a documented version skew; `nh-c3e`). A `bd --version`-only assertion
+can pass while resolving to the host binary. C4 compares the resolved path against
+the store path, and C6 checks that `NEOHASKELL_SHELL_PATH` — the witness
+`scripts/with-toolchain` restores on its fast path — still contains `bd`'s `bin`
+directory, so the fast path cannot silently hand back a host binary.
+
+**F7 — fingerprint churn (expected, once).** Both edited files are inside
+`scripts/toolchain-fp`'s hashed set (`flake.nix`, `nix/*.nix`), so the fingerprint
+**value changes exactly once** when this lands. Every already-open shell, tmux
+pane, and mid-run agent re-enters `nix develop` on its next `./dev` call and then
+matches again. The *mechanism* must not change: an empty fingerprint (missing
+hasher) still disables the fast path with a warning rather than failing silently.
+C6 proves determinism and the witness; a changed value is expected, not a
+regression.
+
+**F8 — shell derivation identity changes.** Dropping the `mkShell` wrapper changes
+the devShell derivation's name and hash. Nothing in the repo keys on the shell's
+*name* (`scripts/with-toolchain` keys on the fingerprint plus the PATH witness), so
+this is inert — but it does mean a one-time rebuild/substitute for everyone,
+including CI until the cache warms.
+
+**F9 — cache population.** `cachix-push.yml`'s path filter lists `nix/**` but not
+`flake.nix`. This change touches `nix/hix.nix`, so the new shell closure **does**
+get pushed. The gap itself (a `flake.nix`-only shell change never repopulating the
+cache) is real and pre-existing, and is left to a follow-up bead rather than
+widened into this change's scope.
+
+**F10 — documentation drift.** A future rename of `neohaskellTools` that leaves
+`README.md` describing the old name is caught by C8, which asserts the recipe's
+anchors against the code rather than merely checking that prose exists.
+
+**F11 — `shell.tools` misuse for the next tool.** The AC3 recipe must not tempt
+someone into putting a Haskell tool in `neohaskellTools` (it would be resolved
+against nixpkgs' GHC, not the project's — the exact reason `doctest` is pinned as
+a `shell.tools` entry at `nix/hix.nix:28-30`). C3 and C8 both carry the
+distinction.
+
+### Concurrency-sensitive behavior
+
+Nix is the concurrency story here, and the honest claim is that this change adds
+no new sharing:
+
+- **Concurrent `nix develop` entries** (parallel agents, several tmux panes, the
+  CI matrix) racing to realise the new shell are serialised by the nix daemon's
+  per-derivation locks. Worst case is duplicated substitution work, never a
+  partially-populated shell — and each entry either gets the complete new closure
+  or fails; there is no intermediate state a shell can be entered in.
+- **The `with-toolchain` fast path** is read-only against `NEOHASKELL_SHELL_FP` /
+  `NEOHASKELL_SHELL_PATH`; concurrent readers of a *stale* fingerprint all take the
+  slow path (re-enter `nix develop`) independently. Stale-read behavior is
+  fail-safe by construction, and this change does not alter it.
+- **`scripts/toolchain-fp`** hashes files, holds no state, and writes nothing, so
+  concurrent invocations are independent. C6's two-consecutive-runs assertion
+  covers the determinism this relies on.
+
+## Known limits — not proven mechanically
+
+Kept out of the criteria table on purpose, so the table stays honest about what CI
+actually proves:
+
+**Only two of the four supported systems are exercised.** `flake-utils.lib.eachSystem`
+covers `{x86_64,aarch64} × {linux,darwin}`, but CI enters the shell on
+`x86_64-linux` (`test.yml`) and `aarch64-darwin` (`test-macos.yml`) only.
+Cross-evaluating the other two from a developer machine is not available either:
+the flake sets `allow-import-from-derivation = true`, so evaluating a foreign
+system's devShell tries to *build* foreign derivations. The wiring is uniform
+inside `eachSystem` with no system-conditional, which is the argument that the
+remaining two systems behave identically — an argument, not a test. This limit is
+pre-existing and unchanged by this change.
+
+**AC2 ("survives a hix/haskell.nix input bump") is not directly testable** at
+merge time — no bump exists to test against. What this change ships instead is the
+*mechanism* that makes the next bump cheap (hix's own extension point rather than
+a composition trick) plus C1-C3, which fail loudly if a future bump is "fixed" by
+re-introducing `inputsFrom`.
+
+## Edit-set delta (declared, not silent)
+
+The binding localization's `files:` list is the **implementation** edit set:
+`flake.nix`, `nix/hix.nix`, `README.md` — unchanged by this spec, and the route
+(overlay injection + `shell.buildInputs`, no `mkShell`/`inputsFrom`) is followed
+exactly. Localization enumerated no test assets, so the proving tests above add,
+at test-writing time: `scripts/devshell-check` (+ its `./dev` verb registration),
+`workflow-check` assertions for C7, and one `- run:` step in each of `test.yml`,
+`test-macos.yml`, and `checks.yml`. These are test assets, not a re-scoping of the
+implementation, and they route to no additional design review (`dev-pipeline`
+carries no risk tag and no test globs, exactly like `ci-cd`). The spec commit also
+adds `docs/decisions/0075-*.md`, its row in `docs/decisions/README.md`, and the
+regenerated tracked `website/src/content/docs/adrs/index.mdx` that `./dev
+adr-website --check` gates.
+
+## Primitives
+
+The primitives-first lens (lock 1), answered so the primitives review has a
+record to check rather than re-derive. **The mechanical triggers are all
+negative**: no new Haskell module, no new `build-depends`, no new flake input
+(`beads` already exists), and no direct hackage import — this change contains no
+Haskell at all, so the dialect's "reach hackage only through a `core/` wrapper"
+rule has no surface here. The binding localization recorded the same conclusion
+(`nh-mol-x4c` not triggered).
+
+The lens still has a non-trivial answer at the Nix layer, and it is the reason
+the attribute is a **set**, not a bare name. `neohaskellTools` is the primitive
+this change introduces: the single, named place where a non-Haskell, non-hix-managed
+CLI tool enters the dev environment. Everything about the design follows from
+treating it that way — one injection point instead of a per-tool composition
+trick, extension by adding a key rather than by wrapping the shell again, and a
+documented recipe (C8) so the second tool costs one line instead of a fresh
+invention. The rule-of-three question ("should this be promoted?") is therefore
+answered pre-emptively rather than after the third `mkShell` workaround.
+
+What is deliberately **not** promoted: no `./dev` verb, script, or abstraction is
+added for *managing* the tool set (the recipe is two edits in two files), and
+`scripts/devshell-check` is a test asset, not a primitive — it asserts the wiring,
+it does not own it. If a third or fourth tool ever makes the two-file edit feel
+repetitive, the next promotion is a `codemap/extension-points.yaml` row, which is
+listed as a follow-up rather than pre-built here.
+
+## User impact
+
+**Not breaking, and deliberately invisible at runtime.** `nix develop` offers the
+same tools at the same versions; `bd` is the same `flake.lock`-pinned build on the
+same `PATH`. No public signature, wire format, or testbed behavior changes, so
+there is no acceptance-level (`.hurl`) coverage — this change has no
+HTTP-observable surface.
+
+**One-time cost when it lands.** The toolchain fingerprint changes once (F7), so
+the first `./dev` call in any already-open session re-enters `nix develop`, and
+the devShell derivation is rebuilt/substituted once (F8) before the cache warms.
+
+**New, documented extension point for contributors and agents.** Adding the next
+non-Haskell CLI tool is now: add a key under `neohaskellTools` in `flake.nix`, list
+`pkgs.neohaskellTools.<key>` in `nix/hix.nix` `shell.buildInputs` — with the
+Haskell-tool exception (`shell.tools`) written down next to it in `README.md`.
+
+**One new flake attribute.** `legacyPackages.<system>.neohaskellTools` now exists
+(holding `bd`). It is purely additive and shadows nothing (C2); `packages`, `apps`
+(including `neo`), and `nixConfig` are untouched.
+
+**Follow-ups deliberately not bundled** (to be filed as beads, not fixed here):
+`cachix-push.yml`'s path filter missing `flake.nix` (F9); no codemap alias routing
+"dev shell"/"dev environment" to `ci-cd`; and a possible
+`codemap/extension-points.yaml` row for "add a non-Haskell CLI tool to the
+devShell", which today's registry (Haskell-only) has no entry for.
+
+## ADR
+
+[ADR-0075](../decisions/0075-devshell-tool-injection-via-overlay-and-hix-buildinputs.md)
+— why `bd` enters through an overlay-injected, namespaced `neohaskellTools` set
+plus hix's `shell.buildInputs` rather than `mkShell.inputsFrom`; why
+`beads.overlays.default` stays unused; why the attribute is namespaced rather than
+bare; and what happens if hix's module `pkgs` turns out not to see our overlay.
+Triggered by the "significant new infrastructure" / "changing code style
+conventions" entries in the `docs/decisions/README.md` ADR-required list — the
+mechanical flags (`breaking` / `new-dependency` / `new-capability` /
+`new-extension-point`) are all false, exactly as in change 003.

--- a/docs/decisions/0075-devshell-tool-injection-via-overlay-and-hix-buildinputs.md
+++ b/docs/decisions/0075-devshell-tool-injection-via-overlay-and-hix-buildinputs.md
@@ -1,0 +1,119 @@
+# ADR-0075: Non-Haskell devShell tools enter through a namespaced overlay attribute and hix's `shell.buildInputs`
+
+## Status
+
+Accepted
+
+## Context
+
+`bd` (beads) is a Go binary that the dispatcher, the agents, and every
+contributor need on `PATH` inside `nix develop`. It cannot come from hix's
+`shell.tools`: those are resolved by haskell.nix against the project's own GHC
+(the reason `doctest` is pinned there — `nix/hix.nix:28-30`). It also cannot come
+from `beads.overlays.default`: that overlay calls `final.buildGo126Module`, which
+our pin (`haskellNix/nixpkgs-unstable`) does not have, and an overlay always
+evaluates against the pkgs it is applied to, not the pkgs it was authored
+against. So `bd` is consumed as beads' self-contained `packages.${system}.bd`,
+built entirely against beads' own nixpkgs.
+
+The first wiring (`flake.nix:63-71`) got it into the shell by *replacing* hix's
+devShell:
+
+```nix
+devShells = (flake.devShells or { }) // {
+  default = pkgs.mkShell {
+    inputsFrom = [ flake.devShells.default ];
+    packages = [ beads.packages.${system}.bd ];
+  };
+};
+```
+
+`inputsFrom` is a build-environment composition trick — it re-derives a shell
+from another shell's inputs. Issue #811 asks for the extension point hix actually
+documents for "add one more CLI tool", on the grounds that the composition trick
+is fragile across hix/haskell.nix bumps, and asks that the procedure for the
+*next* such tool be written down. This decision covers the shape of that
+extension point. The change itself is specified in
+[docs/changes/007-bd-via-hix-shell-extension-point.md](../changes/007-bd-via-hix-shell-extension-point.md).
+
+## Decision
+
+**One overlay injects one namespaced attribute set; hix's own `shell.buildInputs`
+consumes it.**
+
+```nix
+# flake.nix — in the `overlays` list
+(final: _prev: { neohaskellTools = { bd = beads.packages.${system}.bd; }; })
+
+# nix/hix.nix — shell.buildInputs
+shell.buildInputs = with pkgs; [ git nixfmt-classic … neohaskellTools.bd ];
+```
+
+and the `devShells` override block in `flake.nix` is deleted, so
+`devShells.default` is hix's shell again, unwrapped.
+
+Three sub-decisions, each of which was the alternative worth arguing about:
+
+**1. hix's `shell.buildInputs`, not a cleverer `flake.nix`-level composition.**
+The rejected alternative — `flake.devShells.default.overrideAttrs`, keeping the
+fix inside `flake.nix` — satisfies the letter of AC1 ("available without relying
+on `mkShell.inputsFrom`") by swapping one composition trick for another. Using
+hix's documented extension point satisfies it structurally: the shell is
+*declared* with `bd` in it rather than post-processed, which is what makes the
+wiring survive a hix bump, and it gives AC3's recipe a real second step. The cost
+is that `nix/hix.nix` is now part of the edit set, which is accepted.
+
+**2. A namespaced `neohaskellTools` set, not a bare `bd` attribute.** A bare
+overlay binding would shadow any same-named nixpkgs attribute for everything
+built from our pkgs — including `legacyPackages.<system>.bd` — with nothing in
+the diff to show it. Today's pin has no `bd` attribute, so the collision is
+latent rather than present, which is exactly the failure that surfaces a year
+later during an unrelated bump. The namespaced set also gives the AC3 recipe an
+obvious home for the next tool and keeps the added surface on `legacyPackages`
+down to one name. In the spec's vocabulary, `neohaskellTools` **is** the
+primitive: the single named door through which non-Haskell CLI tools enter the
+dev environment.
+
+**3. `beads.overlays.default` stays unused, permanently.** Not a temporary
+workaround pending a nixpkgs bump: any wiring that reintroduces it fails
+evaluation on every system with a missing `buildGo126Module`, and is out of
+contract by intake. `bd`'s version stays whatever `flake.lock` pins — this change
+bumps nothing.
+
+**If hix's module `pkgs` turns out not to see our overlay** (evaluation fails with
+`attribute 'neohaskellTools' missing`, because haskell.nix hands the module a
+differently-pinned pkgs), the run **parks as `wrong-localization` and re-enters at
+intake**, where the `overrideAttrs` alternative gets weighed on its merits. It does
+not silently degrade into the `flake.nix`-only fix — the whole point of the
+decision is which extension point is used, so quietly changing that answer while
+keeping the issue closed would make the record lie.
+
+## Consequences
+
+**Positive.**
+
+- The devShell is declared in one place again (`nix/hix.nix`), the way hix
+  intends; `flake.nix` composes no shell at all.
+- Adding the next non-Haskell CLI tool is a documented two-step edit (a key under
+  `neohaskellTools`, an entry in `shell.buildInputs`) rather than a fresh
+  invention, with the Haskell-tool exception (`shell.tools`) written next to it.
+- The wiring becomes statically checkable: `./dev devshell-check --self-test`
+  fails if `inputsFrom` returns, if the overlay binds a bare attribute, if `bd` is
+  pointed at nixpkgs' `beads` (pinned 1.0.3, below the `.beads/formulas/*.toml`
+  schema floor of 1.1.0), or if the README recipe drifts from the attribute name
+  in the code.
+
+**Negative / accepted.**
+
+- `legacyPackages.<system>.neohaskellTools` is a new public flake attribute. It is
+  additive and shadows nothing, but it is reachable from a `nix flake show`-style
+  walk, which can force `beads.packages.${system}.bd` for a system beads may not
+  publish — the same failure as today's `flake.nix:69`, moved rather than widened.
+- The toolchain fingerprint (`scripts/toolchain-fp`, which hashes `flake.nix` and
+  `nix/*.nix`) changes value once, so every open shell re-enters `nix develop`
+  once, and the devShell derivation is rebuilt/substituted once before the cache
+  warms. The fingerprint *mechanism* is untouched.
+- Only two of the four supported systems are exercised by CI (`x86_64-linux`,
+  `aarch64-darwin`). The wiring is uniform inside `flake-utils.lib.eachSystem`
+  with no system-conditional, which is an argument for the other two, not a test —
+  a pre-existing limit this decision does not change.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -88,6 +88,7 @@ ADRs document significant architectural decisions made during the development of
 | [0072](0072-neo-cutover-and-onboarding-slo.md) | Neo CLI cutover — archive-as-human-gate and the clean-machine onboarding SLO | Accepted |
 | [0073](0073-deterministic-uuid-v5.md) | Deterministic UUID v5 as a Core primitive and a Decision combinator | Implemented |
 | [0074](0074-dependabot-auto-merge.md) | Dependabot patch/minor auto-merges; majors stop for a human | Accepted |
+| [0075](0075-devshell-tool-injection-via-overlay-and-hix-buildinputs.md) | Non-Haskell devShell tools enter via a namespaced overlay attribute + hix `shell.buildInputs` | Accepted |
 
 <!-- adr-index: this table is validated by scripts/adr-index-check (./dev adr-check,
      CI job `adr-index` in checks.yml) — every NNNN-*.md file must appear exactly

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,8 @@
   # it's applied to, not the pkgs it was authored against). Instead this
   # consumes beads' self-contained `packages.${system}.bd` output directly,
   # built entirely against beads' own independently-pinned nixpkgs
-  # (nixos-25.11, which does have buildGo126Module) — see the devShells
-  # override below.
+  # (nixos-25.11, which does have buildGo126Module) — see the
+  # `neohaskellTools` overlay below.
   inputs.beads.url = "github:gastownhall/beads";
   outputs = { self, nixpkgs, flake-utils, haskellNix, beads }:
     let
@@ -33,6 +33,14 @@
               #evalSystem = "x86_64-linux";
             };
           })
+          # The single, named extension point for a non-Haskell, non-hix-
+          # managed CLI tool to enter the dev shell (README.md: "Adding a
+          # non-Haskell CLI tool to the dev shell"). Namespaced rather than a
+          # bare `bd` attribute so it can never silently shadow a same-named
+          # nixpkgs package (today's pin has none, but that's latent, not
+          # guaranteed) — nix/hix.nix's shell.buildInputs consumes it as
+          # pkgs.neohaskellTools.bd.
+          (final: _prev: { neohaskellTools = { bd = beads.packages.${system}.bd; }; })
         ];
         pkgs = import nixpkgs {
           inherit system overlays;
@@ -54,19 +62,6 @@
           neo = {
             type = "app";
             program = "${neo}/bin/neo";
-          };
-        };
-        # `default` is the shell contributors/agents actually use
-        # (scripts/with-toolchain enters it via `nix develop --command`).
-        # Extend the hix-generated shell with bd (beads), rather than
-        # touching nix/hix.nix's shell.buildInputs: bd comes from a
-        # separately-pinned nixpkgs (see the `beads` input comment above),
-        # so it is composed in via `mkShell { inputsFrom; }` instead of
-        # being folded into the hix project's own pkgs/overlay chain.
-        devShells = (flake.devShells or { }) // {
-          default = pkgs.mkShell {
-            inputsFrom = [ flake.devShells.default ];
-            packages = [ beads.packages.${system}.bd ];
           };
         };
       });

--- a/nix/hix.nix
+++ b/nix/hix.nix
@@ -63,5 +63,10 @@
     # 5.0.18.4 silently ignores --local=DIR txt dirs (verified 2026-07-08);
     # the nixpkgs build of the same version indexes them correctly.
     haskellPackages.hoogle
+    # bd (beads) — NOT shell.tools: that resolves against the project's own
+    # GHC (haskell.nix), but bd is a Go binary from a separately-pinned
+    # nixpkgs (see flake.nix's `neohaskellTools` overlay); the mirror-image
+    # case of the doctest note above.
+    pkgs.neohaskellTools.bd
   ];
 }

--- a/scripts/devshell-check
+++ b/scripts/devshell-check
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""Proving tests for change 007 (bd enters the devShell through hix's own
+extension point — docs/changes/007-bd-via-hix-shell-extension-point.md).
+
+Two modes, matching the spec's two shapes:
+
+  --self-test   Pure static assertions against the real, checked-out
+                flake.nix / nix/hix.nix / README.md — no nix, seconds. Proves
+                C1 (flake.nix composes no shell), C2 (the overlay injects
+                exactly one namespaced `neohaskellTools` attribute, no bare
+                `bd` shadowing, no beads.overlays.default/nixpkgs.follows),
+                C3 (nix/hix.nix reaches bd via shell.buildInputs and not
+                shell.tools, with every pre-existing shell declaration still
+                present), and C8 (README's AC3 recipe names the actual code
+                attribute, so a rename breaks the doc check). Runs in the
+                nix-free checks.yml `doctor` job.
+
+  (default)     In-shell integration checks — must run inside `nix develop`
+                (nix develop --command ./dev devshell-check). Proves C4 (bd
+                resolves to the exact beads.packages.<system>.bd store path,
+                version >= 1.1.0), C5 (every declared shell tool still
+                resolves to a /nix/store path, and hoogle is specifically the
+                nixpkgs build), and C6 (scripts/toolchain-fp is deterministic
+                and the NEOHASKELL_SHELL_FP / NEOHASKELL_SHELL_PATH witnesses
+                match). Runs from test.yml `build` and test-macos.yml
+                `tests-macos` (C7 freezes both — see scripts/workflow-check).
+
+Run:  ./dev devshell-check              (in-shell)   CI: test.yml, test-macos.yml
+      ./dev devshell-check --self-test  (static)     CI: checks.yml (doctor job)
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FLAKE_NIX = REPO_ROOT / "flake.nix"
+HIX_NIX = REPO_ROOT / "nix" / "hix.nix"
+README = REPO_ROOT / "README.md"
+
+# The pre-existing shell.tools entries (C3) — must stay unweakened.
+REQUIRED_SHELL_TOOLS = (
+    "cabal", "hlint", "fourmolu", "hspec-discover", "haskell-language-server",
+    "cabal-gild", "ghcid", "hiedb", "doctest",
+)
+# The pre-existing shell.buildInputs entries (C3) — must stay unweakened.
+REQUIRED_BUILD_INPUTS = (
+    "git", "nixfmt-classic", "postgresql", "hurl", "poppler_utils",
+    "python3.withPackages", "haskellPackages.hoogle",
+)
+# Commands checked purely by "resolves under /nix/store" (C5). bd (identity +
+# version floor) and hoogle (nixpkgs-build identity) get their own checks.
+PATH_ONLY_TOOLS = (
+    "cabal", "hlint", "fourmolu", "hspec-discover", "haskell-language-server",
+    "cabal-gild", "ghcid", "hiedb", "doctest",
+    "git", "nixfmt", "psql", "hurl", "pdftotext", "python3",
+)
+BD_VERSION_FLOOR = (1, 1, 0)
+
+
+# ── comment stripping + tiny attrset parser (shared by C1-C3, C8) ─────────────
+
+def strip_comments(text):
+    """Drop `#` comments (full-line and trailing) so a rule can't be spoofed
+    by prose in a comment. Nix's `${...}` interpolation is self-balancing
+    around any `{`/`}` it contains, so the brace scanner below is unaffected
+    by leaving it in place."""
+    out = []
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        if " #" in line:
+            line = line[: line.index(" #")]
+        out.append(line)
+    return "\n".join(out)
+
+
+def find_matching(text, open_idx, open_ch, close_ch):
+    """Index of the `close_ch` matching the `open_ch` at `open_idx`, counting
+    ONLY that bracket pair (nested `${...}` interpolation self-balances, so
+    this stays correct without special-casing it)."""
+    depth = 0
+    i = open_idx
+    while i < len(text):
+        c = text[i]
+        if c == open_ch:
+            depth += 1
+        elif c == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def top_level_entries(body):
+    """`name = value;` pairs at depth 0 inside an attrset body (the text
+    between its `{` and `}`, exclusive). Good enough for the controlled,
+    simple attrsets this change introduces — not a general Nix parser."""
+    entries = []
+    depth = 0
+    i, n = 0, len(body)
+    while i < n:
+        c = body[i]
+        if depth == 0:
+            m = re.match(r"\s*([A-Za-z_][A-Za-z0-9_.\-]*)\s*=\s*(?!=)", body[i:])
+            if m:
+                val_start = i + m.end()
+                j, vdepth = val_start, 0
+                while j < n:
+                    cj = body[j]
+                    if cj in "{[(":
+                        vdepth += 1
+                    elif cj in "}])":
+                        if vdepth == 0:
+                            break
+                        vdepth -= 1
+                    elif cj == ";" and vdepth == 0:
+                        break
+                    j += 1
+                entries.append((m.group(1), body[val_start:j].strip()))
+                i = j + 1
+                continue
+        if c in "{[(":
+            depth += 1
+        elif c in "}])":
+            depth -= 1
+        i += 1
+    return entries
+
+
+def overlay_bodies(code):
+    """Body text (between `{` and `}`, exclusive) of every
+    `(final: _prev: { ... })`-shaped overlay lambda in `code`."""
+    bodies = []
+    for m in re.finditer(r"final\s*:\s*_?prev\s*:\s*\{", code):
+        open_idx = m.end() - 1
+        close_idx = find_matching(code, open_idx, "{", "}")
+        if close_idx != -1:
+            bodies.append(code[open_idx + 1 : close_idx])
+    return bodies
+
+
+# ── C1: flake.nix composes no shell ────────────────────────────────────────
+
+def check_flake_wiring(flake_text):
+    errs = []
+    code = strip_comments(flake_text)
+    for banned in ("mkShell", "inputsFrom", "devShells"):
+        if banned in code:
+            errs.append(
+                f"flake.nix still contains '{banned}' — devShells.default "
+                "must be hix's own shell, unwrapped (C1)")
+    return errs
+
+
+# ── C2: the overlay shape ──────────────────────────────────────────────────
+
+def check_overlay_shape(flake_text):
+    """Returns (errs, attr_name) — attr_name is the actual injected attribute
+    name (for C8 to cross-check README against), or None if not found."""
+    errs = []
+    code = strip_comments(flake_text)
+    bodies = overlay_bodies(code)
+    if not bodies:
+        errs.append(
+            "flake.nix: no `(final: _prev: { ... })`-shaped overlay found — "
+            "cannot verify the neohaskellTools injection (C2)")
+        return errs, None
+
+    all_names, neohaskell_value = [], None
+    for body in bodies:
+        for name, value in top_level_entries(body):
+            all_names.append(name)
+            if name == "neohaskellTools":
+                neohaskell_value = value
+
+    if "bd" in all_names:
+        errs.append(
+            "flake.nix: an overlay injects a bare top-level `bd` attribute — "
+            "this silently shadows any same-named nixpkgs attribute; "
+            "namespace it under `neohaskellTools` instead (C2/F2)")
+    if all_names.count("neohaskellTools") == 0:
+        errs.append(
+            "flake.nix: no overlay injects a top-level `neohaskellTools` "
+            "attribute (C2)")
+    elif all_names.count("neohaskellTools") > 1:
+        errs.append(
+            "flake.nix: `neohaskellTools` is injected by more than one "
+            "overlay (C2)")
+
+    attr_name = "neohaskellTools" if "neohaskellTools" in all_names else None
+
+    if neohaskell_value is not None:
+        inner = neohaskell_value.strip()
+        if inner.startswith("{") and inner.endswith("}"):
+            inner_names_values = top_level_entries(inner[1:-1])
+        else:
+            inner_names_values = []
+            errs.append(
+                f"flake.nix: neohaskellTools is not an attribute-set literal "
+                f"({inner!r}) (C2)")
+        inner_names = [n for n, _ in inner_names_values]
+        if inner_names != ["bd"]:
+            errs.append(
+                "flake.nix: neohaskellTools must inject exactly one "
+                f"attribute, `bd` (found {inner_names or 'none'}) (C2)")
+        else:
+            got = re.sub(r"\s+", "", inner_names_values[0][1])
+            expected = re.sub(r"\s+", "", "beads.packages.${system}.bd")
+            if got != expected:
+                errs.append(
+                    f"flake.nix: neohaskellTools.bd = "
+                    f"{inner_names_values[0][1]!r}, expected "
+                    "beads.packages.${system}.bd (C2/F3)")
+
+    if "beads.overlays.default" in code:
+        errs.append(
+            "flake.nix: references beads.overlays.default — out of "
+            "contract, it calls final.buildGo126Module which our pin lacks "
+            "(C2/F4)")
+    if re.search(r"inputs\.beads\.inputs\.nixpkgs\.follows", code):
+        errs.append(
+            "flake.nix: sets inputs.beads.inputs.nixpkgs.follows — out of "
+            "contract (C2/F4)")
+    return errs, attr_name
+
+
+# ── C3: nix/hix.nix wiring, nothing weakened ───────────────────────────────
+
+def check_hix_wiring(hix_text):
+    errs = []
+    code = strip_comments(hix_text)
+
+    tools_match = re.search(r"shell\.tools\s*=\s*\{", code)
+    if not tools_match:
+        errs.append("nix/hix.nix: no `shell.tools = { ... }` block found (C3)")
+    else:
+        close_idx = find_matching(code, tools_match.end() - 1, "{", "}")
+        body = code[tools_match.end() : close_idx]
+        names = [n for n, _ in top_level_entries(body)]
+        missing = [t for t in REQUIRED_SHELL_TOOLS if t not in names]
+        if missing:
+            errs.append(
+                f"nix/hix.nix: shell.tools is missing {missing} — a "
+                "pre-existing entry was weakened (C3)")
+        if "bd" in names or "neohaskellTools" in body:
+            errs.append(
+                "nix/hix.nix: bd/neohaskellTools reached from shell.tools — "
+                "bd is a Go binary and must resolve via shell.buildInputs, "
+                "not shell.tools (C3/F11)")
+
+    build_match = re.search(
+        r"shell\.buildInputs\s*=\s*(?:with\s+pkgs\s*;\s*)?\[", code)
+    if not build_match:
+        errs.append(
+            "nix/hix.nix: no `shell.buildInputs = [ ... ]` block found (C3)")
+    else:
+        close_idx = find_matching(code, build_match.end() - 1, "[", "]")
+        body = code[build_match.end() : close_idx]
+        missing = [b for b in REQUIRED_BUILD_INPUTS if b not in body]
+        if missing:
+            errs.append(
+                f"nix/hix.nix: shell.buildInputs is missing pre-existing "
+                f"entries {missing} (C3)")
+        if "pkgs.neohaskellTools.bd" not in body:
+            errs.append(
+                "nix/hix.nix: shell.buildInputs does not reach bd as "
+                "pkgs.neohaskellTools.bd (C3)")
+
+    if re.sub(r"\s+", "", "shell.withHoogle = false") not in re.sub(r"\s+", "", code):
+        errs.append("nix/hix.nix: shell.withHoogle = false is missing (C3)")
+
+    hook_match = re.search(r"shell\.shellHook\s*=\s*''(.*?)''", code, re.S)
+    if not hook_match:
+        errs.append("nix/hix.nix: no shell.shellHook block found (C3)")
+    else:
+        hook = hook_match.group(1)
+        for var in ("NEOHASKELL_SHELL_FP", "NEOHASKELL_SHELL_PATH"):
+            if var not in hook:
+                errs.append(
+                    f"nix/hix.nix: shell.shellHook no longer exports {var} "
+                    "(C3)")
+    return errs
+
+
+# ── C8: README's AC3 recipe tracks the real attribute name ────────────────
+
+def check_doc_coherence(readme_text, attr_name):
+    errs = []
+    if attr_name is None:
+        errs.append(
+            "README.md: cannot verify the AC3 recipe — flake.nix has no "
+            "neohaskellTools-shaped overlay yet (C2 must land first) (C8)")
+        return errs
+    if attr_name not in readme_text:
+        errs.append(
+            f"README.md: does not mention `{attr_name}` — the AC3 recipe "
+            "must name the actual code attribute, not a stale one (C8/F10)")
+    if f"pkgs.{attr_name}." not in readme_text:
+        errs.append(
+            f"README.md: does not show `pkgs.{attr_name}.<key>` being "
+            "listed in nix/hix.nix shell.buildInputs (C8)")
+    if "shell.buildInputs" not in readme_text:
+        errs.append(
+            "README.md: AC3 recipe does not name `shell.buildInputs` as "
+            "where the tool is listed (C8)")
+    if "shell.tools" not in readme_text:
+        errs.append(
+            "README.md: AC3 recipe does not document the Haskell-tool "
+            "exception (shell.tools) (C8/F11)")
+    return errs
+
+
+# ── in-shell (C4-C6): real `nix develop` state ─────────────────────────────
+
+def _run(cmd):
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def current_system():
+    r = _run(["nix", "eval", "--impure", "--raw", "--expr", "builtins.currentSystem"])
+    if r.returncode != 0:
+        raise RuntimeError(f"nix eval builtins.currentSystem failed: {r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def flake_out_path(attr_path):
+    """The store path of legacyPackages.<system>.<attr_path>, via `.outPath`
+    — reads the derivation's output path without building anything new.
+
+    Evaluated through the `<repo>#<ref>` flake-ref form (an ABSOLUTE repo
+    path, not `.#...` + a cwd change, and not `builtins.getFlake`): the
+    latter two both re-derive the flake's `src` from a fresh git-ls-files
+    fetch, which on this repo pulls in a foreign-system IFD derivation
+    (`git-ls-files.drv` pinned to x86_64-linux) and fails on other hosts —
+    see the `avoiding-ifd-cross-platform` skill. The plain flake-ref form
+    reuses the already-resolved flake the surrounding `nix develop` entered."""
+    system = current_system()
+    ref = f'{REPO_ROOT}#legacyPackages."{system}".{attr_path}.outPath'
+    r = _run(["nix", "eval", "--impure", "--raw", ref])
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"nix eval legacyPackages.{system}.{attr_path}.outPath failed: "
+            f"{r.stderr.strip()}")
+    return r.stdout.strip()
+
+
+def resolved_bin(name):
+    which = shutil.which(name)
+    if which is None:
+        raise RuntimeError(f"'{name}' not found on PATH")
+    return os.path.realpath(which)
+
+
+def _under(resolved, store_path):
+    store_path = store_path.rstrip("/")
+    return resolved == store_path or resolved.startswith(store_path + "/")
+
+
+def check_bd_identity(errs):
+    expected = flake_out_path("neohaskellTools.bd")
+    resolved = resolved_bin("bd")
+    if not _under(resolved, expected):
+        errs.append(
+            f"bd resolves to {resolved}, expected under {expected} "
+            "(beads.packages.<system>.bd) — not the pinned build (C4/F6)")
+    version_out = _run(["bd", "--version"]).stdout.strip()
+    m = re.search(r"(\d+)\.(\d+)\.(\d+)", version_out)
+    if not m:
+        errs.append(f"bd --version produced no parseable version: {version_out!r} (C4)")
+    elif tuple(int(g) for g in m.groups()) < BD_VERSION_FLOOR:
+        errs.append(
+            f"bd --version = {version_out!r} is below the "
+            f">= {'.'.join(map(str, BD_VERSION_FLOOR))} schema floor (C4/F3)")
+
+
+def check_tool_inventory(errs):
+    for name in PATH_ONLY_TOOLS:
+        try:
+            resolved = resolved_bin(name)
+        except RuntimeError as e:
+            errs.append(f"{e} (C5)")
+            continue
+        if not resolved.startswith("/nix/store/"):
+            errs.append(f"{name} resolves to {resolved}, not a /nix/store path (C5)")
+
+    r = _run(["python3", "-c", "import yaml"])
+    if r.returncode != 0:
+        errs.append(f"python3 -c 'import yaml' failed: {r.stderr.strip()} (C5)")
+
+    try:
+        expected = flake_out_path("haskellPackages.hoogle")
+        resolved = resolved_bin("hoogle")
+        if not _under(resolved, expected):
+            errs.append(
+                f"hoogle resolves to {resolved}, expected under {expected} "
+                "(haskellPackages.hoogle, the nixpkgs build) — got "
+                "haskell.nix's hoogle-with-packages wrapper instead? "
+                "(./dev api --local would silently re-break) (C5)")
+    except RuntimeError as e:
+        errs.append(f"{e} (C5)")
+
+
+def check_fingerprint_witness(errs):
+    fp_script = str(REPO_ROOT / "scripts" / "toolchain-fp")
+    r1, r2 = _run([fp_script]), _run([fp_script])
+    if r1.returncode != 0 or not r1.stdout.strip():
+        errs.append(
+            f"scripts/toolchain-fp produced no output ({r1.stderr.strip()}) "
+            "(C6)")
+        return
+    fp1, fp2 = r1.stdout.strip(), r2.stdout.strip()
+    if fp1 != fp2:
+        errs.append(
+            "scripts/toolchain-fp is non-deterministic across two "
+            f"consecutive runs ({fp1} != {fp2}) (C6/F7)")
+
+    env_fp = os.environ.get("NEOHASKELL_SHELL_FP", "")
+    if env_fp != fp1:
+        errs.append(
+            f"NEOHASKELL_SHELL_FP={env_fp!r} does not match "
+            f"scripts/toolchain-fp={fp1!r} — are you inside `nix develop`? "
+            "(C6)")
+
+    env_path = os.environ.get("NEOHASKELL_SHELL_PATH", "")
+    if not env_path:
+        errs.append(
+            "NEOHASKELL_SHELL_PATH is empty — the PATH witness "
+            "with-toolchain restores on its fast path (C6)")
+        return
+    try:
+        bd_bin_dir = os.path.dirname(resolved_bin("bd"))
+        if bd_bin_dir not in env_path.split(os.pathsep):
+            errs.append(
+                "NEOHASKELL_SHELL_PATH does not contain bd's bin dir "
+                f"({bd_bin_dir}) — with-toolchain's fast path could hand "
+                "back a host binary (C6/F6)")
+    except RuntimeError as e:
+        errs.append(f"{e} (C6)")
+
+
+# ── dispatch ────────────────────────────────────────────────────────────────
+
+def self_test():
+    ok = True
+
+    def check(name, errs):
+        nonlocal ok
+        print(f"  {'ok  ' if not errs else 'FAIL'} {name}")
+        for e in errs:
+            print(f"        - {e}")
+        ok = ok and not errs
+
+    flake_text = FLAKE_NIX.read_text(encoding="utf-8")
+    hix_text = HIX_NIX.read_text(encoding="utf-8")
+    readme_text = README.read_text(encoding="utf-8")
+
+    check("flake-wiring: flake.nix composes no shell (C1)",
+          check_flake_wiring(flake_text))
+    overlay_errs, attr_name = check_overlay_shape(flake_text)
+    check("overlay-shape: one namespaced attribute, no shadowing (C2)",
+          overlay_errs)
+    check("hix-wiring: bd via shell.buildInputs, nothing weakened (C3)",
+          check_hix_wiring(hix_text))
+    check("doc-coherence: README recipe tracks the code attribute (C8)",
+          check_doc_coherence(readme_text, attr_name))
+
+    print("devshell-check: self-test", "OK" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def run_in_shell():
+    ok = True
+
+    def check(name, fn):
+        nonlocal ok
+        errs = []
+        try:
+            fn(errs)
+        except Exception as e:  # nix/PATH failures are check failures, not crashes
+            errs.append(str(e))
+        print(f"  {'ok  ' if not errs else 'FAIL'} {name}")
+        for e in errs:
+            print(f"        - {e}")
+        ok = ok and not errs
+
+    check("bd store-path identity + version floor (C4)", check_bd_identity)
+    check("tool inventory (C5)", check_tool_inventory)
+    check("fingerprint witness (C6)", check_fingerprint_witness)
+
+    print("devshell-check: in-shell", "OK" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main(argv):
+    if argv and argv[0] == "--self-test":
+        return self_test()
+    if argv:
+        print(f"usage: devshell-check [--self-test]  (got {argv!r})", file=sys.stderr)
+        return 2
+    return run_in_shell()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/workflow-check
+++ b/scripts/workflow-check
@@ -951,6 +951,50 @@ def check_onboarding_slo(name, text):
     return errs
 
 
+# ── change 007: devshell-check wiring (C7) ─────────────────────────────────
+# (docs/changes/007-bd-via-hix-shell-extension-point.md) The two jobs that
+# already enter the shell must invoke `./dev devshell-check` in-shell
+# (C4-C6), and the nix-free `checks.yml` `doctor` job must invoke
+# `./dev devshell-check --self-test` (C1-C3, C8). A regression that drops
+# either therefore fails a required check rather than rotting silently.
+DEVSHELL_VERB = "devshell-check"
+DEVSHELL_IN_SHELL_JOBS = {
+    "test.yml": "build",
+    "test-macos.yml": "tests-macos",
+}
+
+
+def check_devshell_check_in_shell(name, text, job_key):
+    errs = []
+    job = job_blocks(strip_comments(text)).get(job_key, "")
+    if not job:
+        errs.append(f"{name}: missing the `{job_key}` job (cannot verify "
+                     f"{DEVSHELL_VERB} wiring)")
+        return errs
+    if not re.search(
+        rf"nix develop --command\s+\./dev {re.escape(DEVSHELL_VERB)}\b", job
+    ):
+        errs.append(
+            f"{name}: `{job_key}` job never runs `./dev {DEVSHELL_VERB}` "
+            "in-shell (`nix develop --command ...`) — C4-C6 would never run "
+            "in CI")
+    return errs
+
+
+def check_devshell_check_selftest(name, text):
+    errs = []
+    doctor = job_blocks(strip_comments(text)).get("doctor", "")
+    if not doctor:
+        errs.append(f"{name}: missing the `doctor` job (cannot verify "
+                     f"{DEVSHELL_VERB} --self-test wiring)")
+        return errs
+    if f"./dev {DEVSHELL_VERB} --self-test" not in doctor:
+        errs.append(
+            f"{name}: `doctor` job never runs `./dev {DEVSHELL_VERB} "
+            "--self-test` — C1/C2/C3/C8 would never run in CI")
+    return errs
+
+
 def run(root=WORKFLOWS):
     errs = []
     for wf in sorted(root.glob("*.yml")):
@@ -973,6 +1017,11 @@ def run(root=WORKFLOWS):
             errs += check_installer_ci(wf.name, text)
         if wf.name == ONBOARDING_SLO_GATE:
             errs += check_onboarding_slo(wf.name, text)
+        if wf.name in DEVSHELL_IN_SHELL_JOBS:
+            errs += check_devshell_check_in_shell(
+                wf.name, text, DEVSHELL_IN_SHELL_JOBS[wf.name])
+        if wf.name == "checks.yml":
+            errs += check_devshell_check_selftest(wf.name, text)
     retro = root / "retrospect.yml"
     if not retro.exists():
         errs.append("retrospect.yml is missing (deterministic learning-loop digest)")
@@ -1595,6 +1644,59 @@ def self_test():
     slo_bad("slo job pre-installing Nix is flagged (collides with the release installer)",
             good_slo.replace("      - uses: actions/checkout@v7.0.1\n",
                              "      - uses: actions/checkout@v7.0.1\n      - uses: DeterminateSystems/determinate-nix-action@v3.21.7\n"))
+
+    # ── change 007: devshell-check wiring (C7) ────────────────────────────────
+    good_build_job = (
+        "jobs:\n  build:\n    steps:\n"
+        "      - name: Build the project with cabal\n"
+        "        run: nix develop --command cabal build all --disable-documentation\n"
+        "      - name: devShell proving tests (change 007 — C4-C6)\n"
+        "        run: nix develop --command ./dev devshell-check\n"
+    )
+    check("test.yml build job running devshell-check in-shell passes",
+          not check_devshell_check_in_shell("test.yml", good_build_job, "build"))
+    check("test.yml build job missing devshell-check is flagged",
+          check_devshell_check_in_shell(
+              "test.yml",
+              good_build_job.replace(
+                  "      - name: devShell proving tests (change 007 — C4-C6)\n"
+                  "        run: nix develop --command ./dev devshell-check\n", ""),
+              "build"))
+    check("test.yml build job running devshell-check OUTSIDE the shell is flagged",
+          check_devshell_check_in_shell(
+              "test.yml",
+              good_build_job.replace(
+                  "        run: nix develop --command ./dev devshell-check\n",
+                  "        run: ./dev devshell-check\n"),
+              "build"))
+    check("test.yml missing the build job entirely is flagged",
+          check_devshell_check_in_shell("test.yml", "jobs:\n  other:\n    steps: []\n", "build"))
+
+    good_macos_job = good_build_job.replace("  build:", "  tests-macos:")
+    check("test-macos.yml tests-macos job running devshell-check in-shell passes",
+          not check_devshell_check_in_shell("test-macos.yml", good_macos_job, "tests-macos"))
+    check("test-macos.yml tests-macos job missing devshell-check is flagged",
+          check_devshell_check_in_shell(
+              "test-macos.yml",
+              good_macos_job.replace(
+                  "      - name: devShell proving tests (change 007 — C4-C6)\n"
+                  "        run: nix develop --command ./dev devshell-check\n", ""),
+              "tests-macos"))
+
+    good_doctor_job = (
+        "jobs:\n  doctor:\n    steps:\n"
+        "      - run: ./dev doctor\n"
+        "      - run: ./dev workflow-check\n"
+        "      - run: ./dev devshell-check --self-test\n"
+    )
+    check("checks.yml doctor job running devshell-check --self-test passes",
+          not check_devshell_check_selftest("checks.yml", good_doctor_job))
+    check("checks.yml doctor job missing devshell-check --self-test is flagged",
+          check_devshell_check_selftest(
+              "checks.yml",
+              good_doctor_job.replace("      - run: ./dev devshell-check --self-test\n", "")))
+    check("checks.yml missing the doctor job entirely is flagged",
+          check_devshell_check_selftest("checks.yml", "jobs:\n  other:\n    steps: []\n"))
 
     print("workflow-check: self-test", "OK" if ok else "FAILED")
     return 0 if ok else 1

--- a/website/src/content/docs/adrs/index.mdx
+++ b/website/src/content/docs/adrs/index.mdx
@@ -87,3 +87,4 @@ ADRs are immutable: when a decision is reversed, a new ADR is written that refer
 | [0072](/adrs/0072-neo-cutover-and-onboarding-slo/) | Neo CLI cutover — archive-as-human-gate and the clean-machine onboarding SLO | Accepted |
 | [0073](/adrs/0073-deterministic-uuid-v5/) | Deterministic UUID v5 as a Core primitive and a Decision combinator | Implemented |
 | [0074](/adrs/0074-dependabot-auto-merge/) | Dependabot patch/minor auto-merges; majors stop for a human | Accepted |
+| [0075](/adrs/0075-devshell-tool-injection-via-overlay-and-hix-buildinputs/) | Non-Haskell devShell tools enter via a namespaced overlay attribute + hix `shell.buildInputs` | Accepted |


### PR DESCRIPTION
Gate 1 — **spec only**, no implementation. The diff is the contract the
maintainer approves before any code is written.

Closes-spec-for: #811

## What this proposes

Drop the `pkgs.mkShell { inputsFrom = [ flake.devShells.default ]; }` workaround
in `flake.nix` and give `bd` a first-class entry through hix's own extension
point:

1. `flake.nix` — one overlay injecting a single namespaced attribute,
   `neohaskellTools = { bd = beads.packages.${system}.bd; }`, and the `devShells`
   override block deleted.
2. `nix/hix.nix` — `pkgs.neohaskellTools.bd` in `shell.buildInputs` (not
   `shell.tools`, which haskell.nix resolves against the project GHC).
3. `README.md` — the AC3 recipe for adding the next non-Haskell CLI tool.

No version bump, no runtime change: `bd` stays the same `flake.lock`-pinned
derivation on the same `PATH`. `beads.overlays.default` stays unused (it calls
`final.buildGo126Module`, which our pin lacks).

## Contents of this PR

- `docs/changes/007-bd-via-hix-shell-extension-point.md` — the spec: contract
  delta (empty signatures — infrastructure only), criteria C1–C8, failure modes
  F1–F11 with a concurrency section, a Primitives section, an explicit
  edit-set delta, and the limits that are argued rather than tested.
- `docs/decisions/0075-*.md` + its index row and the regenerated ADR landing
  page — why hix's extension point over a cleverer composition, why the
  attribute is namespaced rather than bare, and what happens if hix's module
  `pkgs` turns out not to see our overlay (park as `wrong-localization`, never
  a silent fallback).

## Gates

- `./dev spec-check` — OK (8 specs valid)
- `./dev spec-check --plan` — `design_reviews: []` (no security/perf review
  routed; matches the binding localization)
- `./dev adr-check`, `./dev adr-website --check`, `./dev doctor` — green

## Continue signal

A maintainer `@claude` comment on this PR is the Gate 1 approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)