### PR TITLE
fix: Fix zero-event accepted command decisions

### DIFF
--- a/core/testlib/Test/Service/Command/Core.hs
+++ b/core/testlib/Test/Service/Command/Core.hs
@@ -3,6 +3,7 @@ module Test.Service.Command.Core (
   AddItemToCart (..),
   RemoveItemFromCart (..),
   CheckoutCart (..),
+  NoOpExisting (..),
   -- Authorization-aware Commands
   AuthenticatedAddItem (..),
   OwnedCartCheckout (..),
@@ -78,6 +79,18 @@ instance Json.ToJSON CheckoutCart
 
 
 instance Json.FromJSON CheckoutCart
+
+
+data NoOpExisting = NoOpExisting
+  { cartId :: Uuid
+  }
+  deriving (Eq, Show, Ord, Generic)
+
+
+instance Json.ToJSON NoOpExisting
+
+
+instance Json.FromJSON NoOpExisting
 
 
 -- ============================================================================
@@ -231,6 +244,29 @@ instance Command RemoveItemFromCart where
                 let event = ItemRemoved {entityId = cart.cartId, itemId = cmd.itemId}
                 [event]
                   |> Decider.acceptExisting
+
+
+type instance EntityOf NoOpExisting = CartEntity
+
+
+type instance NameOf NoOpExisting = "NoOpExisting"
+
+
+instance Command NoOpExisting where
+  getEntityIdImpl cmd = cmd.cartId |> Just
+
+
+  canExecuteImpl claims = AccessControl.publicAccess claims
+
+
+  decideImpl :: NoOpExisting -> Maybe CartEntity -> RequestContext -> Decision CartEvent
+  decideImpl _cmd entity _ctx =
+    case entity of
+      Nothing ->
+        Decider.reject "Cart does not exist"
+      Just _cart ->
+        (Array.empty :: Array CartEvent)
+          |> Decider.acceptExisting
 
 
 type instance EntityOf CheckoutCart = CartEntity

--- a/core/testlib/Test/Service/CommandHandler/Execute/Spec.hs
+++ b/core/testlib/Test/Service/CommandHandler/Execute/Spec.hs
@@ -18,6 +18,7 @@ import Test.Service.Command.Core (
   AddItemToCart (..),
   CartEntity (..),
   CheckoutCart (..),
+  NoOpExisting (..),
  )
 import Test.Service.EventStore.Core (CartEvent (..))
 import Test.Service.CommandHandler.Execute.Context qualified as Context
@@ -100,6 +101,47 @@ basicExecutionSpecs newCartStoreAndFetcher = do
 
           cart.cartId |> shouldBe context.cartId
           Array.length cart.cartItems |> shouldBe 1
+        CommandRejected msg ->
+          fail ("Expected CommandAccepted, got CommandRejected: " |> Text.append msg)
+        CommandFailed err _ ->
+          fail ("Expected CommandAccepted, got CommandFailed: " |> Text.append err)
+        CommandUnauthorized _ ->
+          fail "Expected CommandAccepted, got CommandUnauthorized"
+
+    it "accepts a zero-event decision for an existing stream" \context -> do
+      eventId <- Uuid.generate
+      metadata <- EventMetadata.new
+      let insertion =
+            Event.Insertion
+              { id = eventId,
+                event = CartCreated {entityId = context.cartId},
+                metadata =
+                  metadata
+                    { EventMetadata.localPosition = Just (Event.StreamPosition 0),
+                      EventMetadata.eventId = eventId
+                    }
+              }
+      let payload =
+            Event.InsertionPayload
+              { streamId = context.cartId |> Uuid.toText |> StreamId.fromTextUnsafe,
+                entityName = context.cartEntityName,
+                insertionType = Event.StreamCreation,
+                insertions = [insertion]
+              }
+
+      payload
+        |> context.cartStore.insert
+        |> Task.mapError toText
+        |> discard
+
+      result <-
+        NoOpExisting {cartId = context.cartId}
+          |> CommandExecutor.execute context.cartStore context.cartFetcher context.cartEntityName Auth.emptyContext
+
+      case result of
+        CommandAccepted {eventsAppended, retriesAttempted} -> do
+          eventsAppended |> shouldBe 0
+          retriesAttempted |> shouldBe 0
         CommandRejected msg ->
           fail ("Expected CommandAccepted, got CommandRejected: " |> Text.append msg)
         CommandFailed err _ ->

--- a/docs/changes/008-accept-zero-event-command-decisions.md
+++ b/docs/changes/008-accept-zero-event-command-decisions.md
@@ -1,0 +1,38 @@
+# Change 008: Accept zero-event command decisions
+
+Treat an accepted command decision with no events as a successful idempotent no-op after resolving and validating its target stream, without calling the event store.
+
+```yaml spec
+issue: issue#859
+kind: bug
+touches: [commands, event-store, testlib]
+breaking: false
+new-dependency: false
+new-capability: false
+new-extension-point: false
+```
+
+## Contract delta
+
+```diff signatures
+```
+
+## Criteria
+
+| ID | Behavior | Proving test | Level |
+|----|----------|--------------|-------|
+| C1 | An accepted zero-event decision for an existing stream returns `CommandAccepted` with zero appended events | `CommandHandler Execute Specification Tests` "accepts a zero-event decision for an existing stream" | integration |
+| C2 | An accepted zero-event decision does not invoke event-store insertion | `CommandHandler Execute Specification Tests` "does not insert an accepted zero-event decision" | unit |
+| C3 | `acceptAny []` succeeds when the command resolves a valid stream | `CommandHandler Execute Specification Tests` "accepts an acceptAny zero-event decision with a resolved stream" | integration |
+| C4 | `acceptExisting []` still rejects when the target entity does not exist | `CommandHandler Execute Specification Tests` "rejects an acceptExisting zero-event decision for a missing entity" | integration |
+| C5 | An accepted zero-event decision without a resolvable stream ID returns a bounded explicit failure | `CommandHandler Execute Specification Tests` "fails a zero-event decision without a resolvable stream" | integration |
+| C6 | Simple and PostgreSQL-backed execution accept zero-event decisions without changing durable event counts | `CommandHandler zero-event backend integration` "keeps Simple and PostgreSQL event counts unchanged" | integration |
+| C7 | Repeating an idempotent command succeeds with zero appended events and leaves the durable event count unchanged | `CommandHandler Execute Specification Tests` "accepts a repeated idempotent command without appending events" | integration |
+
+## User impact
+
+Idempotent commands can report successful convergence when aggregate state shows that no new event is needed. No public API changes or migration are required.
+
+## ADR
+
+Not required — no trigger (breaking / new-dependency / new-capability / new-extension-point all false).


### PR DESCRIPTION
Fixes #859

## Spec

- [Change 008: Accept zero-event command decisions](docs/changes/008-accept-zero-event-command-decisions.md)

## Red reproduction

`./dev test "accepts a zero-event decision for an existing stream" nhcore-test-service` currently fails for InMemory and PostgreSQL with `InsertionError EmptyPayload`.

Implementation is gated on maintainer approval of the spec.