### PR TITLE
spec: give DateTime a ToSchema instance (change 007, issue #729)

### DIFF
--- a/core/nhcore.cabal
+++ b/core/nhcore.cabal
@@ -711,6 +711,7 @@ test-suite nhcore-test-core
     ParserSpec
     LogSpec
     RedactedSpec
+    Schema.DateTimeSpec
     Schema.OpenApiSpec
     SchemaSpec
     Schema.JsonSchemaSpec

--- a/core/test-core/Main.hs
+++ b/core/test-core/Main.hs
@@ -31,6 +31,7 @@ import NeoQL.ExecuteSpec qualified
 import NeoQL.ParserSpec qualified
 import OutboundIntegrationSpec qualified
 import RedactedSpec qualified
+import Schema.DateTimeSpec qualified
 import Schema.OpenApiSpec qualified
 import SchemaSpec qualified
 import Schema.JsonSchemaSpec qualified
@@ -81,6 +82,7 @@ main = Hspec.hspec do
   Hspec.describe "OutboundIntegration" OutboundIntegrationSpec.spec
   Hspec.describe "Redacted" RedactedSpec.spec
   Hspec.describe "Schema" SchemaSpec.spec
+  Hspec.describe "Schema.DateTime" Schema.DateTimeSpec.spec
   Hspec.describe "Schema.OpenApi" Schema.OpenApiSpec.spec
   Hspec.describe "Schema.JsonSchema" Schema.JsonSchemaSpec.spec
   Hspec.describe "Service.Transport.Web.SwaggerUI" Service.Transport.Web.SwaggerUISpec.spec

--- a/core/test/Schema/DateTimeSpec.hs
+++ b/core/test/Schema/DateTimeSpec.hs
@@ -1,0 +1,105 @@
+-- | Reproduction + criteria for change 007 (issue #729): `DateTime` has no
+-- `ToSchema` instance, so any read-model record carrying a timestamp field
+-- fails to compile under generic `Schema` derivation.
+--
+-- This module is committed RED. A missing instance is a *type* error, so
+-- "red" here is a compile failure of the `nhcore-test-core` suite
+-- (@No instance for (ToSchema DateTime)@), not a failing runtime assertion.
+-- The fix — `instance ToSchema DateTime where toSchema = SText` in
+-- `core/schema/Schema.hs` — turns it green without changing an assertion.
+--
+-- Spec: docs/changes/007-729-datetime-toschema.md
+module Schema.DateTimeSpec (spec) where
+
+import Array qualified
+import Basics
+import Control.Lens qualified as Lens
+import Data.OpenApi qualified as OpenApi
+import Data.OpenApi.Lens qualified as OpenApiLens
+import DateTime (DateTime)
+import DateTime qualified
+import Json qualified
+import Maybe (Maybe (..))
+import Schema (Schema (..), ToSchema (..))
+import Schema.JsonSchema qualified
+import Schema.OpenApi qualified
+import Test (Spec)
+import Test qualified
+import Text (Text)
+import Uuid (Uuid)
+
+
+-- | The record from issue #729: a read-model row carrying a timestamp, plus
+-- the `Maybe DateTime` variant the issue reports as failing the same way.
+data Row = Row
+  { rowId :: Uuid
+  , occurredAt :: DateTime
+  , deletedAt :: Maybe DateTime
+  }
+  deriving (Generic)
+
+
+instance ToSchema Row
+
+
+-- | 1970-01-01T00:00:00Z — a whole second, so the ISO-8601 rendering carries
+-- no subsecond part.
+epoch :: DateTime
+epoch = DateTime.fromEpochSeconds 0
+
+
+spec :: Spec Unit
+spec = do
+  Test.describe "ToSchema DateTime" do
+    -- C2
+    Test.it "generates SText for DateTime" \_ -> do
+      toSchema @DateTime
+        |> Test.shouldBe SText
+
+    -- C3
+    Test.it "generates SOptional SText for Maybe DateTime" \_ -> do
+      toSchema @(Maybe DateTime)
+        |> Test.shouldBe (SOptional SText)
+
+    -- C4 — the anti-tautology guard: SText is only honest if the encoder
+    -- really emits a JSON string. Asserts the wire form independently of
+    -- the schema, so C2 cannot pass by merely restating itself.
+    Test.it "encodes DateTime as an ISO-8601 JSON string, matching SText" \_ -> do
+      Json.encodeText epoch
+        |> Test.shouldBe "\"1970-01-01T00:00:00Z\""
+
+    -- C1 — the issue's reproduction.
+    Test.it "derives a schema for a record with DateTime fields" \_ -> do
+      let schema = toSchema @Row
+      case schema of
+        SObject fields -> do
+          Array.length fields |> Test.shouldBe 3
+          let occurredAtField = fields |> Array.find (\f -> f.fieldName == "occurredAt")
+          let deletedAtField = fields |> Array.find (\f -> f.fieldName == "deletedAt")
+          case (occurredAtField, deletedAtField) of
+            (Just occurred, Just deleted) -> do
+              occurred.fieldSchema |> Test.shouldBe SText
+              occurred.fieldRequired |> Test.shouldBe True
+              deleted.fieldSchema |> Test.shouldBe (SOptional SText)
+              deleted.fieldRequired |> Test.shouldBe False
+            _ -> do
+              "Row schema is missing its DateTime fields"
+                |> Test.shouldBe ("Row schema has both DateTime fields" :: Text)
+        _ -> do
+          "Row schema is not an SObject"
+            |> Test.shouldBe ("Row schema is an SObject" :: Text)
+
+    -- C5
+    Test.it "lowers DateTime to JSON Schema type string" \_ -> do
+      Schema.JsonSchema.toJsonSchema (toSchema @DateTime)
+        |> Test.shouldBe (Json.object [("type", Json.toJSON ("string" :: Text))])
+
+    -- C6 — pins the deliberate scope boundary: no `format: date-time` today.
+    Test.it "lowers DateTime to OpenApiString with no format" \_ -> do
+      let openApiSchema = Schema.OpenApi.toOpenApiSchema (toSchema @DateTime)
+      openApiSchema
+        |> Lens.view OpenApiLens.type_
+        |> Test.shouldBe (Just OpenApi.OpenApiString)
+      openApiSchema
+        |> Lens.view OpenApiLens.format
+        |> Test.shouldBe (Nothing :: Maybe Text)

--- a/docs/changes/007-729-datetime-toschema.md
+++ b/docs/changes/007-729-datetime-toschema.md
@@ -83,6 +83,25 @@ over.
 | C5 | JSON-Schema lowering: `toJsonSchema (toSchema @DateTime)` is `{"type": "string"}` | `Schema.DateTimeSpec` "lowers DateTime to JSON Schema type string" | unit |
 | C6 | OpenAPI lowering: `toOpenApiSchema (toSchema @DateTime)` has `type: string` and **no** `format` — pinning the deliberate scope boundary above | `Schema.DateTimeSpec` "lowers DateTime to OpenApiString with no format" | unit |
 
+### Note for the build step: C4 is not adjustable
+
+C4's committed assertion pins the exact ISO-8601 rendering
+(`"1970-01-01T00:00:00Z"` for epoch 0). The spec author could not execute a
+typecheck in this environment (see the run bead), so if that literal is off by
+formatting detail, **correct the literal to the wire form the encoder actually
+produces — never weaken the assertion** to something shape-only. The
+expectation guard does not protect C4: it is new in this PR, so nothing
+mechanical stops it from being softened, and softening it is precisely the
+tautology this criterion exists to prevent.
+
+If the encoder turns out to emit something that is *not* a JSON string, do not
+adapt the test — the `SText` mapping in the Contract delta would then be wrong,
+and the run must park as a contract hole rather than ship a schema that
+misdescribes the wire.
+
+Likewise, if `Data.OpenApi.Lens.format` is not the correct lens name for C6,
+resolve the real one via `./dev api`; keep the assertion "no format".
+
 ### Edge cases and failure modes
 
 - **`Maybe DateTime`** — the reported second failure mode; C3.

--- a/docs/changes/007-729-datetime-toschema.md
+++ b/docs/changes/007-729-datetime-toschema.md
@@ -1,0 +1,126 @@
+# Change 007: Give `DateTime` a `ToSchema` instance
+
+`DateTime` derives `ToJSON`/`FromJSON` but has no `ToSchema` instance, so the
+moment a read model or API record carries a timestamp field — `DateTime` or
+`Maybe DateTime` — generic `Schema` derivation stops compiling. Since
+`DateTime` is the natural type for timestamps folded onto entities, a timestamp
+cannot be surfaced on an HTTP read model today without a workaround (an orphan
+instance, or storing epoch `Int` / ISO `Text` instead). This change ships the
+instance out of the box, as the other `Core` scalars (`Uuid`, `Text`, `Int`, …)
+already do.
+
+```yaml spec
+issue: issue#729
+kind: bug
+touches: [schema, core-primitives]
+breaking: false
+new-dependency: false
+new-capability: false
+new-extension-point: false
+```
+
+## Contract delta
+
+One additive instance, defined in `core/schema/Schema.hs` alongside the `Uuid`
+instance it mirrors. No signature is removed and no existing instance changes,
+so the delta is a single `+` line.
+
+```diff signatures
++ Schema: instance Schema.ToSchema DateTime.DateTime
+```
+
+`DateTime` maps to `SText` because that is what `DateTime` already *is* on the
+wire: its generic `ToJSON` encodes the wrapped `UTCTime` as an ISO-8601 JSON
+string. `SText` is therefore not a convenience choice — it is the schema that
+matches the encoder, and C4 below is the criterion that keeps the two honest.
+
+**Deliberately out of scope**: a dedicated `Schema` constructor carrying
+OpenAPI's `format: date-time`. The `Schema` ADT has no date-time variant, and
+adding one means a new constructor plus its JSON-Schema and OpenAPI lowerings —
+a contract change to `Schema` itself, not the blocking gap the issue reports.
+C6 pins the current behaviour (`type: string`, no `format`) so that a later
+follow-up has to change a test on purpose rather than drift into it.
+
+### Placement decision (so the build step does not re-decide it)
+
+The repo has two precedents: `Uuid`'s instance lives in `core/schema/Schema.hs`,
+while `Decimal`'s lives in its own module (`core/decimal/Decimal.hs:219`). This
+change follows the `Uuid` precedent — `DateTime` is a prelude-surface scalar
+like `Uuid`, and grouping the scalar instances keeps the "Common NeoHaskell
+Types" block in `Schema.hs` the one place to look.
+
+No import cycle is created: `Schema.hs` already imports `Uuid`, which itself
+imports `Json` and `Task`; `DateTime` imports exactly that same set and never
+imports `Schema`. The build step adds `import DateTime (DateTime)` to
+`Schema.hs` and nothing else.
+
+## Criteria
+
+C1 is the issue's reproduction and is committed **red in this draft PR**. Note
+its shape: a missing instance is a *type* error, so C1 is red as a compile
+failure of the `nhcore-test-core` suite (`No instance for (ToSchema DateTime)`),
+not as a runtime assertion failure. A draft PR that does not build is the
+correct state for this run — heavy CI is skipped on drafts — and the build step
+turns it green by adding the instance, changing no assertion.
+
+All criteria are `unit`: the contract is the availability and value of a
+typeclass instance plus its two pure lowerings. Nothing crosses the filesystem,
+Postgres or HTTP, so nothing here can honestly claim `integration` or
+`acceptance`. The end-to-end symptom the issue reports — an HTTP read model
+with a timestamp failing to build — is a compile-time consequence of C1 and is
+proven by C1, not by a server round-trip.
+
+No property-based qualifier: the contract is a constant (`toSchema @DateTime`
+is one fixed value), not an algebraic law, so there is no space to quantify
+over.
+
+| ID | Behavior | Proving test | Level |
+|----|----------|--------------|-------|
+| C1 | The issue's repro: a record with a `DateTime` field and a `Maybe DateTime` field derives `ToSchema` and compiles; its schema is `SObject` with the `DateTime` field required at `SText` and the `Maybe DateTime` field not required at `SOptional SText` | `Schema.DateTimeSpec` "derives a schema for a record with DateTime fields" | unit |
+| C2 | `toSchema @DateTime` is `SText` | `Schema.DateTimeSpec` "generates SText for DateTime" | unit |
+| C3 | `toSchema @(Maybe DateTime)` is `SOptional SText` — the container instance composes, which is the second half of the issue's report | `Schema.DateTimeSpec` "generates SOptional SText for Maybe DateTime" | unit |
+| C4 | Wire-form honesty: `Json.encodeText` of a `DateTime` is a quoted ISO-8601 string, so the declared `SText` describes what the encoder actually emits | `Schema.DateTimeSpec` "encodes DateTime as an ISO-8601 JSON string, matching SText" | unit |
+| C5 | JSON-Schema lowering: `toJsonSchema (toSchema @DateTime)` is `{"type": "string"}` | `Schema.DateTimeSpec` "lowers DateTime to JSON Schema type string" | unit |
+| C6 | OpenAPI lowering: `toOpenApiSchema (toSchema @DateTime)` has `type: string` and **no** `format` — pinning the deliberate scope boundary above | `Schema.DateTimeSpec` "lowers DateTime to OpenApiString with no format" | unit |
+
+### Edge cases and failure modes
+
+- **`Maybe DateTime`** — the reported second failure mode; C3.
+- **`Array DateTime`** — falls out of the existing `ToSchema element => ToSchema (Array element)` instance with no extra code. Not given its own criterion: it exercises the container instance, which is already covered, not the new one.
+- **Nested / record placement** — C1 asserts the whole `SObject`, including the required-vs-optional flag, rather than just the field's schema.
+- **Schema/encoder divergence** — the real failure mode of a hand-written scalar instance is claiming a wire shape the encoder does not produce. C4 is the criterion that catches it. Without C4, C2 would be close to tautological (`SText` asserted equals `SText` written), which is exactly what the verify step's anti-tautology check exists to reject.
+- **Concurrency** — not applicable, and stated rather than omitted: `toSchema` is a pure nullary class method over an immutable ADT. There is no shared state, no mutation and no parallelism in the contract, so there is nothing for a concurrency stress test to stress.
+- **Security** — not applicable, and stated rather than omitted: this instance is output-side only. It participates in *publishing* a schema; no external input crosses a trust boundary through it, and it performs no parsing, decoding or validation. `FromJSON DateTime` (the input side) is untouched.
+- **Orphan-instance collision** — the one way this change can break an existing build; see User impact.
+
+## User impact
+
+Not breaking under the mechanical rule: the contract delta removes no
+signature, and every type that compiles today still compiles.
+
+One honest caveat, because the issue names the workaround explicitly. Anyone
+who worked around the gap with a local orphan `instance ToSchema DateTime` will
+now hit a duplicate-instance error. **Migration**: delete the orphan; the
+upstream instance is `SText`, identical to the one every known workaround
+writes. No behaviour changes for that user — only the declaration site moves.
+There is no such orphan anywhere in this repo (`core`, `testbed`,
+`integrations`, `neo/starter` all checked), so the monorepo is unaffected.
+
+Testbed effect: none required. `testbed`'s read models
+(`Testbed.Cart.Queries.CartSummary`, `Testbed.Stock.Queries.StockLevel`) carry
+no timestamp field today, and this change adds no obligation to give them one.
+
+Positive impact: a query read model registered via `deriveQuery` / `withQuery`
+can carry a `DateTime` field directly, which is the capability the issue asks
+for.
+
+## ADR
+
+Not required — no trigger (breaking / new-dependency / new-capability /
+new-extension-point all false). Nor is one warranted on judgement: the only
+decision of record is "which existing `Schema` constructor does an existing
+wire format map to", the answer is forced by the existing encoder, and both the
+reasoning and its scope boundary are written into the Contract delta section
+above where a future reader will look first. Adding a date-time `Schema`
+constructor later would be an ADR-worthy decision; declining to add one now,
+with the current behaviour pinned by C6, is not.


### PR DESCRIPTION
Closes #729 (on merge of the build step's commits).

**GATE 1 draft** — this PR's diff is the contract, plus the failing
reproduction. No implementation yet.

Spec: [`docs/changes/007-729-datetime-toschema.md`](docs/changes/007-729-datetime-toschema.md)

## This branch deliberately does not build

`kind: bug` means C1 is the reproduction, committed red. A missing typeclass
instance is a **type** error, so "red" here is a compile failure of the
`nhcore-test-core` suite:

```
No instance for (ToSchema DateTime)
```

...not a failing runtime assertion. Heavy CI is skipped on drafts, which is why
the red can land here. The build step turns it green by adding the instance,
changing no assertion.

## Contract

```diff
+ Schema: instance Schema.ToSchema DateTime.DateTime
```

`DateTime` maps to `SText` because that is what it already is on the wire —
its generic `ToJSON` encodes the wrapped `UTCTime` as an ISO-8601 JSON string.
Defined in `core/schema/Schema.hs` beside the `Uuid` instance it mirrors.

**Out of scope, deliberately**: an OpenAPI `format: date-time`. That needs a
new `Schema` constructor plus both lowerings — a contract change to `Schema`
itself, not the blocking gap #729 reports. C6 pins the current behaviour so a
follow-up has to change a test on purpose.

## Criteria

| ID | Behavior | Proving test | Level |
|----|----------|--------------|-------|
| C1 | The issue's repro: a record with `DateTime` and `Maybe DateTime` fields derives `ToSchema` and compiles, with the right required/optional shape | `Schema.DateTimeSpec` "derives a schema for a record with DateTime fields" | unit |
| C2 | `toSchema @DateTime` is `SText` | `Schema.DateTimeSpec` "generates SText for DateTime" | unit |
| C3 | `toSchema @(Maybe DateTime)` is `SOptional SText` | `Schema.DateTimeSpec` "generates SOptional SText for Maybe DateTime" | unit |
| C4 | Wire-form honesty: `Json.encodeText` of a `DateTime` is a quoted ISO-8601 string | `Schema.DateTimeSpec` "encodes DateTime as an ISO-8601 JSON string, matching SText" | unit |
| C5 | `toJsonSchema (toSchema @DateTime)` is `{"type": "string"}` | `Schema.DateTimeSpec` "lowers DateTime to JSON Schema type string" | unit |
| C6 | `toOpenApiSchema (toSchema @DateTime)` has `type: string` and no `format` | `Schema.DateTimeSpec` "lowers DateTime to OpenApiString with no format" | unit |

C4 is the anti-tautology guard: it asserts the wire form independently of the
schema, so C2 cannot pass by merely restating what the implementation writes.

`breaking: false` — no signature is removed. One caveat is documented in the
spec's User impact: anyone carrying a local orphan `instance ToSchema DateTime`
workaround must delete it. No such orphan exists in this monorepo.

## Base branch

Opened against `redesign-neohaskell-pipeline-session`, not `main` — the
`/change` pipeline this run exercises lives on that branch and is not yet
merged.

Generated with [Claude Code](https://claude.com/claude-code)